### PR TITLE
Bump tasks.

### DIFF
--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 31
+        "Patch": 32
     },
     "demands": [
         "ant"

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 31
+    "Patch": 32
   },
   "demands": [
     "ant"

--- a/Tasks/AndroidSigning/task.json
+++ b/Tasks/AndroidSigning/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 12
+        "Patch": 13
     },
     "demands": [
         "JDK",

--- a/Tasks/AndroidSigning/task.loc.json
+++ b/Tasks/AndroidSigning/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "demands": [
     "JDK",

--- a/Tasks/CMake/task.json
+++ b/Tasks/CMake/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 15
+        "Patch": 16
     },
     "minimumAgentVersion": "1.91.0",
     "instanceNameFormat": "CMake $(cmakeArgs)",

--- a/Tasks/CMake/task.loc.json
+++ b/Tasks/CMake/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 16
   },
   "minimumAgentVersion": "1.91.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/CmdLine/task.json
+++ b/Tasks/CmdLine/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 19
+        "Patch": 20
     },
     "groups": [
         {

--- a/Tasks/CmdLine/task.loc.json
+++ b/Tasks/CmdLine/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 19
+    "Patch": 20
   },
   "groups": [
     {

--- a/Tasks/CocoaPods/task.json
+++ b/Tasks/CocoaPods/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 8
+        "Patch": 9
     },
     "demands": [
         "cocoapods"

--- a/Tasks/CocoaPods/task.loc.json
+++ b/Tasks/CocoaPods/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 8
+    "Patch": 9
   },
   "demands": [
     "cocoapods"

--- a/Tasks/CopyFiles/task.json
+++ b/Tasks/CopyFiles/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 12
+        "Patch": 13
     },
     "demands": [],
     "minimumAgentVersion": "1.91.0",

--- a/Tasks/CopyFiles/task.loc.json
+++ b/Tasks/CopyFiles/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "demands": [],
   "minimumAgentVersion": "1.91.0",

--- a/Tasks/CopyPublishBuildArtifacts/task.json
+++ b/Tasks/CopyPublishBuildArtifacts/task.json
@@ -1,76 +1,84 @@
 {
-	"id": "1D341BB0-2106-458C-8422-D00BCEA6512A",
-	"name": "CopyPublishBuildArtifacts",
-	"friendlyName": "Copy and Publish Build Artifacts",
-	"description": "Copy Build artifacts to staging folder then publish Build artifacts to the server or a file share using minimatch patterns",
-	"helpMarkDown": "[More Information](http://go.microsoft.com/fwlink/?LinkID=613725)",
-	"category": "Utility",
-	"visibility": [
-		"Build"
-	],
-	"author": "Microsoft Corporation",
-	"version": {
-		"Major": 1,
-		"Minor": 0,
-		"Patch": 19
-	},
-	"demands": [],
-	"minimumAgentVersion": "1.83.0",
-	"inputs": [{
-		"name": "CopyRoot",
-		"type": "filePath",
-		"label": "Copy Root",
-		"defaultValue": "",
-		"required": false,
-		"helpMarkDown": "Root folder to apply copy patterns to.  Empty is the root of the repo.  Use variables if build steps building outside the repo. Example: $(agent.builddirectory)"
-	}, {
-		"name": "Contents",
-		"type": "multiLine",
-		"label": "Contents",
-		"defaultValue": "",
-		"required": true,
-		"helpMarkDown": "File or folder paths to include as part of the artifact.  Supports multiple lines or minimatch patterns. [More Information](http://go.microsoft.com/fwlink/?LinkID=613725)"
-	}, {
-		"name": "ArtifactName",
-		"type": "string",
-		"label": "Artifact Name",
-		"defaultValue": "",
-		"required": true,
-		"helpMarkDown": "The name of the artifact to create."
-	}, {
-		"name": "ArtifactType",
-		"type": "pickList",
-		"label": "Artifact Type",
-		"defaultValue": "",
-		"required": true,
-		"helpMarkDown": "The type of the artifact to create.",
-		"options": {
-			"Container": "Server",
-			"FilePath": "File share"
-		}
-	}, {
-		"name": "TargetPath",
-		"type": "string",
-		"label": "Path",
-		"defaultValue": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)",
-		"required": false,
-		"helpMarkDown": "The file share to which to copy the files",
-		"visibleRule": "ArtifactType = FilePath"
-	}],
-	"instanceNameFormat": "Copy Publish Artifact: $(ArtifactName)",
-	"execution": {
-		"PowerShell": {
-			"target": "$(currentDirectory)\\CopyPublishBuildArtifacts.ps1",
-			"argumentFormat": "",
-			"workingDirectory": "$(currentDirectory)",
-			"platforms": ["windows"]
-		},
-		"Node": {
-			"target": "copypublishbuildartifacts.js",
-			"argumentFormat": ""
-		}
-	},
-	"messages": {
-		"CopyPublishBuildArtifactsNotSupported": "Copy and Publish Build Artifacts task is not supported within Release"
-	}
+    "id": "1D341BB0-2106-458C-8422-D00BCEA6512A",
+    "name": "CopyPublishBuildArtifacts",
+    "friendlyName": "Copy and Publish Build Artifacts",
+    "description": "Copy Build artifacts to staging folder then publish Build artifacts to the server or a file share using minimatch patterns",
+    "helpMarkDown": "[More Information](http://go.microsoft.com/fwlink/?LinkID=613725)",
+    "category": "Utility",
+    "visibility": [
+        "Build"
+    ],
+    "author": "Microsoft Corporation",
+    "version": {
+        "Major": 1,
+        "Minor": 0,
+        "Patch": 20
+    },
+    "demands": [],
+    "minimumAgentVersion": "1.83.0",
+    "inputs": [
+        {
+            "name": "CopyRoot",
+            "type": "filePath",
+            "label": "Copy Root",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Root folder to apply copy patterns to.  Empty is the root of the repo.  Use variables if build steps building outside the repo. Example: $(agent.builddirectory)"
+        },
+        {
+            "name": "Contents",
+            "type": "multiLine",
+            "label": "Contents",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "File or folder paths to include as part of the artifact.  Supports multiple lines or minimatch patterns. [More Information](http://go.microsoft.com/fwlink/?LinkID=613725)"
+        },
+        {
+            "name": "ArtifactName",
+            "type": "string",
+            "label": "Artifact Name",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "The name of the artifact to create."
+        },
+        {
+            "name": "ArtifactType",
+            "type": "pickList",
+            "label": "Artifact Type",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "The type of the artifact to create.",
+            "options": {
+                "Container": "Server",
+                "FilePath": "File share"
+            }
+        },
+        {
+            "name": "TargetPath",
+            "type": "string",
+            "label": "Path",
+            "defaultValue": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)",
+            "required": false,
+            "helpMarkDown": "The file share to which to copy the files",
+            "visibleRule": "ArtifactType = FilePath"
+        }
+    ],
+    "instanceNameFormat": "Copy Publish Artifact: $(ArtifactName)",
+    "execution": {
+        "PowerShell": {
+            "target": "$(currentDirectory)\\CopyPublishBuildArtifacts.ps1",
+            "argumentFormat": "",
+            "workingDirectory": "$(currentDirectory)",
+            "platforms": [
+                "windows"
+            ]
+        },
+        "Node": {
+            "target": "copypublishbuildartifacts.js",
+            "argumentFormat": ""
+        }
+    },
+    "messages": {
+        "CopyPublishBuildArtifactsNotSupported": "Copy and Publish Build Artifacts task is not supported within Release"
+    }
 }

