### PR TITLE
Fixing L0 tests for vstest task

### DIFF
--- a/Tests/L0/VsTest/RunSettingsForParallel.ReturnsNewFileIfParallelIsTrueAndFileNameIsANonRunsettingsNonTestSettingsFile.ps1
+++ b/Tests/L0/VsTest/RunSettingsForParallel.ReturnsNewFileIfParallelIsTrueAndFileNameIsANonRunsettingsNonTestSettingsFile.ps1
@@ -1,0 +1,36 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\lib\Initialize-Test.ps1
+Register-Mock Get-LocalizedString { $OFS = " " ; "$args" }
+Register-Mock Get-TaskVariable
+
+. $PSScriptRoot\..\..\..\Tasks\VsTest\Helpers.ps1
+
+$cpuCount="1"
+$temptestsettingsfile = [io.path]::ChangeExtension([io.path]::GetTempFileName(),"xml")
+$testsettings = @('<?xml version="1.0" encoding="utf-8"?> 
+<TestSettings name="Empty Test Settings">
+  <Description>Empty testsettings</Description>
+</TestSettings>
+')
+Set-Content -Value $testsettings -Path $temptestsettingsfile
+
+$returnedFilePath = SetupRunSettingsFileForParallel "true" $temptestsettingsfile $cpuCount
+
+$fileExists = Test-Path $returnedFilePath
+Assert-AreEqual $true $fileExists
+
+Assert-AreNotEqual $temptestsettingsfile $returnedFilePath
+
+$readRunSettingsFile=[System.Xml.XmlDocument](Get-Content $returnedFilePath)
+Assert-AreEqual $cpuCount $readRunSettingsFile.RunSettings.RunConfiguration.MaxCpuCount
+
+#cleanup
+if($fileExists){
+	Remove-Item $returnedFilePath
+}
+if(Test-Path $temptestsettingsfile){
+	Remove-Item $temptestsettingsfile
+}

--- a/Tests/L0/VsTest/RunSettingsForParallel.ReturnsSameFileIfParallelIsTrueAndFileNameIsTestSettingsFile.ps1
+++ b/Tests/L0/VsTest/RunSettingsForParallel.ReturnsSameFileIfParallelIsTrueAndFileNameIsTestSettingsFile.ps1
@@ -22,10 +22,7 @@ $returnedFilePath = SetupRunSettingsFileForParallel "true" $temptestsettingsfile
 $fileExists = Test-Path $returnedFilePath
 Assert-AreEqual $true $fileExists
 
-Assert-AreNotEqual $temptestsettingsfile $returnedFilePath
-
-$readRunSettingsFile=[System.Xml.XmlDocument](Get-Content $returnedFilePath)
-Assert-AreEqual $cpuCount $readRunSettingsFile.RunSettings.RunConfiguration.MaxCpuCount
+Assert-AreEqual $temptestsettingsfile $returnedFilePath
 
 #cleanup
 if($fileExists){

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -61,8 +61,11 @@ describe('VsTest Suite', function () {
         it('(RunSettingsForParallel.ReturnsNewFileIfParallelIsTrueAndFileNameIsADirectory) returns new file if parallel flag is true and runsettings input is a directory', (done) => {
             psm.runPS(path.join(__dirname, 'RunSettingsForParallel.ReturnsNewFileIfParallelIsTrueAndFileNameIsADirectory.ps1'), done);
         })
-        it('(RunSettingsForParallel.ReturnsNewFileIfParallelIsTrueAndFileNameIsANonRunsettingsFile) returns new file if parallel flag is true and runsettings input is not a runsettings file', (done) => {
-            psm.runPS(path.join(__dirname, 'RunSettingsForParallel.ReturnsNewFileIfParallelIsTrueAndFileNameIsANonRunsettingsFile.ps1'), done);
+        it('(RunSettingsForParallel.ReturnsNewFileIfParallelIsTrueAndFileNameIsANonRunsettingsNonTestSettingsFile) returns new file if parallel flag is true and runsettings input is not a runsettings or testsettings file', (done) => {
+            psm.runPS(path.join(__dirname, 'RunSettingsForParallel.ReturnsNewFileIfParallelIsTrueAndFileNameIsANonRunsettingsNonTestSettingsFile.ps1'), done);
+        })
+		it('(RunSettingsForParallel.ReturnsSameFileIfParallelIsTrueAndFileNameIsTestSettingsFile) returns same file if parallel flag is true and runsettings input is a testsettings file', (done) => {
+            psm.runPS(path.join(__dirname, 'RunSettingsForParallel.ReturnsSameFileIfParallelIsTrueAndFileNameIsTestSettingsFile.ps1'), done);
         })
     }
 });


### PR DESCRIPTION
Last changes to vstest task caused the L0 tests to break. Fixing the tests and adding new tests.