### PR TITLE
Adding check to make sure expected element in XML is present in config

### DIFF
--- a/Tasks/NuGetInstaller/VsoNuGetHelper.ps1
+++ b/Tasks/NuGetInstaller/VsoNuGetHelper.ps1
@@ -121,6 +121,19 @@ function SetCredentialsNuGetConfigAndSaveTemp
         [uri]$targetFeed
     )
 
+    #check that the config has a configuration section
+    if($nugetConfig.configuration -eq $null)
+    {
+        if($nugetConfig.packages -ne $null)
+        {
+            throw (Get-LocalizedString -Key "An invalid NuGet.config was passed to the NuGet Installer step. Check the settings for this build step and confirm you selected NuGet.config rather than packages.config.")
+        }
+        else
+        {
+            throw (Get-LocalizedString -Key "An invalid NuGet.config was passed to the NuGet Installer step.")
+        }
+    }
+
     $credentialsSection = $nugetConfig.SelectSingleNode("configuration/packageSourceCredentials")
     if($credentialsSection -eq $null)
     {

--- a/Tasks/NuGetInstaller/task.json
+++ b/Tasks/NuGetInstaller/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 31
+        "Patch": 32
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [
@@ -34,7 +34,7 @@
             "type": "filePath",
             "label": "Path to NuGet.config",
             "defaultValue": "",
-            "helpMarkDown": "To use feeds within this account, check in a NuGet.config which lists those feeds as sources and select it here. This will allow the build system to authenticate to those feeds, assuming youâ€™ve added the build identity as a reader or contributor to the feed.\n\nWant to know more about feed permissions? [Learn more]( https://go.microsoft.com/fwlink/?LinkID=733327).",
+            "helpMarkDown": "To use feeds within this account, check in a NuGet.config which lists those feeds as sources and select it here. This will allow the build system to authenticate to those feeds, assuming you’ve added the build identity as a reader or contributor to the feed.\n\nWant to know more about feed permissions? [Learn more]( https://go.microsoft.com/fwlink/?LinkID=733327).",
             "required": "false"
         },
         {

--- a/Tasks/NuGetInstaller/task.loc.json
+++ b/Tasks/NuGetInstaller/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 31
+    "Patch": 32
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [


### PR DESCRIPTION
We were seeing null reference exceptions when the wrong file was used.  This change should allow users to better diagnose the configuration issue.