--- a/Tasks/CopyPublishBuildArtifacts/task.loc.json
+++ b/Tasks/CopyPublishBuildArtifacts/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 19
+    "Patch": 20
   },
   "demands": [],
   "minimumAgentVersion": "1.83.0",

--- a/Tasks/DecryptFile/task.json
+++ b/Tasks/DecryptFile/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 6
+        "Patch": 7
     },
     "groups": [
         {

--- a/Tasks/DecryptFile/task.loc.json
+++ b/Tasks/DecryptFile/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 6
+    "Patch": 7
   },
   "groups": [
     {

--- a/Tasks/DeleteFiles/task.json
+++ b/Tasks/DeleteFiles/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 6
+        "Patch": 7
     },
     "demands": [],
     "minimumAgentVersion": "1.92.0",

--- a/Tasks/DeleteFiles/task.loc.json
+++ b/Tasks/DeleteFiles/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 6
+    "Patch": 7
   },
   "demands": [],
   "minimumAgentVersion": "1.92.0",

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 26
+        "Patch": 27
     },
     "demands": [
         "java"

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 26
+    "Patch": 27
   },
   "demands": [
     "java"

--- a/Tasks/Grunt/task.json
+++ b/Tasks/Grunt/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 0,
         "Minor": 5,
-        "Patch": 12
+        "Patch": 13
     },
     "demands": [
         "node.js"

--- a/Tasks/Grunt/task.loc.json
+++ b/Tasks/Grunt/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 0,
     "Minor": 5,
-    "Patch": 12
+    "Patch": 13
   },
   "demands": [
     "node.js"

--- a/Tasks/Gulp/task.json
+++ b/Tasks/Gulp/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 0,
         "Minor": 5,
-        "Patch": 16
+        "Patch": 17
     },
     "demands": [
         "node.js"

--- a/Tasks/Gulp/task.loc.json
+++ b/Tasks/Gulp/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 0,
     "Minor": 5,
-    "Patch": 16
+    "Patch": 17
   },
   "demands": [
     "node.js"

--- a/Tasks/MSBuild/task.json
+++ b/Tasks/MSBuild/task.json
@@ -6,131 +6,131 @@
     "helpMarkDown": "[More Information](http://go.microsoft.com/fwlink/?LinkID=613724)",
     "category": "Build",
     "visibility": [
-                "Build"
-                  ],    
+        "Build"
+    ],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 25
+        "Patch": 26
     },
