### PR TITLE
Improve markdown for CopyFiles tag

### DIFF
--- a/Tasks/CopyFiles/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CopyFiles/Strings/resources.resjson/en-US/resources.resjson
@@ -9,7 +9,7 @@
   "loc.input.label.Contents": "Contents",
   "loc.input.help.Contents": "File paths to include as part of the copy. Supports multiple lines of minimatch patterns. [More Information](https://go.microsoft.com/fwlink/?LinkID=708389)",
   "loc.input.label.TargetFolder": "Target Folder",
-  "loc.input.help.TargetFolder": "Target folder files will copy to. Use [variables](https://go.microsoft.com/fwlink/?LinkID=550988). Example: $(build.artifactstagingdirectory)",
+  "loc.input.help.TargetFolder": "Target folder or UNC path files will copy to. You can use [variables](http://go.microsoft.com/fwlink/?LinkID=550988). Example: $(build.artifactstagingdirectory)",
   "loc.input.label.CleanTargetFolder": "Clean Target Folder",
   "loc.input.help.CleanTargetFolder": "Delete all existing files in target folder before copy",
   "loc.input.label.OverWrite": "Overwrite",

--- a/Tasks/CopyFiles/task.json
+++ b/Tasks/CopyFiles/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 18
+        "Patch": 19
     },
     "demands": [],
     "minimumAgentVersion": "1.91.0",

--- a/Tasks/CopyFiles/task.json
+++ b/Tasks/CopyFiles/task.json
@@ -46,7 +46,7 @@
             "label": "Target Folder",
             "defaultValue": "",
             "required": true,
-            "helpMarkDown": "Target folder files will copy to. Use [variables](https://go.microsoft.com/fwlink/?LinkID=550988). Example: $(build.artifactstagingdirectory)"
+            "helpMarkDown": "Target folder or UNC path files will copy to. You can use [variables](http://go.microsoft.com/fwlink/?LinkID=550988). Example: $(build.artifactstagingdirectory)"
         },
         {
             "name": "CleanTargetFolder",

--- a/Tasks/CopyFiles/task.loc.json
+++ b/Tasks/CopyFiles/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 18
+    "Patch": 19
   },
   "demands": [],
   "minimumAgentVersion": "1.91.0",


### PR DESCRIPTION
Mention that copy files work also with UNC paths as target and reword so that it is clear that variables are optional.