### PR TITLE
move regedit to optional dependencies

### DIFF
--- a/Tasks/VsTest/package.json
+++ b/Tasks/VsTest/package.json
@@ -1,24 +1,26 @@
 {
-  "name": "vsts-tasks-vstest",
-  "version": "1.0.0",
-  "description": "VSTS VSTEST Task",
-  "main": "VSTest.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Microsoft/vsts-tasks.git"
-  },
-  "author": "Microsoft Corporation",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/Microsoft/vsts-tasks/issues"
-  },
-  "homepage": "https://github.com/Microsoft/vsts-tasks#readme",
-  "dependencies": {
-    "regedit": "2.2.6",	
-    "xml2js": "0.4.16",
-    "vsts-task-lib": "^0.8.2"
-  }
+    "name": "vsts-tasks-vstest",
+    "version": "1.0.0",
+    "description": "VSTS VSTEST Task",
+    "main": "VSTest.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Microsoft/vsts-tasks.git"
+    },
+    "author": "Microsoft Corporation",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/Microsoft/vsts-tasks/issues"
+    },
+    "homepage": "https://github.com/Microsoft/vsts-tasks#readme",
+    "dependencies": {
+        "xml2js": "0.4.16",
+        "vsts-task-lib": "^0.8.2"
+    },
+    "optionalDependencies": {
+        "regedit": "2.2.6"
+    }
 }

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 42
+        "Patch": 43
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 42
+    "Patch": 43
   },
   "demands": [
     "vstest"

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -7,6 +7,7 @@ import assert = require('assert');
 import trm = require('../../lib/taskRunner');
 import psm = require('../../lib/psRunner');
 import path = require('path');
+import os = require('os');
 var shell = require('shelljs');
 var ps = shell.which('powershell');
 var psr = null;
@@ -116,320 +117,322 @@ describe('VsTest Suite', function() {
             psr.run(path.join(__dirname, 'DefaultTestResultsDirectoryIsUsedIfOverrideParamsAreUsed.ps1'), done);
         })
     }
