### PR TITLE
Tidy up issue with Get-AzureWebSite where it can return an array of s…

### DIFF
--- a/Tasks/AzureWebPowerShellDeployment/Publish-AzureWebDeployment.ps1
+++ b/Tasks/AzureWebPowerShellDeployment/Publish-AzureWebDeployment.ps1
@@ -68,17 +68,31 @@ $azureWebSiteError = $null
 #If we're provided a WebSiteLocation, check for it and create it if necessary
 if($WebSiteLocation)
 {
-    if (!$Slot -and $WebSiteName -notlike '*(*)*') {
-        $Slot = 'production'
-    }
 
     $extraParameters = @{ }
     if ($Slot) { $extraParameters['Slot'] = $Slot }   
     
     Write-Host "Get-AzureWebSite -Name $WebSiteName -ErrorAction SilentlyContinue -ErrorVariable azureWebSiteError $(if ($Slot) { "-Slot $Slot" })"    
-        
-    $azureWebSite = Get-AzureWebSite -Name $WebSiteName -ErrorAction SilentlyContinue -ErrorVariable azureWebSiteError @extraParameters
-        
+    $azureWebSite = Get-AzureWebSite -Name $WebSiteName -ErrorAction SilentlyContinue -ErrorVariable azureWebSiteError @extraParameters | Where-Object {$_.Name -eq $WebSiteName }
+    #May get an Site array if there is more than one reference, e.g. Name does return wildcard entries, for example 
+    #   Name somesite    and Name somesite(staging) = both are returned using just Name somesite
+
+    if ($azureWebSite.GetType().FullName -eq "Microsoft.WindowsAzure.Commands.Utilities.Websites.Services.WebEntities.Site")
+    {
+       $index = $azureWebSite.SiteProperties.Properties.FindIndex({$args[0].Name -eq "PublishingUsername"})
+       $username=$azureWebSite.SiteProperties.Properties[$index].Value
+       $index = $azureWebSite.SiteProperties.Properties.FindIndex({$args[0].Name -eq "PublishingPassword"})
+       $pass=$azureWebSite.SiteProperties.Properties[$index].Value
+       $securePwd = ConvertTo-SecureString $pass -AsPlainText -Force
+    }
+    else
+    {
+        $username = $azureWebSite.PublishingUsername
+        $securePwd = ConvertTo-SecureString $azureWebSite.PublishingPassword -AsPlainText -Force
+    }
+    Write-Host "Web Sites Found.."
+    $azureWebSite | ForEach-Object { Write-Host $_.Name.ToString() }
+
     if($azureWebSiteError){
         $azureWebSiteError | ForEach-Object { Write-Warning $_.Exception.ToString() }
     }
@@ -128,8 +142,7 @@ if($azureWebSite) {
             $status = 4 #succeeded
         }
 
-        $username = $azureWebSite.PublishingUsername
-        $securePwd = ConvertTo-SecureString $azureWebSite.PublishingPassword -AsPlainText -Force
+       
         $credential = New-Object System.Management.Automation.PSCredential ($username, $securePwd)
         
         $author = Get-TaskVariable $distributedTaskContext "build.sourceVersionAuthor"


### PR DESCRIPTION
Sometimes there are cases where a Azure Web site may have a default instance and one slot instance.  These would have the website names of  "MainSite"   and  "MainSite(SlotName)". 

This pull request removes the default slot setting (Production) and supports returning the current instance from the Get-AzureWebSite -Name which will return an array in the case above. 
