### PR TITLE
Surfaced SetParamFile in AzureRMWebDeploy task

### DIFF
--- a/Tasks/AzureRmWebAppDeployment/AzureRmWebAppDeployment.ps1
+++ b/Tasks/AzureRmWebAppDeployment/AzureRmWebAppDeployment.ps1
@@ -88,10 +88,12 @@ $ErrorActionPreference = 'Stop'
 $msDeployExePath = Get-MsDeployExePath
 
 # Ensure that at most a package (.zip) file is found
-$packageFile = Get-SingleFilePath -file $Package
+$packageFilePath = Get-SingleFilePath -file $Package
 
-$setParametersFilePath = ""
-if( -not [String]::IsNullOrEmpty($SetParametersFile)){
+# Since the SetParametersFile is optional, but it's a FilePath type, it will have the value System.DefaultWorkingDirectory when not specified
+if( $SetParametersFile -eq $env:SYSTEM_DEFAULTWORKINGDIRECTORY -or $SetParametersFile -eq [String]::Concat($env:SYSTEM_DEFAULTWORKINGDIRECTORY, "\")){
+    $setParametersFilePath = ""
+} else {
     $setParametersFilePath = Get-SingleFilePath -file $SetParametersFile
 }
 
@@ -103,7 +105,7 @@ $azureRMWebAppConnectionDetails = Get-AzureRMWebAppConnectionDetails -webAppName
 $webAppNameForMSDeployCmd = Get-WebAppNameForMSDeployCmd -webAppName $WebAppName -deployToSlotFlag $DeployToSlotFlag -slotName $SlotName
 
 # Construct arguments for msdeploy command
-$msDeployCmdArgs = Get-MsDeployCmdArgs -packageFile $packageFile -webAppNameForMSDeployCmd $webAppNameForMSDeployCmd -azureRMWebAppConnectionDetails $azureRMWebAppConnectionDetails -removeAdditionalFilesFlag $RemoveAdditionalFilesFlag `
+$msDeployCmdArgs = Get-MsDeployCmdArgs -packageFile $packageFilePath -webAppNameForMSDeployCmd $webAppNameForMSDeployCmd -azureRMWebAppConnectionDetails $azureRMWebAppConnectionDetails -removeAdditionalFilesFlag $RemoveAdditionalFilesFlag `
                                        -excludeFilesFromAppDataFlag $ExcludeFilesFromAppDataFlag -takeAppOfflineFlag $TakeAppOfflineFlag -virtualApplication $VirtualApplication -AdditionalArguments $AdditionalArguments `
                                        -setParametersFile $setParametersFilePath
 

--- a/Tasks/AzureRmWebAppDeployment/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureRmWebAppDeployment/Strings/resources.resjson/en-US/resources.resjson
@@ -16,6 +16,8 @@
   "loc.input.help.SlotName": "Enter or Select an existing Slot other than the Production slot.",
   "loc.input.label.Package": "Package",
   "loc.input.help.Package": "Location of the Web App zip package on the automation agent or on a UNC path accessible to the automation agent like, \\\\\\\\BudgetIT\\Web\\Deploy\\Fabrikam.zip. Predefined system variables and wild cards like, $(System.DefaultWorkingDirectory)\\\\***.zip` can be also used here.",
+  "loc.input.label.SetParametersFile": "SetParameters File",
+  "loc.input.help.SetParametersFile": "Optional: location of the SetParameters.xml file to use.",
   "loc.input.label.RemoveAdditionalFilesFlag": "Remove Additional Files at Destination",
   "loc.input.help.RemoveAdditionalFilesFlag": "Select the option to delete files on the AzureRM Web App that have no matching files in the Web App zip package.",
   "loc.input.label.ExcludeFilesFromAppDataFlag": "Exclude Files from the App_Data Folder",

--- a/Tasks/AzureRmWebAppDeployment/Utility.ps1
+++ b/Tasks/AzureRmWebAppDeployment/Utility.ps1
@@ -51,16 +51,16 @@ function Get-SingleFile
     }
 }
 
