### PR TITLE
Minor fixes in publish test results

### DIFF
--- a/Tasks/PublishTestResults/publishtestresults.ts
+++ b/Tasks/PublishTestResults/publishtestresults.ts
@@ -30,10 +30,11 @@ else {
   var matchingTestResultsFiles = [testResultsFiles];
 }
 
-if(!matchingTestResultsFiles) {
+if(!matchingTestResultsFiles || matchingTestResultsFiles.length == 0) {
   tl.warning('No test result files matching ' + testResultsFiles + ' were found.');  
   tl.exit(0);
 }
-
-var tp = new tl.TestPublisher(testRunner);
-tp.publish(matchingTestResultsFiles, mergeResults, platform, config, testRunTitle, publishRunAttachments);
+else{
+  var tp = new tl.TestPublisher(testRunner);
+  tp.publish(matchingTestResultsFiles, mergeResults, platform, config, testRunTitle, publishRunAttachments);
+}

--- a/Tasks/PublishTestResults/task.json
+++ b/Tasks/PublishTestResults/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 26
+        "Patch": 27
     },
     "demands": [],
     "minimumAgentVersion": "1.83.0",

--- a/Tasks/PublishTestResults/task.loc.json
+++ b/Tasks/PublishTestResults/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 26
+    "Patch": 27
   },
   "demands": [],
   "minimumAgentVersion": "1.83.0",

--- a/Tests/L0/PublishTestResults/_suite.ts
+++ b/Tests/L0/PublishTestResults/_suite.ts
@@ -1,0 +1,131 @@
+/// <reference path="../../../definitions/mocha.d.ts"/>
+/// <reference path="../../../definitions/node.d.ts"/>
+
+import assert = require('assert');
+import trm = require('../../lib/taskRunner');
+import psm = require('../../lib/psRunner');
+import path = require('path');
+import shell = require('shelljs');
+
+function setResponseFile(name: string) {
+    process.env['MOCK_RESPONSES'] = path.join(__dirname, name);
+}
+
+describe('Publish Test Results Suite', function() {
+    this.timeout(10000);
+
+    before((done) => {
+        // init here
+        done();
+    });
+
+    after(function() {
+
+    });
+
+    it('Publish test results with resultFiles filter that does not match with any files', (done) => {
+        setResponseFile('publishTestResultResponses.json');
+
+        var tr = new trm.TaskRunner('PublishTestResults');
+
+        tr.setInput('testRunner', 'JUnit');
+        tr.setInput('testResultsFiles', '/invalid/*pattern');
+
+        tr.run()
+            .then(() => {
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.invokedToolCount == 0, 'should exit before running PublishTestResults');
+                
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Publish test results with resultFiles filter that matches with some files', (done) => {
+        setResponseFile('publishTestResultResponses.json');
+
+        var tr = new trm.TaskRunner('PublishTestResults');
+
+        tr.setInput('testRunner', 'JUnit');
+        tr.setInput('testResultsFiles', '/some/*pattern');
+        tr.setInput('mergeTestResults', 'true');
+
+        tr.run()
+            .then(() => {
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.stdout.search(/##vso\[results.publish type=JUnit;mergeResults=true;resultFiles=some\/path\/one,some\/path\/two;\]/) >=0 , 'should publish test results.');
+                
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Publish test results with resultFiles as file path', (done) => {
+        setResponseFile('publishTestResultResponses.json');
+
+        var tr = new trm.TaskRunner('PublishTestResults');
+
+        tr.setInput('testRunner', 'JUnit');
+        tr.setInput('testResultsFiles', 'file.xml');
+
+        tr.run()
+            .then(() => {
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.stdout.search(/##vso\[results.publish type=JUnit;resultFiles=file.xml;\]/) >= 0, 'should publish test results.');
+
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Publish test results when test result files input is not provided', (done) => {
+        setResponseFile('publishTestResultResponses.json');
+
+        var tr = new trm.TaskRunner('PublishTestResults');
+        tr.setInput('testRunner', 'Junit');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length > 0, 'should have written to stderr');
+                assert(tr.stdErrContained('Input required: testResultsFiles'));
+                assert(tr.failed, 'task should have failed');
+                assert(tr.invokedToolCount == 0, 'should exit before running PublishTestResults');
+
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+    
+    it('Publish test results when test runner type input is not provided', (done) => {
+        setResponseFile('publishTestResultResponses.json');
+
+        var tr = new trm.TaskRunner('PublishTestResults');
+        tr.setInput('testResultsFiles', '/file.xml');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length > 0, 'should have written to stderr');
+                assert(tr.stdErrContained('Input required: testRunner'));
+                assert(tr.failed, 'task should have failed');
+                assert(tr.invokedToolCount == 0, 'should exit before running PublishTestResults');
+
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+});

--- a/Tests/L0/PublishTestResults/publishTestResultResponses.json
+++ b/Tests/L0/PublishTestResults/publishTestResultResponses.json
@@ -1,0 +1,18 @@
+{
+    "getVariable": {
+        "agent.buildDirectory": "/someDir"
+    },
+    "find": {
+        "/someDir": [
+            "someDir/someFile2",
+            "/someDir/someFile1"
+        ]
+    },
+    "match": {
+        "/some/*pattern": [
+            "some/path/one",
+            "some/path/two"
+        ],
+        "/invalid/*pattern": []
+    }
+}

--- a/Tests/lib/vsts-task-lib/task.ts
+++ b/Tests/lib/vsts-task-lib/task.ts
@@ -591,14 +591,14 @@ export class TestPublisher {
 
     public testRunner: string;
 
-    public publish(resultFiles, mergeResults, platform, config) {
-
-        if (mergeResults == 'true') {
-            _writeLine("Merging test results from multiple files to one test run is not supported on this version of build agent for OSX/Linux, each test result file will be published as a separate test run in VSO/TFS.");
-        }
+    public publish(resultFiles, mergeResults, platform, config, runTitle, publishRunAttachments) {
 
         var properties = <{ [key: string]: string }>{};
         properties['type'] = this.testRunner;
+
+        if (mergeResults) {
+            properties['mergeResults'] = mergeResults;
+        }
 
         if (platform) {
             properties['platform'] = platform;
@@ -608,9 +608,19 @@ export class TestPublisher {
             properties['config'] = config;
         }
 
-        for (var i = 0; i < resultFiles.length; i++) {
-            command('results.publish', properties, resultFiles[i]);
+        if (runTitle) {
+            properties['runTitle'] = runTitle;
         }
+
+        if (publishRunAttachments) {
+            properties['publishRunAttachments'] = publishRunAttachments;
+        }
+
+        if (resultFiles) {
+            properties['resultFiles'] = resultFiles;
+        }
+
+        command('results.publish', properties, '');
     }
 }
 


### PR DESCRIPTION
Issue: when there are no matching files matchingTestResultsFiles is an empty array. 
Fix: verify the length of the array before calling command.