### PR TITLE
Fix issues of connecting to a locked down HTTPS SonarQube server:

### DIFF
--- a/Tasks/Common/SonarQubeHelpers/SonarQubeHelper.ps1
+++ b/Tasks/Common/SonarQubeHelpers/SonarQubeHelper.ps1
@@ -162,6 +162,8 @@ function InvokeGetRestMethod
        
     }  
 
+    # Fix for HTTPS websites that support only TLS 1.2, as described by https://jira.sonarsource.com/browse/SONARMSBRU-169
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls
     $response = Invoke-RestMethod -Uri $request -Method Get -Headers $allheaders
 
     return $response

--- a/Tasks/SonarQubePostTest/SonarQubeMetrics.ps1
+++ b/Tasks/SonarQubePostTest/SonarQubeMetrics.ps1
@@ -55,7 +55,7 @@ function FetchQualityGateDetails
 #
 function FetchMetricNames
 {
-    $response = InvokeGetRestMethod "/api/metrics/search?ps=500&f=name" $false
+    $response = InvokeGetRestMethod "/api/metrics/search?ps=500&f=name" $true
     Assert (HasElements $response) "No metrics were found"
     
     return $response.metrics

--- a/Tasks/SonarQubePostTest/task.json
+++ b/Tasks/SonarQubePostTest/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 47
+    "Patch": 48
   },
   "minimumAgentVersion": "1.99.0",
   "demands": [

--- a/Tasks/SonarQubePostTest/task.loc.json
+++ b/Tasks/SonarQubePostTest/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 47
+    "Patch": 48
   },
   "minimumAgentVersion": "1.99.0",
   "demands": [

--- a/Tasks/SonarQubePreBuild/task.json
+++ b/Tasks/SonarQubePreBuild/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 42
+    "Patch": 43
   },
   "minimumAgentVersion": "1.99.0",
   "demands": [

--- a/Tasks/SonarQubePreBuild/task.loc.json
+++ b/Tasks/SonarQubePreBuild/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 42
+    "Patch": 43
   },
   "minimumAgentVersion": "1.99.0",
   "demands": [


### PR DESCRIPTION
- configure the web client to use TLS 1.2
- Use auth when calling the api/metrics/search API