-function Get-SinglePackageFile
+function Get-SingleFilePath
 {
-    param([String][Parameter(Mandatory=$true)] $package)
+    param([String][Parameter(Mandatory=$true)] $file)
 
-    Write-Host (Get-LocalizedString -Key "packageFile = Find-Files -SearchPattern {0}" -ArgumentList $package)
-    $packageFile = Find-Files -SearchPattern $package
-    Write-Host (Get-LocalizedString -Key "packageFile = {0}" -ArgumentList $packageFile)
+    Write-Host (Get-LocalizedString -Key "filePath = Find-Files -SearchPattern {0}" -ArgumentList $file)
+    $filePath = Find-Files -SearchPattern $file
+    Write-Host (Get-LocalizedString -Key "filePath = {0}" -ArgumentList $filePath)
 
-    $packageFile = Get-SingleFile -files $packageFile -pattern $package
-    return $packageFile
+    $filePath = Get-SingleFile -files $filePath -pattern $file
+    return $filePath
 }
 
 function Get-WebAppNameForMSDeployCmd
@@ -89,6 +89,7 @@ function Get-MsDeployCmdArgs
           [String][Parameter(Mandatory=$true)] $excludeFilesFromAppDataFlag,
           [String][Parameter(Mandatory=$true)] $takeAppOfflineFlag,
           [String][Parameter(Mandatory=$false)] $virtualApplication,
+          [String][Parameter(Mandatory=$false)] $setParametersFile,
           [String][Parameter(Mandatory=$false)] $AdditionalArguments)
 
     $msDeployCmdArgs = [String]::Empty
@@ -126,6 +127,10 @@ function Get-MsDeployCmdArgs
         $msDeployCmdArgs += [String]::Format(' -skip:Directory="\\App_Data"')
     }
 
+    if( -not [String]::IsNullOrEmpty($setParametersFile)){
+        $msDeployCmdArgs += [String]::Format(' -setParamFile:"{0}"', $setParametersFile)
+    }
+    
     # msploy additional arguments 
     if( -not [String]::IsNullOrEmpty($AdditionalArguments)){
         $msDeployCmdArgs += ( " " + $AdditionalArguments)

--- a/Tasks/AzureRmWebAppDeployment/task.json
+++ b/Tasks/AzureRmWebAppDeployment/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "minimumAgentVersion": "1.99.0",
 	"groups": [
@@ -83,6 +83,14 @@
             "defaultValue": "",
             "required": true,
             "helpMarkDown": "Location of the Web App zip package on the automation agent or on a UNC path accessible to the automation agent like, \\\\\\\\BudgetIT\\Web\\Deploy\\Fabrikam.zip. Predefined system variables and wild cards like, $(System.DefaultWorkingDirectory)\\\\***.zip` can be also used here."
+        },
+        {
+            "name": "SetParametersFile",
+            "type": "filePath",
+            "label": "SetParameters File",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Optional: location of the SetParameters.xml file to use."
         },
         {
             "name": "RemoveAdditionalFilesFlag",

--- a/Tasks/AzureRmWebAppDeployment/task.loc.json
+++ b/Tasks/AzureRmWebAppDeployment/task.loc.json
@@ -85,6 +85,14 @@
       "helpMarkDown": "ms-resource:loc.input.help.Package"
     },
     {
+      "name": "SetParametersFile",
+      "type": "filePath",
+      "label": "ms-resource:loc.input.label.SetParametersFile",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.SetParametersFile"
+    },
+    {
       "name": "RemoveAdditionalFilesFlag",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.RemoveAdditionalFilesFlag",


### PR DESCRIPTION
I often use a SetParameters.xml file with WebDeploy. Instead of adding it as an additional arg, I've surfaced this as an optional arg on the task. This allows the user to browse the path easily in the UI.
<img width="419" alt="setparams" src="https://cloud.githubusercontent.com/assets/1932561/15357335/6b0114b8-1cfe-11e6-8272-148af92f5f1c.png">
