### PR TITLE
Fix #439494 (maven promise chain)

### DIFF
--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 12
+        "Patch": 13
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "Maven $(mavenPOMFile)",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "minimumAgentVersion": "1.83.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
…Online/_workitems#_a=edit&id=439494&fullScreen=false) by porting a more general fix describe by commit 9750786d. This reorders the Q-promise chain and ensures the step outcome is correctly set.