### PR TITLE
Enable PRCA by default

### DIFF
--- a/Tasks/Common/SonarQubeHelpers/SonarQubeHelper.ps1
+++ b/Tasks/Common/SonarQubeHelpers/SonarQubeHelper.ps1
@@ -270,7 +270,7 @@ function ExitOnPRBuild
 {    
     if ((IsPrBuild) -and !(IsFeatureEnabled "SQPullRequestBot" $true))
     {
-        Write-Host "SonarQube analysis is disabled during builds triggered by pull requests. Set a build variable named 'SQPullRequestBot' to 'true' to have the task post code analysis issues as comments in the PR. More information at http://go.microsoft.com/fwlink/?LinkID=786316"
+        Write-Host "SonarQube analysis is disabled during builds triggered by pull requests because the flag SQPullRequestBot is set to false"
         exit
     } 
 }

--- a/Tasks/Common/SonarQubeHelpers/SonarQubeHelper.ps1
+++ b/Tasks/Common/SonarQubeHelpers/SonarQubeHelper.ps1
@@ -268,7 +268,7 @@ function IsFeatureEnabled
 #
 function ExitOnPRBuild
 {    
-    if ((IsPrBuild) -and !(IsFeatureEnabled "SQPullRequestBot" $false))
+    if ((IsPrBuild) -and !(IsFeatureEnabled "SQPullRequestBot" $true))
     {
         Write-Host "SonarQube analysis is disabled during builds triggered by pull requests. Set a build variable named 'SQPullRequestBot' to 'true' to have the task post code analysis issues as comments in the PR. More information at http://go.microsoft.com/fwlink/?LinkID=786316"
         exit

--- a/Tasks/SonarQubePostTest/task.json
+++ b/Tasks/SonarQubePostTest/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 43
+    "Patch": 44
   },
   "minimumAgentVersion": "1.95.0",
   "demands": [

--- a/Tasks/SonarQubePostTest/task.loc.json
+++ b/Tasks/SonarQubePostTest/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 43
+    "Patch": 44
   },
   "minimumAgentVersion": "1.95.0",
   "demands": [

--- a/Tasks/SonarQubePreBuild/task.json
+++ b/Tasks/SonarQubePreBuild/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 40
+    "Patch": 41
   },
   "minimumAgentVersion": "1.95.0",
   "demands": [

--- a/Tasks/SonarQubePreBuild/task.loc.json
+++ b/Tasks/SonarQubePreBuild/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 40
+    "Patch": 41
   },
   "minimumAgentVersion": "1.95.0",
   "demands": [

--- a/Tests/L0/SonarQubePostTest/DisableAnalysisOnPrBuild.ps1
+++ b/Tests/L0/SonarQubePostTest/DisableAnalysisOnPrBuild.ps1
@@ -51,11 +51,11 @@ function VerifyPrRun
     }
 }
 
-
+# PRCA is enabled by default but can be disabled through the build variable
 VerifyPrRun -SQPullRequestBotSetting "true" -IsPrBuild $true -ExpectedToRun $true
 VerifyPrRun -SQPullRequestBotSetting "false" -IsPrBuild $true -ExpectedToRun $false
-VerifyPrRun -SQPullRequestBotSetting "something_else" -IsPrBuild $true -ExpectedToRun $false
-VerifyPrRun -SQPullRequestBotSetting $null -IsPrBuild $true -ExpectedToRun $false
+VerifyPrRun -SQPullRequestBotSetting "something_else" -IsPrBuild $true -ExpectedToRun $true
+VerifyPrRun -SQPullRequestBotSetting $null -IsPrBuild $true -ExpectedToRun $true
 
 VerifyPrRun -SQPullRequestBotSetting "true" -IsPrBuild $false -ExpectedToRun $true
 VerifyPrRun -SQPullRequestBotSetting "false" -IsPrBuild $false -ExpectedToRun $true

--- a/Tests/L0/SonarQubePreBuild/DisableAnalysisOnPrBuild.ps1
+++ b/Tests/L0/SonarQubePreBuild/DisableAnalysisOnPrBuild.ps1
@@ -45,11 +45,11 @@ function VerifyPrRun
     }
 }
 
-
+# PRCA is enabled by default but can be disabled through the build variable
 VerifyPrRun -SQPullRequestBotSetting "true" -IsPrBuild $true -ExpectedToRun $true
 VerifyPrRun -SQPullRequestBotSetting "false" -IsPrBuild $true -ExpectedToRun $false
-VerifyPrRun -SQPullRequestBotSetting "something_else" -IsPrBuild $true -ExpectedToRun $false
-VerifyPrRun -SQPullRequestBotSetting $null -IsPrBuild $true -ExpectedToRun $false
+VerifyPrRun -SQPullRequestBotSetting "something_else" -IsPrBuild $true -ExpectedToRun $true
+VerifyPrRun -SQPullRequestBotSetting $null -IsPrBuild $true -ExpectedToRun $true
 
 VerifyPrRun -SQPullRequestBotSetting "true" -IsPrBuild $false -ExpectedToRun $true
 VerifyPrRun -SQPullRequestBotSetting "false" -IsPrBuild $false -ExpectedToRun $true


### PR DESCRIPTION
We have kept PRCA behind a build flag because of its complexity and integration risks. The flag is "off" by default. This change will make it "on" by default. 