### PR TITLE
Darque warrior patch 1

### DIFF
--- a/Tasks/NugetPackager/task.json
+++ b/Tasks/NugetPackager/task.json
@@ -11,6 +11,9 @@
         "Minor": 1,
         "Patch": 65
     },
+    "demands": [
+    "Cmd"
+    ],
     "minimumAgentVersion": "1.83.0",
     "groups": [
         {

--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -11,6 +11,9 @@
         "Minor": 1,
         "Patch": 50
     },
+    "demands": [
+        "Cmd"
+    ],
     "minimumAgentVersion": "1.83.0",
     "groups": [
         {


### PR DESCRIPTION
I got pinged on [Twitter ](https://twitter.com/tomgilder/status/729679834562084864) by a user that tried to use these two tasks on non Windows agents. Because there was no demand for Cmd you could save the definition.  Until the tasks are re-written as Node.js tasks we need to add the Cmd demand to give a more meaningfully error if they attempt to use the tasks with a pool that does not have Windows agents in it. This will also ensure if they have a mixed pool of agents these tasks are only run on Windows agents.  

I did not change the NuGetInstaller task because it has a Node.js implementation.