### PR TITLE
Check that solution file is a file

### DIFF
--- a/Tasks/NuGetInstaller/NuGetInstaller.ps1
+++ b/Tasks/NuGetInstaller/NuGetInstaller.ps1
@@ -136,7 +136,7 @@ try
         {
             if (-not (Test-Path $sf -PathType Leaf)) # check if the path is a file to give a friendly message if not
             {
-                Write-Error (Get-LocalizedString -Key "Path '{0}' does not exist or is not a solution file" -ArgumentList $sf)
+                Write-Error (Get-LocalizedString -Key "Path '{0}' does not exist or is not a solution file. Check the 'path to solution or packages.config' property of the NuGetInstaller task " -ArgumentList $sf)
             }
             else
             {

--- a/Tasks/NuGetInstaller/NuGetInstaller.ps1
+++ b/Tasks/NuGetInstaller/NuGetInstaller.ps1
@@ -134,9 +134,16 @@ try
     {
         if($nuGetPath)
         {
-            $slnFolder = $(Get-ItemProperty -Path $sf -Name 'DirectoryName').DirectoryName
-            Write-Verbose "Running nuget package $restoreMode for $slnFolder"
-            Invoke-Tool -Path $nugetPath -Arguments "$restoreMode `"$sf`" $args" -WorkingFolder $slnFolder
+            if (-not (Test-Path $sf -PathType Leaf)) # check if the path is a file to give a friendly message if not
+            {
+                Write-Error (Get-LocalizedString -Key "Path '{0}' does not exist or is not a solution file" -ArgumentList $sf)
+            }
+            else
+            {
+                $slnFolder = $(Get-ItemProperty -Path $sf -Name 'DirectoryName').DirectoryName
+                Write-Verbose "Running nuget package $restoreMode for $slnFolder"
+                Invoke-Tool -Path $nugetPath -Arguments "$restoreMode `"$sf`" $args" -WorkingFolder $slnFolder
+            }
         }
     }
 }

--- a/Tasks/NuGetInstaller/task.json
+++ b/Tasks/NuGetInstaller/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 29
+        "Patch": 30
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NuGetInstaller/task.loc.json
+++ b/Tasks/NuGetInstaller/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 29
+    "Patch": 30
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [


### PR DESCRIPTION
Add test to give a more useful error message when the "path to solution or packages.config" property of the NuGetInstaller task is set to a folder that exists. Issue #1686 