### PR TITLE
Updated Max Envelop Size

### DIFF
--- a/Tasks/PowerShellOnTargetMachines/ConfigureWinRM.ps1
+++ b/Tasks/PowerShellOnTargetMachines/ConfigureWinRM.ps1
@@ -148,6 +148,10 @@ function Add-FirewallException
 netsh advfirewall firewall set rule group="File and Printer Sharing" new enable=yes
 winrm quickconfig
 
+# The default MaxEnvelopeSizekb on Windows Server is 500 Kb which is very less. It needs to be at 8192 Kb. The small envelop size if not changed
+# results in WS-Management service responding with error that the request size exceeded the configured MaxEnvelopeSize quota.
+winrm set winrm/config @{MaxEnvelopeSizekb = "8192"}
+
 # Validate script arguments
 if(-not (Is-InputValid -hostname $hostname))
 {


### PR DESCRIPTION
The default MaxEnvelopeSizekb on Windows Server is 500 Kb which is very less. It needs to be at 8192 Kb. The small envelop size if not changed results in WS-Management service responding with error that the request size exceeded the configured MaxEnvelopeSize quota.