### PR TITLE
Fix bug with error pipeline from ad hoc Azure PowerShell script.

### DIFF
--- a/Tasks/AzurePowerShell/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShell/AzurePowerShell.ps1
@@ -46,8 +46,8 @@ $global:ErrorActionPreference = 'Continue'
 ([scriptblock]::Create($scriptCommand)) |
     ForEach-Object {
         Remove-Variable -Name scriptCommand
-        . $_
-    } 2>&1 |
+        . $_ 2>&1
+    } |
     ForEach-Object {
         # Put the object back into the pipeline. When doing this, the object needs
         # to be wrapped in an array to prevent unraveling.

--- a/Tasks/AzurePowerShell/task.json
+++ b/Tasks/AzurePowerShell/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 19
+        "Patch": 20
     },
     "demands": [
         "azureps"

--- a/Tasks/AzurePowerShell/task.loc.json
+++ b/Tasks/AzurePowerShell/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 19
+    "Patch": 20
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
Is the fix already in master?  If not, link the bug tracking that work.
Yes.

What testing was done?
Manually verified error records from the ad-hoc script are handled correctly.

Does this fix change the AT/DT contract?
No.

Does this fix include any database servicing changes?
No.

Were tests added to cover this to make sure it doesn't regress?  If not, link a bug or user story tracking that work.
No. I added a test case work item. Extensive unit tests have been added for the underlying Azure Helpers module that this task relies on. I still need to add unit tests for this task itself.