### PR TITLE
Fixing Nuget Installer task failing within Release

### DIFF
--- a/Tasks/NuGetInstaller/NuGetInstaller.ps1
+++ b/Tasks/NuGetInstaller/NuGetInstaller.ps1
@@ -40,10 +40,10 @@ if ($excludeVersion -and "$excludeVersion".ToUpperInvariant() -ne 'FALSE')
 if ($solution.Contains("*") -or $solution.Contains("?"))
 {
     Write-Verbose "Pattern found in solution parameter."
-    if ($env:BUILD_SOURCESDIRECTORY)
+    if ($env:SYSTEM_DEFAULTWORKINGDIRECTORY)
     {
-        Write-Verbose "Find-Files -SearchPattern $solution -RootFolder $env:BUILD_SOURCESDIRECTORY"
-        $solutionFiles = Find-Files -SearchPattern $solution -RootFolder $env:BUILD_SOURCESDIRECTORY
+        Write-Verbose "Find-Files -SearchPattern $solution -RootFolder $env:SYSTEM_DEFAULTWORKINGDIRECTORY"
+        $solutionFiles = Find-Files -SearchPattern $solution -RootFolder $env:SYSTEM_DEFAULTWORKINGDIRECTORY
     }
     else
     {
@@ -91,7 +91,7 @@ if($nuGetRestoreArgs)
     $args = ($args + " " + $nuGetRestoreArgs);
 }
 
-if($nugetConfigPath -and ($nugetConfigPath -ne $env:Build_SourcesDirectory))
+if($nugetConfigPath -and ($nugetConfigPath -ne $env:System_DefaultWorkingDirectory))
 {
     $args = "$args -configfile `"$tempNuGetConfigPath`""
 

--- a/Tasks/NuGetInstaller/VsoNuGetHelper.ps1
+++ b/Tasks/NuGetInstaller/VsoNuGetHelper.ps1
@@ -1,6 +1,6 @@
 Add-Type -AssemblyName System.Security
 
-$nuGetTempDirectory = Join-Path $Env:AGENT_BUILDDIRECTORY "NuGet\"
+$nuGetTempDirectory = Join-Path $Env:SYSTEM_ARTIFACTSDIRECTORY "NuGet\"
 $tempNuGetConfigPath = Join-Path $nuGetTempDirectory "newNuGet.config"
 
 function SaveTempNuGetConfig

--- a/Tasks/NuGetInstaller/nugetinstaller.ts
+++ b/Tasks/NuGetInstaller/nugetinstaller.ts
@@ -25,7 +25,7 @@ if(!nuGetPathToUse) {
 }
 tl.checkPath(nuGetPathToUse, 'nuget');
 
-var sourcesFolder = tl.getVariable('build.sourcesdirectory');
+var sourcesFolder = tl.getVariable('system.defaultworkingdirectory');
 var runnuget = function(fn) {
     return Q.fcall(() => {
         var nugetTool = tl.createToolRunner(nuGetPathToUse);

--- a/Tasks/NuGetInstaller/task.json
+++ b/Tasks/NuGetInstaller/task.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "id": "333b11bd-d341-40d9-afcf-b32d5ce6f23b",
     "name": "NuGetInstaller",
     "friendlyName": "NuGet Installer",
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 28
+        "Patch": 29
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NuGetInstaller/task.loc.json
+++ b/Tasks/NuGetInstaller/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 28
+    "Patch": 29
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [


### PR DESCRIPTION
Fixing usage of variables that were specific to Build. Instead using the corresponding variables that are available in both Build & Release.