### PR TITLE
handling an empty resultsfolder in runsettings

### DIFF
--- a/Tasks/VsTest/Helpers.ps1
+++ b/Tasks/VsTest/Helpers.ps1
@@ -27,7 +27,7 @@ function IsVisualStudio2015Update1OrHigherInstalled {
 	)
 	
 	if ([string]::IsNullOrWhiteSpace($vsTestVersion)){
-		$vsTestVersion = Locate-VSVersion
+		$vsTestVersion = Get-VSVersion
 	}
 	
 	$version = [int]($vsTestVersion)
@@ -115,7 +115,7 @@ function Get-SubKeysInFloatFormat($keys)
 	return $targetKeys
 }
 
-function Locate-VSVersion()
+function Get-VSVersion()
 {
 	#Find the latest version
 	$regPath = "HKLM:\SOFTWARE\Microsoft\VisualStudio"
@@ -134,7 +134,7 @@ function Locate-VSVersion()
 	return $version
 }
 
-function GetResultsLocation {
+function Get-ResultsLocation {
 	[cmdletbinding()]
 	[OutputType([System.String])]
 	param(		
@@ -157,8 +157,11 @@ function GetResultsLocation {
             }
             else
             {
-                # Resutls directory is relative to the location of runsettings
-                return [io.path]::GetFullPath([io.path]::Combine([io.path]::GetDirectoryName($runSettingsFilePath), $customLocation))
+				if(![string]::IsNullOrWhiteSpace($customLocation))
+				{
+					# Resutls directory is relative to the location of runsettings
+					return [io.path]::GetFullPath([io.path]::Combine([io.path]::GetDirectoryName($runSettingsFilePath), $customLocation))
+				}
             }
         }        
     }

--- a/Tasks/VsTest/VSTest.ps1
+++ b/Tasks/VsTest/VSTest.ps1
@@ -111,7 +111,7 @@ try
         #If there is settings file and no override parameters, try to get the custom resutls location
         if(![System.String]::IsNullOrWhiteSpace($runSettingsFileWithParallel) -and !$overrideTestrunParameters)
         {
-            $testResultsDirectory = GetResultsLocation $runSettingsFileWithParallel 
+            $testResultsDirectory = Get-ResultsLocation $runSettingsFileWithParallel 
         }
         if(!$testResultsDirectory)
         {

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 44
+        "Patch": 45
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 44
+    "Patch": 45
   },
   "demands": [
     "vstest"

--- a/Tests/L0/VsTest/GetResultsLocationReturnsNullForDirectory.ps1
+++ b/Tests/L0/VsTest/GetResultsLocationReturnsNullForDirectory.ps1
@@ -7,6 +7,6 @@ param()
 $tempDirName = [System.Guid]::NewGuid().ToString() + '.runsettings'
 $tempDir = New-Item -Type Directory -Name $tempDirName
 
-$resultsLocation = GetResultsLocation $tempDirName
+$resultsLocation = Get-ResultsLocation $tempDirName
 
 Assert-AreEqual $null $resultsLocation 

--- a/Tests/L0/VsTest/GetResultsLocationReturnsNullForEmptyPath.ps1
+++ b/Tests/L0/VsTest/GetResultsLocationReturnsNullForEmptyPath.ps1
@@ -4,8 +4,9 @@ param()
 . $PSScriptRoot\..\..\lib\Initialize-Test.ps1
 . $PSScriptRoot\..\..\..\Tasks\VsTest\Helpers.ps1
 
-$temprunsettingsfile = [io.path]::ChangeExtension([io.path]::GetTempFileName(),"runsettings")
+$temprunsettingsfile = [io.path]::GetTempFileName()
 $runsettings = @('<RunSettings><RunConfiguration>
+<ResultsDirectory></ResultsDirectory> 
 </RunConfiguration></RunSettings>
 ')
 Set-Content -Value $runsettings -Path $temprunsettingsfile

--- a/Tests/L0/VsTest/GetResultsLocationReturnsPathForTmpFile.ps1
+++ b/Tests/L0/VsTest/GetResultsLocationReturnsPathForTmpFile.ps1
@@ -11,7 +11,7 @@ $runsettings = @('<RunSettings><RunConfiguration>
 ')
 Set-Content -Value $runsettings -Path $temprunsettingsfile
 
-$resultsLocation = GetResultsLocation $temprunsettingsfile
+$resultsLocation = Get-ResultsLocation $temprunsettingsfile
 
 Assert-AreEqual 'C:\myResultsFolder' $resultsLocation 
 

--- a/Tests/L0/VsTest/GetResultsLocationReturnsPathFromRunsettings.ps1
+++ b/Tests/L0/VsTest/GetResultsLocationReturnsPathFromRunsettings.ps1
@@ -11,7 +11,7 @@ $runsettings = @('<RunSettings><RunConfiguration>
 ')
 Set-Content -Value $runsettings -Path $temprunsettingsfile
 
-$resultsLocation = GetResultsLocation $temprunsettingsfile
+$resultsLocation = Get-ResultsLocation $temprunsettingsfile
 
 Assert-AreEqual 'C:\myResultsFolder' $resultsLocation 
 

--- a/Tests/L0/VsTest/GetResultsLocationReturnsPathFromRunsettingsForRelativePaths.ps1
+++ b/Tests/L0/VsTest/GetResultsLocationReturnsPathFromRunsettingsForRelativePaths.ps1
@@ -11,7 +11,7 @@ $runsettings = @('<RunSettings><RunConfiguration>
 ')
 Set-Content -Value $runsettings -Path $tempsettingsfile
 
-$resultsLocation = GetResultsLocation $tempsettingsfile
+$resultsLocation = Get-ResultsLocation $tempsettingsfile
 
 $expectedLocation = [io.path]::Combine([io.path]::GetDirectoryName($tempsettingsfile), "myResultsFolder")
 Assert-AreEqual $expectedLocation $resultsLocation 

--- a/Tests/L0/VsTest/GetResultsReturnsNullForTestsettings.ps1
+++ b/Tests/L0/VsTest/GetResultsReturnsNullForTestsettings.ps1
@@ -4,6 +4,6 @@ param()
 . $PSScriptRoot\..\..\lib\Initialize-Test.ps1
 . $PSScriptRoot\..\..\..\Tasks\VsTest\Helpers.ps1
 
-$resultsLocation = GetResultsLocation "C:\asdf.testsettings"
+$resultsLocation = Get-ResultsLocation "C:\asdf.testsettings"
 
 Assert-AreEqual $null $resultsLocation


### PR DESCRIPTION
due to this issue an empty value in this setting lead to the folder containing the runsettings to be deleted