### PR TITLE
Update AndroidSigning tasks

### DIFF
--- a/Tasks/AndroidSigning/androidsigning.ts
+++ b/Tasks/AndroidSigning/androidsigning.ts
@@ -25,8 +25,15 @@ var jarsigning = (fn: string) => {
     // file must exist
     tl.checkPath(fn, 'file to sign');
 
-    var java_home = tl.getVariable('JAVA_HOME');
-    var jarsigner = path.join(java_home, 'bin', 'jarsigner');
+    var jarsigner = tl.which("jarsigner", false);
+    if (!jarsigner) {
+        var java_home = tl.getVariable('JAVA_HOME');
+        if (!java_home) {
+            onError("JAVA_HOME is not set");
+        }
+
+        jarsigner = path.join(java_home, 'bin', 'jarsigner');
+    }
 
     var jarsignerRunner = tl.createToolRunner(jarsigner);
 
@@ -72,7 +79,6 @@ var zipaligning = (fn: string) => {
     tl.checkPath(fn, 'file to zipalign');
 
     var zipaligner = tl.getInput('zipalignLocation', false);
-    tl.debug("zipalign tool: " + zipaligner);
 
     // if the tool path is not set, let's find one (anyone) from the SDK folder
     if (!zipaligner) {
@@ -134,15 +140,12 @@ var process = (fn: string) => {
 //-----------------------------------------------------------------------------
 // Get files to be signed 
 var filesPattern = tl.getInput('files', true);
-tl.debug('filesPattern: ' + filesPattern); 
 
 // Signing the APK?
 var jarsign: boolean = tl.getBoolInput('jarsign');
-tl.debug('jarsign: ' + jarsign);
 
 // Zipaligning the APK?
 var zipalign: boolean = tl.getBoolInput('zipalign');
-tl.debug('zipalign: ' + zipalign);
 
 // Resolve files for the specified value or pattern
 if (filesPattern.indexOf('*') == -1 && filesPattern.indexOf('?') == -1) {

--- a/Tasks/AndroidSigning/task.json
+++ b/Tasks/AndroidSigning/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 19
+        "Patch": 20 
     },
     "demands": [
         "JDK",

--- a/Tasks/AndroidSigning/task.loc.json
+++ b/Tasks/AndroidSigning/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 19
+    "Patch": 20
   },
   "demands": [
     "JDK",

--- a/Tests/L0/AndroidSigning/_suite.ts
+++ b/Tests/L0/AndroidSigning/_suite.ts
@@ -28,7 +28,7 @@ describe('AndroidSigning Suite', function() {
     it('Do not sign or zipalign if nothing is selected', (done) => {
         setResponseFile('androidSignAlignSingleFile.json');
         
-        var tr = new trm.TaskRunner('AndroidSigning');
+        var tr = new trm.TaskRunner('AndroidSigning', true);
         
         tr.setInput('files', '/some/fake.apk');
         tr.setInput('jarsign', 'false');
@@ -45,11 +45,121 @@ describe('AndroidSigning Suite', function() {
             done(err);
         }); 
     })  
+    
+    it ('Do not align or sign if input single file does not exist', (done) => {
+        setResponseFile('androidSignAlignNoFileInput.json');
+        
+        var tr = new trm.TaskRunner('AndroidSigning', true);
+        
+        tr.setInput('files', '/some/path/nonexistent.apk');
+        tr.setInput('jarsign', 'true');
+        tr.setInput('zipalign', 'true');
+        
+        tr.run()
+        .then(() => {
+            assert(tr.invokedToolCount == 0, 'should not run anything');
+            assert(tr.stderr.length > 0, 'should have written to stderr');
+            assert(tr.failed, 'task should have failed');
+            done();
+        })
+        .fail((err) => {
+            done(err);
+        }); 
+    })
+    
+    it ('Do not align or sign if input pattern does not match any files', (done) => {
+        setResponseFile('androidSignAlignNoFileInput.json');
+        
+        var tr = new trm.TaskRunner('AndroidSigning', true);
+        
+        tr.setInput('files', '/some/nonexistent/path/*.apk');
+        tr.setInput('jarsign', 'true');
+        tr.setInput('zipalign', 'true');
+        
+        tr.run()
+        .then(() => {
+            assert(tr.invokedToolCount == 0, 'should not run anything');
+            assert(tr.stderr.length > 0, 'should have failed to match files');
+            assert(tr.failed, 'task should have failed');
+            done();
+        })
+        .fail((err) => {
+            done(err);
+        }); 
+    })
+    
+
+    it ('Use jarsigner from PATH before searching in JAVA_HOME', (done) => {
+        setResponseFile('androidSignAlignEnvNotSet.json');
+        
+        var tr = new trm.TaskRunner('AndroidSigning', true);
+        
+        tr.setInput('files', '/some/path/a.apk');
+        tr.setInput('jarsign', 'true');
+        tr.setInput('keystoreFile', '/some/store'); 
+        tr.setInput('keystorePass', 'pass1');
+        tr.setInput('keystoreAlias', 'somealias');
+        tr.setInput('keyPass', 'pass2');
+        tr.setInput('zipalign', 'false');
+        
+        tr.run()
+        .then(() => {
+            assert(tr.invokedToolCount == 1, 'should have run jarsigner');
+            assert(tr.stderr.length == 0, 'should have jarsigned file');
+            assert(tr.succeeded, 'task should have succeeded');
+            done();
+        })
+        .fail((err) => {
+            done(err);
+        }); 
+    })
+    
+    it ('Fail if jarsigner is not on PATH and JAVA_HOME is not set', (done) => {
+        setResponseFile('androidSignAlignEnvNotSet.json');
+        
+        var tr = new trm.TaskRunner('AndroidSigning', true);
+        
+        tr.setInput('files', '/some/path/a.apk');
+        tr.setInput('jarsign', 'true');
+        tr.setInput('zipalign', 'true');
+        
+        tr.run()
+        .then(() => {
+            assert(tr.invokedToolCount == 0, 'should not run anything');
+            assert(tr.stderr.length > 0, 'should have failed to locate jarsigner');
+            assert(tr.failed, 'task should have failed');
+            done();
+        })
+        .fail((err) => {
+            done(err);
+        }); 
+    })
+    
+    it ('Fail if ANDROID_HOME is not set', (done) => {
+        setResponseFile('androidSignAlignEnvNotSet.json');
+        
+        var tr = new trm.TaskRunner('AndroidSigning', true);
+        
+        tr.setInput('files', '/some/path/a.apk');
+        tr.setInput('jarsign', 'false');
+        tr.setInput('zipalign', 'true');
+        
+        tr.run()
+        .then(() => {
+            assert(tr.invokedToolCount == 0, 'should not run anything');
+            assert(tr.stderr.length > 0, 'should have jarsigned file');
+            assert(tr.failed, 'task should have failed');
+            done();
+        })
+        .fail((err) => {
+            done(err);
+        }); 
+    })
 
     it('Signing a single file', (done) => {
         setResponseFile('androidSignAlignSingleFile.json');
         
-        var tr = new trm.TaskRunner('AndroidSigning');
+        var tr = new trm.TaskRunner('AndroidSigning', true);
         
         tr.setInput('files', '/some/fake.apk');
         tr.setInput('jarsign', 'true');
@@ -74,7 +184,7 @@ describe('AndroidSigning Suite', function() {
     it('zipalign a single file', (done) => {
         setResponseFile('androidSignAlignSingleFile.json');
         
-        var tr = new trm.TaskRunner('AndroidSigning');
+        var tr = new trm.TaskRunner('AndroidSigning', true);
         
         tr.setInput('files', '/some/fake.apk');
         tr.setInput('jarsign', 'false');
@@ -95,7 +205,7 @@ describe('AndroidSigning Suite', function() {
     it('Signing and aligning multiple file', (done) => {
         setResponseFile('androidSignAlignMultipleFile.json');
         
-        var tr = new trm.TaskRunner('AndroidSigning');
+        var tr = new trm.TaskRunner('AndroidSigning', true);
         
         tr.setInput('files', '/some/path/*.apk');
         tr.setInput('jarsign', 'true');

--- a/Tests/L0/AndroidSigning/androidSignAlignEnvNotSet.json
+++ b/Tests/L0/AndroidSigning/androidSignAlignEnvNotSet.json
@@ -1,0 +1,16 @@
+{
+    "getVariable": {
+    },
+    "checkPath": {
+        "/some/path/a.apk": true
+    },
+    "which": {
+        "jarsigner": "/usr/bin/jarsigner"
+    },
+    "exec": {
+        "/usr/bin/jarsigner -keystore /some/store -storepass pass1 -keypass pass2 -signedjar /some/path/a.apk /some/path/a.apk.unsigned somealias": {
+            "code": 0,
+            "stdout": "jarsigner output here"
+        }
+    }
+}

--- a/Tests/L0/AndroidSigning/androidSignAlignMultipleFile.json
+++ b/Tests/L0/AndroidSigning/androidSignAlignMultipleFile.json
@@ -19,22 +19,6 @@
         "/fake/android/home/sdk1/zipalign -v 4 /some/path/b.apk.unaligned /some/path/b.apk": {
             "code": 0,
             "stdout": "zipalign output here"
-        },
-        "\\fake\\java\\home\\bin\\jarsigner -keystore /some/store -storepass pass1 -keypass pass2 -signedjar /some/path/a.apk /some/path/a.apk.unsigned somealias": {
-            "code": 0,
-            "stdout": "jarsigner output here"
-        },
-        "\\fake\\java\\home\\bin\\jarsigner -keystore /some/store -storepass pass1 -keypass pass2 -signedjar /some/path/b.apk /some/path/b.apk.unsigned somealias": {
-            "code": 0,
-            "stdout": "jarsigner output here"
-        },
-         "\\fake\\android\\home\\sdk1\\zipalign -v 4 /some/path/a.apk.unaligned /some/path/a.apk": {
-            "code": 0,
-            "stdout": "zipalign output here"
-        },
-        "\\fake\\android\\home\\sdk1\\zipalign -v 4 /some/path/b.apk.unaligned /some/path/b.apk": {
-            "code": 0,
-            "stdout": "zipalign output here"
         }
     },
     "checkPath": {

--- a/Tests/L0/AndroidSigning/androidSignAlignNoEnvNoPath.json
+++ b/Tests/L0/AndroidSigning/androidSignAlignNoEnvNoPath.json
@@ -1,0 +1,5 @@
+{
+     "checkPath": {
+        "/some/path/a.apk": true
+    }
+}

--- a/Tests/L0/AndroidSigning/androidSignAlignNoFileInput.json
+++ b/Tests/L0/AndroidSigning/androidSignAlignNoFileInput.json
@@ -1,0 +1,17 @@
+{
+    "getVariable": {
+        "JAVA_HOME": "/fake/java/home",
+        "ANDROID_HOME": "/fake/android/home"
+    },
+    "checkPath": {
+        "/some/path/nonexistent.apk": false
+    },
+    "find": {
+        "/some/nonexistent/path": [
+        ]
+    },
+    "match": {
+        "/some/nonexistent/path/*.apk": [
+        ]
+    }
+}

--- a/Tests/L0/AndroidSigning/androidSignAlignSingleFile.json
+++ b/Tests/L0/AndroidSigning/androidSignAlignSingleFile.json
@@ -11,14 +11,6 @@
          "/fake/android/home/sdk1/zipalign -v 4 /some/fake.apk.unaligned /some/fake.apk": {
             "code": 0,
             "stdout": "zipalign output here"
-        },
-        "\\fake\\java\\home\\bin\\jarsigner -keystore /some/store -storepass pass1 -keypass pass2 -signedjar /some/fake.apk /some/fake.apk.unsigned somealias": {
-            "code": 0,
-            "stdout": "jarsigner output here"
-        },
-         "\\fake\\android\\home\\sdk1\\zipalign -v 4 /some/fake.apk.unaligned /some/fake.apk": {
-            "code": 0,
-            "stdout": "zipalign output here"
         }
     },
     "checkPath": {


### PR DESCRIPTION
1. Remove redundant debug lines - task library writes debug lines now
2. Check jarsigner on PATH first before looking in JAVA_HOME
3. Fail with clear message if JAVA_HOME is not set
4. Add additional tests around file input and jarsigner location