### PR TITLE
specify gulp-tsc tsc search order

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,7 @@ gulp.task('cleanTests', function (cb) {
 gulp.task('compileTests', ['cleanTests'], function (cb) {
     var testsPath = path.join(__dirname, 'Tests', '**/*.ts');
     return gulp.src([testsPath, 'definitions/*.d.ts'])
-        .pipe(tsc())
+        .pipe(tsc({ "tscSearch": ['cwd', 'bundle']}))
         .pipe(gulp.dest(_testRoot));
 });
 
@@ -111,7 +111,7 @@ gulp.task('compileTasks', ['clean'], function (cb) {
 
     var tasksPath = path.join(__dirname, 'Tasks', '**/*.ts');
     return gulp.src([tasksPath, 'definitions/*.d.ts'])
-        .pipe(tsc())
+        .pipe(tsc({ "tscSearch": ['cwd', 'bundle']}))
         .pipe(gulp.dest(path.join(__dirname, 'Tasks')));
 });
 


### PR DESCRIPTION
On Windows Systems where Visual Studio is installed, the PATH may contain

    C:\Program Files (x86)\Microsoft SDKs\TypeScript\1.0\

This will lead gulp-tsc to use an old version of tsc. If this version is
older than 1.4.1, this will lead to compile errors (like TS1005) on definitions.

The option being set is documented at https://www.npmjs.com/package/gulp-tsc#optionstscsearch