+    if (os.type().match(/^Win/)) {
 
-    it('Vstest task without test results files input', (done) => {
-        setResponseFile('vstestGood.json');
-        var tr = new trm.TaskRunner('VSTest');
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length > 0, 'should have written to stderr');
-                assert(tr.failed, 'task should have failed');
-                assert(tr.stdErrContained('Input required: testAssembly'));
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+        it('Vstest task without test results files input', (done) => {
+            setResponseFile('vstestGood.json');
+            var tr = new trm.TaskRunner('VSTest');
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length > 0, 'should have written to stderr');
+                    assert(tr.failed, 'task should have failed');
+                    assert(tr.stdErrContained('Input required: testAssembly'));
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task with test results files filter', (done) => {
-        setResponseFile('vstestGood.json');
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', '/some/*pattern');
-        tr.setInput('vsTestVersion', '14.0');
+        it('Vstest task with test results files filter', (done) => {
+            setResponseFile('vstestGood.json');
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', '/some/*pattern');
+            tr.setInput('vsTestVersion', '14.0');
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one some/path/two /logger:trx'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                    assert(tr.succeeded, 'task should have succeeded');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one some/path/two /logger:trx'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task with test results files filter and exclude filter', (done) => {
-        setResponseFile('vstestGood.json');
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', '/some/*pattern;-:/exclude/*pattern');
-        tr.setInput('vsTestVersion', '14.0');
+        it('Vstest task with test results files filter and exclude filter', (done) => {
+            setResponseFile('vstestGood.json');
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', '/some/*pattern;-:/exclude/*pattern');
+            tr.setInput('vsTestVersion', '14.0');
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one /logger:trx'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                    assert(tr.succeeded, 'task should have succeeded');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one /logger:trx'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task with test results files as path', (done) => {
-        setResponseFile('vstestGood.json');
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', 'path/to/file');
-        tr.setInput('vsTestVersion', '14.0');
+        it('Vstest task with test results files as path', (done) => {
+            setResponseFile('vstestGood.json');
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', 'path/to/file');
+            tr.setInput('vsTestVersion', '14.0');
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                    assert(tr.succeeded, 'task should have succeeded');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task when vstest fails', (done) => {
-        setResponseFile('vstestFails.json');
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', '/some/*pattern');
-        tr.setInput('vsTestVersion', '14.0');
+        it('Vstest task when vstest fails', (done) => {
+            setResponseFile('vstestFails.json');
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', '/some/*pattern');
+            tr.setInput('vsTestVersion', '14.0');
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length > 0, 'should have written to stderr');
-                assert(tr.failed, 'task should have failed');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one some/path/two /logger:trx'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish/) < 0, 'should not have published test results.');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length > 0, 'should have written to stderr');
+                    assert(tr.failed, 'task should have failed');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one some/path/two /logger:trx'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish/) < 0, 'should not have published test results.');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task when vstest of specified version is not found', (done) => {
-        setResponseFile('vstestFails.json'); // this response file does not have vs 2013
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', 'path/to/file');
-        tr.setInput('vsTestVersion', '12.0');
+        it('Vstest task when vstest of specified version is not found', (done) => {
+            setResponseFile('vstestFails.json'); // this response file does not have vs 2013
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', 'path/to/file');
+            tr.setInput('vsTestVersion', '12.0');
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length > 0, 'should have written to stderr');
-                assert(tr.failed, 'task should have failed');
-                assert(!tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should not have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish/) < 0, 'should not have published test results.');
-                assert(tr.stdout.search(/Vstest of version 12 is not found. Try again with a visual studio version that exists on your build agent machine./) >= 0, 'should have displayed warning.');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length > 0, 'should have written to stderr');
+                    assert(tr.failed, 'task should have failed');
+                    assert(!tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should not have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish/) < 0, 'should not have published test results.');
+                    assert(tr.stdout.search(/Vstest of version 12 is not found. Try again with a visual studio version that exists on your build agent machine./) >= 0, 'should have displayed warning.');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task with test case filter', (done) => {
-        setResponseFile('vstestGood.json');
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', 'path/to/file');
-        tr.setInput('testFiltercriteria', 'testFilter');
-        tr.setInput('vsTestVersion', '14.0');
+        it('Vstest task with test case filter', (done) => {
+            setResponseFile('vstestGood.json');
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', 'path/to/file');
+            tr.setInput('testFiltercriteria', 'testFilter');
+            tr.setInput('vsTestVersion', '14.0');
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /TestCaseFilter:testFilter /logger:trx'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                    assert(tr.succeeded, 'task should have succeeded');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /TestCaseFilter:testFilter /logger:trx'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task with enable code coverage', (done) => {
-        setResponseFile('vstestGood.json');
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', 'path/to/file');
-        tr.setInput('codeCoverageEnabled', 'true');
-        tr.setInput('vsTestVersion', '14.0');
+        it('Vstest task with enable code coverage', (done) => {
+            setResponseFile('vstestGood.json');
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', 'path/to/file');
+            tr.setInput('codeCoverageEnabled', 'true');
+            tr.setInput('vsTestVersion', '14.0');
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /EnableCodeCoverage /logger:trx'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                    assert(tr.succeeded, 'task should have succeeded');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /EnableCodeCoverage /logger:trx'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task with other console options', (done) => {
-        setResponseFile('vstestGood.json');
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', 'path/to/file');
-        tr.setInput('otherConsoleOptions', 'consoleOptions');
-        tr.setInput('vsTestVersion', '14.0');
+        it('Vstest task with other console options', (done) => {
+            setResponseFile('vstestGood.json');
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', 'path/to/file');
+            tr.setInput('otherConsoleOptions', 'consoleOptions');
+            tr.setInput('vsTestVersion', '14.0');
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file consoleOptions /logger:trx'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                    assert(tr.succeeded, 'task should have succeeded');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file consoleOptions /logger:trx'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task with settings file', (done) => {
-        setResponseFile('vstestGood.json');
+        it('Vstest task with settings file', (done) => {
+            setResponseFile('vstestGood.json');
 
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', 'path/to/file');
-        tr.setInput('vsTestVersion', '14.0');
-        tr.setInput('runSettingsFile', "settings.runsettings");
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', 'path/to/file');
+            tr.setInput('vsTestVersion', '14.0');
+            tr.setInput('runSettingsFile', "settings.runsettings");
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /Settings:settings.runsettings /logger:trx'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                    assert(tr.succeeded, 'task should have succeeded');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /Settings:settings.runsettings /logger:trx'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task with run in parallel and vs 2013', (done) => {
-        setResponseFile('vstestGood.json');
+        it('Vstest task with run in parallel and vs 2013', (done) => {
+            setResponseFile('vstestGood.json');
 
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', 'path/to/file');
-        tr.setInput('vsTestVersion', '12.0');
-        tr.setInput('runInParallel', 'true');
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', 'path/to/file');
+            tr.setInput('vsTestVersion', '12.0');
+            tr.setInput('runInParallel', 'true');
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) >= 0, 'should have given a warning for update1 or higher requirement');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                    assert(tr.succeeded, 'task should have succeeded');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                    assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) >= 0, 'should have given a warning for update1 or higher requirement');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task with run in parallel and vs 2014 below update1', (done) => {
-        setResponseFile('vstestGood.json');
+        it('Vstest task with run in parallel and vs 2014 below update1', (done) => {
+            setResponseFile('vstestGood.json');
 
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', 'path/to/file');
-        tr.setInput('vsTestVersion', '14.0'); // response file sets below update1
-        tr.setInput('runInParallel', 'true');
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', 'path/to/file');
+            tr.setInput('vsTestVersion', '14.0'); // response file sets below update1
+            tr.setInput('runInParallel', 'true');
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) >= 0, 'should have given a warning for update1 or higher requirement');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                    assert(tr.succeeded, 'task should have succeeded');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                    assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) >= 0, 'should have given a warning for update1 or higher requirement');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task with run in parallel and vs 2015', (done) => {
-        setResponseFile('vstestGood.json');
+        it('Vstest task with run in parallel and vs 2015', (done) => {
+            setResponseFile('vstestGood.json');
 
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', 'path/to/file');
-        tr.setInput('vsTestVersion', '15.0');
-        tr.setInput('runInParallel', 'true');
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', 'path/to/file');
+            tr.setInput('vsTestVersion', '15.0');
+            tr.setInput('runInParallel', 'true');
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) < 0, 'should not have given a warning for update1 or higher requirement');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                    assert(tr.succeeded, 'task should have succeeded');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                    assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) < 0, 'should not have given a warning for update1 or higher requirement');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task with run in parallel and vs 2014 update1 or higher', (done) => {
-        setResponseFile('vstestRunInParallel.json');
+        it('Vstest task with run in parallel and vs 2014 update1 or higher', (done) => {
+            setResponseFile('vstestRunInParallel.json');
 
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', 'path/to/file');
-        tr.setInput('vsTestVersion', '14.0'); // response file sets above update1
-        tr.setInput('runInParallel', 'true');
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', 'path/to/file');
+            tr.setInput('vsTestVersion', '14.0'); // response file sets above update1
+            tr.setInput('runInParallel', 'true');
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) < 0, 'should not have given a warning for update1 or higher requirement.');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                    assert(tr.succeeded, 'task should have succeeded');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                    assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) < 0, 'should not have given a warning for update1 or higher requirement.');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
 
-    it('Vstest task with custom adapter path', (done) => {
-        setResponseFile('vstestGood.json');
+        it('Vstest task with custom adapter path', (done) => {
+            setResponseFile('vstestGood.json');
 
-        var tr = new trm.TaskRunner('VSTest');
-        tr.setInput('testAssembly', 'path/to/file');
-        tr.setInput('vsTestVersion', '14.0');
-        tr.setInput('pathtoCustomTestAdapters', "path/to/customadapters");
+            var tr = new trm.TaskRunner('VSTest');
+            tr.setInput('testAssembly', 'path/to/file');
+            tr.setInput('vsTestVersion', '14.0');
+            tr.setInput('pathtoCustomTestAdapters', "path/to/customadapters");
 
-        tr.run()
-            .then(() => {
-                assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx /TestAdapterPath:path/to/customadapters'), 'should have run vstest');
-                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                done();
-            })
-            .fail((err) => {
-                done(err);
-            });
-    })
+            tr.run()
+                .then(() => {
+                    assert(tr.resultWasSet, 'task should have set a result');
+                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                    assert(tr.succeeded, 'task should have succeeded');
+                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx /TestAdapterPath:path/to/customadapters'), 'should have run vstest');
+                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                    done();
+                })
+                .fail((err) => {
+                    done(err);
+                });
+        })
+    }
 });

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -117,322 +117,325 @@ describe('VsTest Suite', function() {
             psr.run(path.join(__dirname, 'DefaultTestResultsDirectoryIsUsedIfOverrideParamsAreUsed.ps1'), done);
         })
     }
-    if (os.type().match(/^Win/)) {
 
-        it('Vstest task without test results files input', (done) => {
-            setResponseFile('vstestGood.json');
-            var tr = new trm.TaskRunner('VSTest');
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length > 0, 'should have written to stderr');
-                    assert(tr.failed, 'task should have failed');
-                    assert(tr.stdErrContained('Input required: testAssembly'));
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task with test results files filter', (done) => {
-            setResponseFile('vstestGood.json');
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', '/some/*pattern');
-            tr.setInput('vsTestVersion', '14.0');
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                    assert(tr.succeeded, 'task should have succeeded');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one some/path/two /logger:trx'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task with test results files filter and exclude filter', (done) => {
-            setResponseFile('vstestGood.json');
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', '/some/*pattern;-:/exclude/*pattern');
-            tr.setInput('vsTestVersion', '14.0');
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                    assert(tr.succeeded, 'task should have succeeded');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one /logger:trx'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task with test results files as path', (done) => {
-            setResponseFile('vstestGood.json');
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', 'path/to/file');
-            tr.setInput('vsTestVersion', '14.0');
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                    assert(tr.succeeded, 'task should have succeeded');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task when vstest fails', (done) => {
-            setResponseFile('vstestFails.json');
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', '/some/*pattern');
-            tr.setInput('vsTestVersion', '14.0');
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length > 0, 'should have written to stderr');
-                    assert(tr.failed, 'task should have failed');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one some/path/two /logger:trx'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish/) < 0, 'should not have published test results.');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task when vstest of specified version is not found', (done) => {
-            setResponseFile('vstestFails.json'); // this response file does not have vs 2013
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', 'path/to/file');
-            tr.setInput('vsTestVersion', '12.0');
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length > 0, 'should have written to stderr');
-                    assert(tr.failed, 'task should have failed');
-                    assert(!tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should not have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish/) < 0, 'should not have published test results.');
-                    assert(tr.stdout.search(/Vstest of version 12 is not found. Try again with a visual studio version that exists on your build agent machine./) >= 0, 'should have displayed warning.');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task with test case filter', (done) => {
-            setResponseFile('vstestGood.json');
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', 'path/to/file');
-            tr.setInput('testFiltercriteria', 'testFilter');
-            tr.setInput('vsTestVersion', '14.0');
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                    assert(tr.succeeded, 'task should have succeeded');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /TestCaseFilter:testFilter /logger:trx'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task with enable code coverage', (done) => {
-            setResponseFile('vstestGood.json');
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', 'path/to/file');
-            tr.setInput('codeCoverageEnabled', 'true');
-            tr.setInput('vsTestVersion', '14.0');
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                    assert(tr.succeeded, 'task should have succeeded');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /EnableCodeCoverage /logger:trx'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task with other console options', (done) => {
-            setResponseFile('vstestGood.json');
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', 'path/to/file');
-            tr.setInput('otherConsoleOptions', 'consoleOptions');
-            tr.setInput('vsTestVersion', '14.0');
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                    assert(tr.succeeded, 'task should have succeeded');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file consoleOptions /logger:trx'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task with settings file', (done) => {
-            setResponseFile('vstestGood.json');
-
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', 'path/to/file');
-            tr.setInput('vsTestVersion', '14.0');
-            tr.setInput('runSettingsFile', "settings.runsettings");
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                    assert(tr.succeeded, 'task should have succeeded');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /Settings:settings.runsettings /logger:trx'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task with run in parallel and vs 2013', (done) => {
-            setResponseFile('vstestGood.json');
-
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', 'path/to/file');
-            tr.setInput('vsTestVersion', '12.0');
-            tr.setInput('runInParallel', 'true');
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                    assert(tr.succeeded, 'task should have succeeded');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                    assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) >= 0, 'should have given a warning for update1 or higher requirement');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task with run in parallel and vs 2014 below update1', (done) => {
-            setResponseFile('vstestGood.json');
-
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', 'path/to/file');
-            tr.setInput('vsTestVersion', '14.0'); // response file sets below update1
-            tr.setInput('runInParallel', 'true');
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                    assert(tr.succeeded, 'task should have succeeded');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                    assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) >= 0, 'should have given a warning for update1 or higher requirement');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task with run in parallel and vs 2015', (done) => {
-            setResponseFile('vstestGood.json');
-
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', 'path/to/file');
-            tr.setInput('vsTestVersion', '15.0');
-            tr.setInput('runInParallel', 'true');
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                    assert(tr.succeeded, 'task should have succeeded');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                    assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) < 0, 'should not have given a warning for update1 or higher requirement');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task with run in parallel and vs 2014 update1 or higher', (done) => {
-            setResponseFile('vstestRunInParallel.json');
-
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', 'path/to/file');
-            tr.setInput('vsTestVersion', '14.0'); // response file sets above update1
-            tr.setInput('runInParallel', 'true');
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                    assert(tr.succeeded, 'task should have succeeded');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                    assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) < 0, 'should not have given a warning for update1 or higher requirement.');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
-
-        it('Vstest task with custom adapter path', (done) => {
-            setResponseFile('vstestGood.json');
-
-            var tr = new trm.TaskRunner('VSTest');
-            tr.setInput('testAssembly', 'path/to/file');
-            tr.setInput('vsTestVersion', '14.0');
-            tr.setInput('pathtoCustomTestAdapters', "path/to/customadapters");
-
-            tr.run()
-                .then(() => {
-                    assert(tr.resultWasSet, 'task should have set a result');
-                    assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
-                    assert(tr.succeeded, 'task should have succeeded');
-                    assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx /TestAdapterPath:path/to/customadapters'), 'should have run vstest');
-                    assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
-                    done();
-                })
-                .fail((err) => {
-                    done(err);
-                });
-        })
+    if (!os.type().match(/^Win/)) {
+        console.log("Skipping vstest tests. Vstest tests run only on windows.")
+        return;
     }
+
+    it('Vstest task without test results files input', (done) => {
+        setResponseFile('vstestGood.json');
+        var tr = new trm.TaskRunner('VSTest');
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length > 0, 'should have written to stderr');
+                assert(tr.failed, 'task should have failed');
+                assert(tr.stdErrContained('Input required: testAssembly'));
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task with test results files filter', (done) => {
+        setResponseFile('vstestGood.json');
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', '/some/*pattern');
+        tr.setInput('vsTestVersion', '14.0');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one some/path/two /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task with test results files filter and exclude filter', (done) => {
+        setResponseFile('vstestGood.json');
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', '/some/*pattern;-:/exclude/*pattern');
+        tr.setInput('vsTestVersion', '14.0');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task with test results files as path', (done) => {
+        setResponseFile('vstestGood.json');
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('vsTestVersion', '14.0');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task when vstest fails', (done) => {
+        setResponseFile('vstestFails.json');
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', '/some/*pattern');
+        tr.setInput('vsTestVersion', '14.0');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length > 0, 'should have written to stderr');
+                assert(tr.failed, 'task should have failed');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one some/path/two /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish/) < 0, 'should not have published test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task when vstest of specified version is not found', (done) => {
+        setResponseFile('vstestFails.json'); // this response file does not have vs 2013
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('vsTestVersion', '12.0');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length > 0, 'should have written to stderr');
+                assert(tr.failed, 'task should have failed');
+                assert(!tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should not have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish/) < 0, 'should not have published test results.');
+                assert(tr.stdout.search(/Vstest of version 12 is not found. Try again with a visual studio version that exists on your build agent machine./) >= 0, 'should have displayed warning.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task with test case filter', (done) => {
+        setResponseFile('vstestGood.json');
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('testFiltercriteria', 'testFilter');
+        tr.setInput('vsTestVersion', '14.0');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /TestCaseFilter:testFilter /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task with enable code coverage', (done) => {
+        setResponseFile('vstestGood.json');
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('codeCoverageEnabled', 'true');
+        tr.setInput('vsTestVersion', '14.0');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /EnableCodeCoverage /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task with other console options', (done) => {
+        setResponseFile('vstestGood.json');
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('otherConsoleOptions', 'consoleOptions');
+        tr.setInput('vsTestVersion', '14.0');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file consoleOptions /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task with settings file', (done) => {
+        setResponseFile('vstestGood.json');
+
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('vsTestVersion', '14.0');
+        tr.setInput('runSettingsFile', "settings.runsettings");
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /Settings:settings.runsettings /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task with run in parallel and vs 2013', (done) => {
+        setResponseFile('vstestGood.json');
+
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('vsTestVersion', '12.0');
+        tr.setInput('runInParallel', 'true');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) >= 0, 'should have given a warning for update1 or higher requirement');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task with run in parallel and vs 2014 below update1', (done) => {
+        setResponseFile('vstestGood.json');
+
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('vsTestVersion', '14.0'); // response file sets below update1
+        tr.setInput('runInParallel', 'true');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) >= 0, 'should have given a warning for update1 or higher requirement');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task with run in parallel and vs 2015', (done) => {
+        setResponseFile('vstestGood.json');
+
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('vsTestVersion', '15.0');
+        tr.setInput('runInParallel', 'true');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) < 0, 'should not have given a warning for update1 or higher requirement');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task with run in parallel and vs 2014 update1 or higher', (done) => {
+        setResponseFile('vstestRunInParallel.json');
+
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('vsTestVersion', '14.0'); // response file sets above update1
+        tr.setInput('runInParallel', 'true');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                assert(tr.stdout.search(/Install Visual Studio 2015 Update 1 or higher on your build agent machine to run the tests in parallel./) < 0, 'should not have given a warning for update1 or higher requirement.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task with custom adapter path', (done) => {
+        setResponseFile('vstestGood.json');
+
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('vsTestVersion', '14.0');
+        tr.setInput('pathtoCustomTestAdapters', "path/to/customadapters");
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe path/to/file /logger:trx /TestAdapterPath:path/to/customadapters'), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish type=VSTest;mergeResults=false;resultFiles=a.trx;\]/) >= 0, 'should publish test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
 });


### PR DESCRIPTION
On Osx npm install regedit fails. Hence moving regedit to optional dependencies and vstest tests to execute only on windows