### PR TITLE
trim whitespace from URL

### DIFF
--- a/Tasks/NugetPublisher/NuGetPublisher.ps1
+++ b/Tasks/NugetPublisher/NuGetPublisher.ps1
@@ -82,7 +82,7 @@ if($connectedServiceName -and $useExternalFeed)
 elseif($feedName -and (-not $useExternalFeed))
 {
     Write-Verbose "Using provided feed URL"
-    $nugetServer = $feedName
+    $nugetServer = $feedName.Trim()
 
     if (-not [URI]::IsWellFormedUriString($nugetServer, [UriKind]::Absolute))
     {


### PR DESCRIPTION
A customer encountered hard-to-troubleshoot issues when accidentally including a trailing space.