-    "demands" : [
+    "demands": [
         "msbuild"
     ],
     "minimumAgentVersion": "1.83.0",
     "groups": [
         {
-            "name":"advanced",
-            "displayName":"Advanced",
-            "isExpanded":false
+            "name": "advanced",
+            "displayName": "Advanced",
+            "isExpanded": false
         }
     ],
     "inputs": [
-        { 
-            "name": "solution", 
-            "type": "filePath", 
-            "label": "Project", 
-            "defaultValue":"**\\*.sln", 
-            "required":true,
-            "helpMarkDown": "Relative path from repo root of the project(s) or solution(s) to run.  Wildcards can be used.  For example, `**\\*.csproj` for all csproj files in all sub folders."  
+        {
+            "name": "solution",
+            "type": "filePath",
+            "label": "Project",
+            "defaultValue": "**\\*.sln",
+            "required": true,
+            "helpMarkDown": "Relative path from repo root of the project(s) or solution(s) to run.  Wildcards can be used.  For example, `**\\*.csproj` for all csproj files in all sub folders."
         },
-        { 
-            "name": "platform", 
-            "type": "string", 
-            "label": "Platform", 
-            "defaultValue":"", 
-            "required":false
+        {
+            "name": "platform",
+            "type": "string",
+            "label": "Platform",
+            "defaultValue": "",
+            "required": false
         },
-        { 
-            "name": "configuration", 
-            "type": "string", 
-            "label": "Configuration", 
-            "defaultValue":"", 
-            "required":false 
+        {
+            "name": "configuration",
+            "type": "string",
+            "label": "Configuration",
+            "defaultValue": "",
+            "required": false
         },
-        { 
-            "name": "msbuildArguments", 
-            "type": "string", 
-            "label": "MSBuild Arguments", 
-            "defaultValue":"", 
-            "required":false,
+        {
+            "name": "msbuildArguments",
+            "type": "string",
+            "label": "MSBuild Arguments",
+            "defaultValue": "",
+            "required": false,
             "helpMarkDown": "Additional arguments passed to MSBuild."
         },
         {
-            "name": "clean", 
-            "type": "boolean", 
-            "label": "Clean", 
-            "defaultValue": "false", 
+            "name": "clean",
+            "type": "boolean",
+            "label": "Clean",
+            "defaultValue": "false",
             "required": false,
             "helpMarkDown": "Run a clean build (/t:clean) prior to the build."
         },
-        { 
-            "name": "restoreNugetPackages", 
-            "type": "boolean", 
-            "label": "Restore NuGet Packages", 
-            "defaultValue": "true", 
+        {
+            "name": "restoreNugetPackages",
+            "type": "boolean",
+            "label": "Restore NuGet Packages",
+            "defaultValue": "true",
             "required": false,
             "helpMarkDown": "Run NuGet restore prior to the build."
         },
-        { 
-            "name": "logProjectEvents", 
-            "type": "boolean", 
-            "label": "Record Project Details", 
-            "defaultValue": "false", 
+        {
+            "name": "logProjectEvents",
+            "type": "boolean",
+            "label": "Record Project Details",
+            "defaultValue": "false",
             "required": false,
-            "groupName":"advanced" 
+            "groupName": "advanced"
         },
         {
-            "name":"msbuildLocationMethod",
-            "type":"radio",
-            "label":"MSBuild",
-            "required":false,
-            "groupName":"advanced",
-            "defaultValue":"version",
+            "name": "msbuildLocationMethod",
+            "type": "radio",
+            "label": "MSBuild",
+            "required": false,
+            "groupName": "advanced",
+            "defaultValue": "version",
             "options": {
-                "version":"Version",
-                "location":"Specify Location"
-            }   
+                "version": "Version",
+                "location": "Specify Location"
+            }
         },
         {
-            "name":"msbuildVersion",
-            "type":"pickList",
-            "label":"MSBuild Version",
-            "required":false,
-            "groupName":"advanced",
-            "defaultValue":"14.0",
+            "name": "msbuildVersion",
+            "type": "pickList",
+            "label": "MSBuild Version",
+            "required": false,
+            "groupName": "advanced",
+            "defaultValue": "14.0",
             "helpMarkDown": "If the preferred version cannot be found, the latest version found will be used instead.",
             "visibleRule": "msbuildLocationMethod = version",
             "options": {
-                "latest":"Latest",
-                "14.0":"MSBuild 14.0",
-                "12.0":"MSBuild 12.0",
-                "4.0":"MSBuild 4.0"
+                "latest": "Latest",
+                "14.0": "MSBuild 14.0",
+                "12.0": "MSBuild 12.0",
+                "4.0": "MSBuild 4.0"
             }
         },
-        { 
-            "name": "msbuildArchitecture", 
-            "type": "pickList", 
-            "label": "MSBuild Architecture", 
-            "defaultValue":"x86", 
-            "required":false,
+        {
+            "name": "msbuildArchitecture",
+            "type": "pickList",
+            "label": "MSBuild Architecture",
+            "defaultValue": "x86",
+            "required": false,
             "helpMarkDown": "Optionally supply the architecture (x86, x64) of MSBuild to run.",
-            "groupName":"advanced",
+            "groupName": "advanced",
             "visibleRule": "msbuildLocationMethod = version",
-            "options":{
-                "x86":"MSBuild x86",
-                "x64":"MSBuild x64"
+            "options": {
+                "x86": "MSBuild x86",
+                "x64": "MSBuild x64"
             }
         },
-        { 
-            "name": "msbuildLocation", 
-            "type": "string", 
-            "label": "Path to MSBuild", 
-            "defaultValue":"", 
-            "required":false,
-            "helpMarkDown": "Optionally supply the path to MSBuild.",  
+        {
+            "name": "msbuildLocation",
+            "type": "string",
+            "label": "Path to MSBuild",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Optionally supply the path to MSBuild.",
             "visibleRule": "msbuildLocationMethod = location",
-            "groupName":"advanced"
+            "groupName": "advanced"
         }
     ],
     "instanceNameFormat": "Build solution $(solution)",

--- a/Tasks/MSBuild/task.loc.json
+++ b/Tasks/MSBuild/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 25
+    "Patch": 26
   },
   "demands": [
     "msbuild"

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 35
+        "Patch": 36
     },
     "minimumAgentVersion": "1.89.0",
     "instanceNameFormat": "Maven $(mavenPOMFile)",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 35
+    "Patch": 36
   },
   "minimumAgentVersion": "1.89.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/Npm/task.json
+++ b/Tasks/Npm/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 6
+        "Patch": 7
     },
     "demands": [
         "npm"

--- a/Tasks/Npm/task.loc.json
+++ b/Tasks/Npm/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 6
+    "Patch": 7
   },
   "demands": [
     "npm"

--- a/Tasks/PublishBuildArtifacts/task.json
+++ b/Tasks/PublishBuildArtifacts/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 27
+        "Patch": 28
     },
     "demands": [],
     "minimumAgentVersion": "1.91.0",
@@ -64,6 +64,6 @@
     },
     "messages": {
         "PublishBuildArtifactsFailed": "Publish build artifacts failed with error: %s",
-        "PublishBuildArtifactsNotSupported" : "Publish build artifacts is not supported within Release"
+        "PublishBuildArtifactsNotSupported": "Publish build artifacts is not supported within Release"
     }
 }

--- a/Tasks/PublishBuildArtifacts/task.loc.json
+++ b/Tasks/PublishBuildArtifacts/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 27
+    "Patch": 28
   },
   "demands": [],
   "minimumAgentVersion": "1.91.0",

--- a/Tasks/PublishSymbols/task.json
+++ b/Tasks/PublishSymbols/task.json
@@ -1,18 +1,18 @@
 {
-    "id":"0675668A-7BBA-4CCB-901D-5AD6554CA653",
-    "name":"PublishSymbols",
+    "id": "0675668A-7BBA-4CCB-901D-5AD6554CA653",
+    "name": "PublishSymbols",
     "friendlyName": "Index Sources & Publish Symbols",
     "description": "Index your source code and publish symbols to a file share",
     "helpMarkDown": "Index your source code and publish symbols to a file share<br/>[More Information](http://go.microsoft.com/fwlink/?LinkID=613722)",
     "category": "Build",
     "visibility": [
-                    "Build"
-                  ],
+        "Build"
+    ],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 21
+        "Patch": 22
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/PublishSymbols/task.loc.json
+++ b/Tasks/PublishSymbols/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 21
+    "Patch": 22
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [

--- a/Tasks/PublishTestResults/task.json
+++ b/Tasks/PublishTestResults/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 20
+        "Patch": 21
     },
     "demands": [],
     "minimumAgentVersion": "1.83.0",

--- a/Tasks/PublishTestResults/task.loc.json
+++ b/Tasks/PublishTestResults/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 20
+    "Patch": 21
   },
   "demands": [],
   "minimumAgentVersion": "1.83.0",

--- a/Tasks/ShellScript/task.json
+++ b/Tasks/ShellScript/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 16
+        "Patch": 17
     },
     "demands": [
         "sh"

--- a/Tasks/ShellScript/task.loc.json
+++ b/Tasks/ShellScript/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 16
+    "Patch": 17
   },
   "demands": [
     "sh"

--- a/Tasks/VSBuild/task.json
+++ b/Tasks/VSBuild/task.json
@@ -1,18 +1,18 @@
 {
-    "id":"71A9A2D3-A98A-4CAA-96AB-AFFCA411ECDA",
-    "name":"VSBuild",
+    "id": "71A9A2D3-A98A-4CAA-96AB-AFFCA411ECDA",
+    "name": "VSBuild",
     "friendlyName": "Visual Studio Build",
     "description": "Build with MSBuild and set the Visual Studio version property",
     "helpMarkDown": "[More Information](http://go.microsoft.com/fwlink/?LinkID=613727)",
     "category": "Build",
     "visibility": [
-                "Build"
-                  ],
+        "Build"
+    ],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 25
+        "Patch": 26
     },
     "demands": [
         "msbuild",
@@ -79,7 +79,7 @@
             "helpMarkDown": "If the preferred version cannot be found, the latest version found will be used instead.",
             "defaultValue": "14.0",
             "options": {
-                "latest":"Latest",
+                "latest": "Latest",
                 "14.0": "Visual Studio 2015",
                 "12.0": "Visual Studio 2013",
                 "11.0": "Visual Studio 2012"

--- a/Tasks/VSBuild/task.loc.json
+++ b/Tasks/VSBuild/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 25
+    "Patch": 26
   },
   "demands": [
     "msbuild",

--- a/Tasks/XamarinTestCloud/task.json
+++ b/Tasks/XamarinTestCloud/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 13
+        "Patch": 14
     },
     "demands": [],
     "minimumAgentVersion": "1.83.0",

--- a/Tasks/XamarinTestCloud/task.loc.json
+++ b/Tasks/XamarinTestCloud/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "demands": [],
   "minimumAgentVersion": "1.83.0",

--- a/Tasks/XamariniOS/task.json
+++ b/Tasks/XamariniOS/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 11
+        "Patch": 12
     },
     "demands": [
         "Xamarin.iOS"

--- a/Tasks/XamariniOS/task.loc.json
+++ b/Tasks/XamariniOS/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 11
+    "Patch": 12
   },
   "demands": [
     "Xamarin.iOS"

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 9
+        "Patch": 10
     },
     "demands": [
         "xcode"

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 9
+    "Patch": 10
   },
   "demands": [
     "xcode"

--- a/Tasks/XcodePackageiOS/task.json
+++ b/Tasks/XcodePackageiOS/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 12
+        "Patch": 13
     },
     "instanceNameFormat": "Xcode Package $(appName)",
     "demands": [

--- a/Tasks/XcodePackageiOS/task.loc.json
+++ b/Tasks/XcodePackageiOS/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 12
+    "Patch": 13
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "demands": [

--- a/Tasks/cURLUploader/task.json
+++ b/Tasks/cURLUploader/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 7
+        "Patch": 8
     },
     "demands": [
         "curl"

--- a/Tasks/cURLUploader/task.loc.json
+++ b/Tasks/cURLUploader/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 7
+    "Patch": 8
   },
   "demands": [
     "curl"


### PR DESCRIPTION
Is the fix already in master?  If not, link the bug tracking that work.
Yes.

What testing was done?
The goal of this change is to bring the task versions to a predictable state for Update 3. The task libs changed slightly due to the encoding issue (pslib) and ep issue (js lib). Bumping all versions brings everyone on update 3 into the same state (updated task lib) regardless of whether they came from update 2 or fresh install from 3.

The lib fixes have been tested already and even released as patches via KB article.

Once this change goes in, I can bump the nuget reference in the vso repo to consume this new package and finish testing the servicing step.

Does this fix change the AT/DT contract?
No

Does this fix include any database servicing changes?
Yes. I have a PR in the VSO repo to add the task servicing step for Update 3. It's the same servicing step we run every sprint to update the tasks. It just had not been added yet for Update 3.

Were tests added to cover this to make sure it doesn't regress?  If not, link a bug or user story tracking that work.
This change is just to consume the new version of the libs. Tests were added when the fixes were made in the vsts-task-lib repo: https://github.com/Microsoft/vsts-task-lib