### PR TITLE
Pass the options when executing gradlew properties

### DIFF
--- a/Tasks/Gradle/gradletask.ts
+++ b/Tasks/Gradle/gradletask.ts
@@ -179,6 +179,7 @@ function enableCodeCoverage() {
 function isMultiModuleProject(wrapperScript: string): boolean {
     var gradleBuild = tl.createToolRunner(wrapperScript);
     gradleBuild.arg("properties");
+    gradleBuild.argString(tl.getInput('options', false));
 
     var data = gradleBuild.execSync().stdout;
     if (typeof data != "undefined" && data) {


### PR DESCRIPTION
The Gradle task doesn't pass the defined options when executing the `gradlew properties`.  This fails when build variables are passed to the Gradle task as options.  For example, defining `-PrepoUrl=... -PrepoUsername=... -PrepoPassword=...` as option will fail the initial `gradlew properties` call:

    buildscript {
      repositories {
        maven {
          url = repoUrl
          credentials {
            username repoUsername
            password repoPassword
    }}}}

The patch fixes the issue