### PR TITLE
Users/achalla/publish results fix

### DIFF
--- a/Tasks/ANT/anttask.ts
+++ b/Tasks/ANT/anttask.ts
@@ -115,7 +115,7 @@ function publishTestResults(publishJUnitResults, testResultsFiles: string) {
             var matchingTestResultsFiles = [testResultsFiles];
         }
 
-        if (!matchingTestResultsFiles) {
+        if (!matchingTestResultsFiles || matchingTestResultsFiles.length == 0) {
             tl.warning('No test result files matching ' + testResultsFiles + ' were found, so publishing JUnit test results is being skipped.');
             return 0;
         }

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 45
+        "Patch": 46
     },
     "demands": [
         "ant"

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 45
+    "Patch": 46
   },
   "demands": [
     "ant"

--- a/Tasks/Gradle/gradletask.ts
+++ b/Tasks/Gradle/gradletask.ts
@@ -89,7 +89,7 @@ if (isSonarQubeEnabled) {
 }
 
 gb.exec()
-    .then(function (code) {
+    .then(function(code) {
         publishTestResults(publishJUnitResults, testResultsFiles);
         publishCodeCoverage(isCodeCoverageOpted);
 
@@ -98,7 +98,7 @@ gb.exec()
         }
         tl.exit(code);
     })
-    .fail(function (err) {
+    .fail(function(err) {
         publishTestResults(publishJUnitResults, testResultsFiles);
         console.error(err.message);
         tl.debug('taskRunner fail');
@@ -120,7 +120,7 @@ function publishTestResults(publishJUnitResults, testResultsFiles: string) {
             var matchingTestResultsFiles = [testResultsFiles];
         }
 
-        if (!matchingTestResultsFiles) {
+        if (!matchingTestResultsFiles || matchingTestResultsFiles.length == 0) {
             tl.warning('No test result files matching ' + testResultsFiles + ' were found, so publishing JUnit test results is being skipped.');
             return 0;
         }

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 43
+        "Patch": 44
     },
     "demands": [
         "java"

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 43
+    "Patch": 44
   },
   "demands": [
     "java"

--- a/Tests/L0/ANT/_suite.ts
+++ b/Tests/L0/ANT/_suite.ts
@@ -416,8 +416,8 @@ describe('ANT Suite', function() {
             .then(() => {
                 assert(tr.stdout.search(/##vso\[results.publish\]/) < 0, 'publish test results should not have got called.');
                 assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr');
-                assert(tr.stdout.indexOf('task.issue type=warning;No test result files matching **/InvalidTestFilter-*.xml were found, so publishing JUnit test results is being skipped.') >= 0, 'should have produced warning.');
+                assert(tr.stderr.length == 0, 'should not have written to stderr');                
+                assert(tr.stdout.search(/##vso\[task.issue type=warning;\]No test result files matching/) >= 0, 'should have produced warning.');
                 assert(tr.succeeded, 'task should have succeeded');
                 done();
             })

--- a/Tests/L0/Gradle/_suite.ts
+++ b/Tests/L0/Gradle/_suite.ts
@@ -715,7 +715,7 @@ describe('gradle Suite', function () {
         tr.setInput('javaHomeSelection', 'JDKVersion');
         tr.setInput('jdkVersion', 'default');
         tr.setInput('publishJUnitResults', 'true');
-        tr.setInput('testResultsFiles', '**/InvalidTestFilter-*.xml');
+        tr.setInput('testResultsFiles', '*InvalidTestFilter*.xml');
         tr.setInput('codeCoverageTool', 'None');
 
         tr.run()
@@ -723,7 +723,8 @@ describe('gradle Suite', function () {
                 assert(tr.stdout.search(/##vso\[results.publish\]/) < 0, "publish test results should not have got called.")
                 assert(tr.resultWasSet, 'task should have set a result');
                 assert(tr.stderr.length == 0, 'should not have written to stderr');
-                assert(tr.stdout.indexOf('task.issue type=warning;No test result files matching **/InvalidTestFilter-*.xml were found, so publishing JUnit test results is being skipped.') >= 0, 'should have produced warning.');
+                console.log(tr.stdout);
+                assert(tr.stdout.search(/##vso\[task.issue type=warning;\]No test result files matching/) >= 0, 'should have produced warning.');
                 assert(tr.succeeded, 'task should have succeeded');
                 done();
             })

--- a/Tests/L0/Gradle/gradleGood.json
+++ b/Tests/L0/Gradle/gradleGood.json
@@ -61,6 +61,9 @@
     "match": {
         "**/TEST-*.xml": [
             "/user/build/fun/test-123.xml"
+        ],
+        "**/build/test-results/TEST-*.xml": [
+            "/user/build/fun/test-results/test-123.xml"
         ]
     }
 }

--- a/Tests/L0/Gradle/gradleSonarQube.json
+++ b/Tests/L0/Gradle/gradleSonarQube.json
@@ -53,7 +53,7 @@
         ]
     },
     "match": {
-        "**/TEST-*.xml": [
+        "**/build/test-results/TEST-*.xml": [
             "/user/build/fun/test-123.xml"
         ]
     }


### PR DESCRIPTION
Issue : when the matching test result files are not found ant and gradle are failing instead of warning.
            This is already fixed in maven.
Testing : manual and uts