### PR TITLE
TestSettings support for Run In Parrallel

### DIFF
--- a/Tasks/VsTest/Helpers.ps1
+++ b/Tasks/VsTest/Helpers.ps1
@@ -54,7 +54,7 @@ function SetupRunSettingsFileForParallel {
 
     if($runInParallelFlag -eq "True")
     {
-	    if([string]::Compare([io.path]::GetExtension($runSettingsFilePath), ".testsettings", $True) -eq 0)
+		if([string]::Compare([io.path]::GetExtension($runSettingsFilePath), ".testsettings", $True) -eq 0)
 		{
 			Write-Verbose "Run in Parallel is not supported with testsettings file."
 		}

--- a/Tasks/VsTest/Helpers.ps1
+++ b/Tasks/VsTest/Helpers.ps1
@@ -56,7 +56,7 @@ function SetupRunSettingsFileForParallel {
 	{
 		if([string]::Compare([io.path]::GetExtension($runSettingsFilePath), ".testsettings", $True) -eq 0)
 		{
-			Write-Verbose "Run in Parallel is not supported with testsettings file."
+			Write-Warning "Run in Parallel is not supported with testsettings file."
 		}
 		else
 		{

--- a/Tasks/VsTest/Helpers.ps1
+++ b/Tasks/VsTest/Helpers.ps1
@@ -53,42 +53,50 @@ function SetupRunSettingsFileForParallel {
     )
 
     if($runInParallelFlag -eq "True")
-    {        
-        $runSettingsForParallel = [xml]'<?xml version="1.0" encoding="utf-8"?>'
-        if([System.String]::IsNullOrWhiteSpace($runSettingsFilePath) -Or ([string]::Compare([io.path]::GetExtension($runSettingsFilePath), ".runsettings", $True) -ne 0) -Or (Test-Path $runSettingsFilePath -pathtype container))  # no file provided so create one and use it for the run
-        {
-            Write-Verbose "No runsettings file provided"
-            $runSettingsForParallel = [xml]'<?xml version="1.0" encoding="utf-8"?>
-<RunSettings>
-  <RunConfiguration>
-    <MaxCpuCount>0</MaxCpuCount>
-  </RunConfiguration>
-</RunSettings>
-'
-        }
-        else 
-        { 
-            Write-Verbose "Adding maxcpucount element to runsettings file provided"
-            $runSettingsForParallel = [System.Xml.XmlDocument](Get-Content $runSettingsFilePath)
-            $runConfigurationElement = $runSettingsForParallel.SelectNodes("//RunSettings/RunConfiguration")
-            if($runConfigurationElement.Count -eq 0)
-            {
-                $runConfigurationElement = $runSettingsForParallel.RunSettings.AppendChild($runSettingsForParallel.CreateElement("RunConfiguration"))
-            }
+    {
+	    if([string]::Compare([io.path]::GetExtension($runSettingsFilePath), ".testsettings", $True) -eq 0)
+		{
+			Write-Verbose "Run in Parallel is not supported with testsettings file."
+		}
+		else
+		{
+			$runSettingsForParallel = [xml]'<?xml version="1.0" encoding="utf-8"?>'
+			if([System.String]::IsNullOrWhiteSpace($runSettingsFilePath) -Or ([string]::Compare([io.path]::GetExtension($runSettingsFilePath), ".runsettings", $True) -ne 0) -Or (Test-Path $runSettingsFilePath -pathtype container))  # no file provided so create one and use it for the run
+			{
+				Write-Verbose "No runsettings file provided"
+				$runSettingsForParallel = [xml]'<?xml version="1.0" encoding="utf-8"?>
+				<RunSettings>
+				  <RunConfiguration>
+					<MaxCpuCount>0</MaxCpuCount>
+				  </RunConfiguration>
+				</RunSettings>
+				'
+			}
+			else 
+			{ 
+				Write-Verbose "Adding maxcpucount element to runsettings file provided"
+				$runSettingsForParallel = [System.Xml.XmlDocument](Get-Content $runSettingsFilePath)
+				$runConfigurationElement = $runSettingsForParallel.SelectNodes("//RunSettings/RunConfiguration")
+				if($runConfigurationElement.Count -eq 0)
+				{
+					$runConfigurationElement = $runSettingsForParallel.RunSettings.AppendChild($runSettingsForParallel.CreateElement("RunConfiguration"))
+				}
 
-            $maxCpuCountElement = $runSettingsForParallel.SelectNodes("//RunSettings/RunConfiguration/MaxCpuCount")
-            if($maxCpuCountElement.Count -eq 0)
-            {
-                $newMaxCpuCountElement = $runConfigurationElement.AppendChild($runSettingsForParallel.CreateElement("MaxCpuCount"))
-            }    
-        }
+				$maxCpuCountElement = $runSettingsForParallel.SelectNodes("//RunSettings/RunConfiguration/MaxCpuCount")
+				if($maxCpuCountElement.Count -eq 0)
+				{
+					$newMaxCpuCountElement = $runConfigurationElement.AppendChild($runSettingsForParallel.CreateElement("MaxCpuCount"))
+				}    
+			}
 
-        $runSettingsForParallel.RunSettings.RunConfiguration.MaxCpuCount = $defaultCpuCount
-        $tempFile = [io.path]::GetTempFileName()
-        $runSettingsForParallel.Save($tempFile)
-        Write-Verbose "Temporary runsettings file created at $tempFile"
-        return $tempFile
-    }
+			$runSettingsForParallel.RunSettings.RunConfiguration.MaxCpuCount = $defaultCpuCount
+			$tempFile = [io.path]::GetTempFileName()
+			$runSettingsForParallel.Save($tempFile)
+			Write-Verbose "Temporary runsettings file created at $tempFile"
+			return $tempFile
+		}
+	}
+	
     return $runSettingsFilePath
 }
 

--- a/Tasks/VsTest/Helpers.ps1
+++ b/Tasks/VsTest/Helpers.ps1
@@ -1,59 +1,59 @@
 function CmdletHasMember {
-    [cmdletbinding()]
-    [OutputType([System.Boolean])]
-    param(
-        [string]$memberName
-    )
-    
-    $publishParameters = (gcm Publish-TestResults).Parameters.Keys.Contains($memberName) 
-    return $publishParameters
+	[cmdletbinding()]
+	[OutputType([System.Boolean])]
+	param(
+		[string]$memberName
+	)
+	
+	$publishParameters = (gcm Publish-TestResults).Parameters.Keys.Contains($memberName) 
+	return $publishParameters
 }
 
 function SetRegistryKeyForParallel {    
-    [cmdletbinding()]
-    param(
-        [string]$vsTestVersion
-    )
-    
-    $regkey = "HKCU\SOFTWARE\Microsoft\VisualStudio\" + $vsTestVersion + "_Config\FeatureFlags\TestingTools\UnitTesting\Taef"
-    reg add $regkey /v Value /t REG_DWORD /d 1 /f /reg:32 > $null
+	[cmdletbinding()]
+	param(
+		[string]$vsTestVersion
+	)
+	
+	$regkey = "HKCU\SOFTWARE\Microsoft\VisualStudio\" + $vsTestVersion + "_Config\FeatureFlags\TestingTools\UnitTesting\Taef"
+	reg add $regkey /v Value /t REG_DWORD /d 1 /f /reg:32 > $null
 }
 
 function IsVisualStudio2015Update1OrHigherInstalled {
-    [cmdletbinding()]
-    [OutputType([System.Boolean])]
-    param(
-        [string]$vsTestVersion
-    )
-    
-    $version = [int]($vsTestVersion)
-    if($version -ge 14)
-    {
-        # checking for dll introduced in vs2015 update1
-        # since path of the dll will change in dev15+ using vstestversion>14 as a blanket yes
-        if((Test-Path -Path "$env:VS140COMNTools\..\IDE\CommonExtensions\Microsoft\TestWindow\TE.TestModes.dll") -Or ($version -gt 14))
-        {
-            # ensure the registry is set otherwise you need to launch VSIDE
-            SetRegistryKeyForParallel $vsTestVersion
-            
-            return $true
-        }
-    }
-    
-    return $false
+	[cmdletbinding()]
+	[OutputType([System.Boolean])]
+	param(
+		[string]$vsTestVersion
+	)
+	
+	$version = [int]($vsTestVersion)
+	if($version -ge 14)
+	{
+		# checking for dll introduced in vs2015 update1
+		# since path of the dll will change in dev15+ using vstestversion>14 as a blanket yes
+		if((Test-Path -Path "$env:VS140COMNTools\..\IDE\CommonExtensions\Microsoft\TestWindow\TE.TestModes.dll") -Or ($version -gt 14))
+		{
+			# ensure the registry is set otherwise you need to launch VSIDE
+			SetRegistryKeyForParallel $vsTestVersion
+			
+			return $true
+		}
+	}
+	
+	return $false
 }
 
 function SetupRunSettingsFileForParallel {
-    [cmdletbinding()]
-    [OutputType([System.String])]
-    param(
-        [string]$runInParallelFlag,
-        [string]$runSettingsFilePath,
-        [string]$defaultCpuCount
-    )
+	[cmdletbinding()]
+	[OutputType([System.String])]
+	param(
+		[string]$runInParallelFlag,
+		[string]$runSettingsFilePath,
+		[string]$defaultCpuCount
+	)
 
-    if($runInParallelFlag -eq "True")
-    {
+	if($runInParallelFlag -eq "True")
+	{
 		if([string]::Compare([io.path]::GetExtension($runSettingsFilePath), ".testsettings", $True) -eq 0)
 		{
 			Write-Verbose "Run in Parallel is not supported with testsettings file."
@@ -97,6 +97,6 @@ function SetupRunSettingsFileForParallel {
 		}
 	}
 	
-    return $runSettingsFilePath
+	return $runSettingsFilePath
 }
 

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 30
+    "Patch": 31
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 30
+    "Patch": 31
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Description: Currently in the vstest task if someone provide a testsettings file in the runsettings field and checks the Run in Parallel checkbox, we ignore the testsettings file and create our own runsettings file.

Fix: Added logic to print appropriate message and honor the testsettings file.

Testing: Manual