### PR TITLE
Fixing java tasks 

### DIFF
--- a/Tasks/ANT/ant.ps1
+++ b/Tasks/ANT/ant.ps1
@@ -108,8 +108,14 @@ if ($jdkPath)
 }
 
 $buildRootPath = Split-Path $antBuildFile -Parent
-$reportDirectoryName = [guid]::NewGuid()
+$reportDirectoryName = "ReportDirectory"
 $reportDirectory = Join-Path $buildRootPath $reportDirectoryName
+
+if(Test-Path $reportDirectory)
+{
+   # delete any previous code coverage data 
+   rm -r $reportDirectory -force | Out-Null
+}
 
 if($isCoverageEnabled)
 {
@@ -128,9 +134,21 @@ $summaryFile = Join-Path $summaryFile $summaryFileName
 # ensuring unique code coverage report task name by using guid
 $CCReportTask = "CodeCoverage_" +[guid]::NewGuid()
 
-$reportBuildFileName = [guid]::NewGuid().tostring() + ".xml"
+$reportBuildFileName = "ReportBuildFile.xml"
 $reportBuildFile = Join-Path $buildRootPath $reportBuildFileName
 $instrumentedClassesDirectory = Join-Path $buildRootPath "InstrumentedClasses"
+
+if(Test-Path $reportBuildFile)
+{
+   # delete any previous code coverage report build file
+   rm -r $reportBuildFile -force | Out-Null
+}
+
+if(Test-Path $instrumentedClassesDirectory)
+{
+   # delete any previous instrumented classes directory
+   rm -r $instrumentedClassesDirectory -force | Out-Null
+}
 
 if($isCoverageEnabled)
 {
@@ -242,23 +260,6 @@ if($isCoverageEnabled)
    	}
 }
 
-if(Test-Path $reportDirectory)
-{
-   # delete any previous code coverage data 
-   rm -r $reportDirectory -force | Out-Null
-}
-
-if(Test-Path $reportBuildFile)
-{
-   # delete any previous code coverage report build file
-   rm -r $reportBuildFile -force | Out-Null
-}
-
-if(Test-Path $instrumentedClassesDirectory)
-{
-   # delete any previous instrumented classes directory
-   rm -r $instrumentedClassesDirectory -force | Out-Null
-}
 Write-Verbose "Leaving script Ant.ps1"
 
 

--- a/Tasks/ANT/ant.ps1
+++ b/Tasks/ANT/ant.ps1
@@ -108,7 +108,7 @@ if ($jdkPath)
 }
 
 $buildRootPath = Split-Path $antBuildFile -Parent
-$reportDirectoryName = "ReportDirectory"
+$reportDirectoryName = "ReportDirectory_75C12DBC-FB59-450A-8E4F-772EA8BFCFA6"
 $reportDirectory = Join-Path $buildRootPath $reportDirectoryName
 
 if(Test-Path $reportDirectory)
@@ -134,7 +134,7 @@ $summaryFile = Join-Path $summaryFile $summaryFileName
 # ensuring unique code coverage report task name by using guid
 $CCReportTask = "CodeCoverage_" +[guid]::NewGuid()
 
-$reportBuildFileName = "ReportBuildFile.xml"
+$reportBuildFileName = "ReportBuildFile_9B5907FC-EC56-4662-B8EA-EC23FCB97C43.xml"
 $reportBuildFile = Join-Path $buildRootPath $reportBuildFileName
 $instrumentedClassesDirectory = Join-Path $buildRootPath "InstrumentedClasses"
 

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 46
+        "Patch": 47
     },
     "demands": [
         "ant"

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 46
+    "Patch": 47
   },
   "demands": [
     "ant"

--- a/Tasks/Gradle/Gradle.ps1
+++ b/Tasks/Gradle/Gradle.ps1
@@ -105,7 +105,7 @@ if ($jdkPath)
 
 $buildRootPath = $cwd
 $wrapperDirectory = Split-Path $wrapperScript -Parent
-$reportDirectoryName = "ReportDirectory"
+$reportDirectoryName = "ReportDirectory_84B7D86C-F08D-4B65-8D37-742D8B02D27B"
 $reportDirectory = Join-Path $buildRootPath $reportDirectoryName
 
 if(Test-Path $reportDirectory)

--- a/Tasks/Gradle/Gradle.ps1
+++ b/Tasks/Gradle/Gradle.ps1
@@ -105,8 +105,14 @@ if ($jdkPath)
 
 $buildRootPath = $cwd
 $wrapperDirectory = Split-Path $wrapperScript -Parent
-$reportDirectoryName = [guid]::NewGuid()
+$reportDirectoryName = "ReportDirectory"
 $reportDirectory = Join-Path $buildRootPath $reportDirectoryName
+
+if(Test-Path $reportDirectory)
+{
+   # delete any code coverage data 
+   rm -r $reportDirectory -force | Out-Null
+}
 
 # check if project is multi module gradle build or not
 $subprojects = Invoke-BatchScript -Path $wrapperScript -Arguments 'properties' -WorkingFolder $buildRootPath | Select-String '^subprojects: (.*)'|ForEach-Object {$_.Matches[0].Groups[1].Value}
@@ -212,12 +218,5 @@ if($isCoverageEnabled)
 		Write-Warning "No code coverage results found to be published. This could occur if there were no tests executed or there was a build failure. Check the gradle output for details." -Verbose
 	}   
 }
-
-if(Test-Path $reportDirectory)
-{
-   # delete any code coverage data 
-   rm -r $reportDirectory -force | Out-Null
-}
-
 
 Write-Verbose "Leaving script Gradle.ps1"

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 44
+        "Patch": 45
     },
     "demands": [
         "java"

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 44
+    "Patch": 45
   },
   "demands": [
     "java"

--- a/Tasks/Maven/maven.ps1
+++ b/Tasks/Maven/maven.ps1
@@ -109,9 +109,8 @@ import-module "Microsoft.TeamFoundation.DistributedTask.Task.TestResults"
 
 
 $buildRootPath = Split-Path $mavenPOMFile -Parent
-$reportDirectoryName = [guid]::NewGuid()
+$reportDirectoryName = "ReportDirectory"
 $reportDirectoryNameCobertura = "target\site\cobertura"
-$reportPOMFileName = [guid]::NewGuid().tostring() + ".xml"
 $reportPOMFile = Join-Path $buildRootPath $reportPOMFileName
 $reportDirectory = Join-Path $buildRootPath $reportDirectoryName
 $reportDirectoryCobertura = Join-Path $buildRootPath $reportDirectoryNameCobertura
@@ -125,6 +124,24 @@ $summaryFileCobertura = Join-Path $summaryFileCobertura $summaryFileNameCobertur
 $CCReportTask = "jacoco:report"
 
 Write-Verbose "SummaryFileCobertura = $summaryFileCobertura"
+
+if(Test-Path $reportDirectory)
+{
+    # delete any previous code coverage data 
+    rm -r $reportDirectory -force | Out-Null
+}
+
+if(Test-Path $reportDirectoryCobertura)
+{
+    # delete any previous code coverage data from Cobertura
+    rm -r $reportDirectoryCobertura -force | Out-Null
+}
+
+if(Test-Path $reportPOMFile)
+{
+    # delete any previous code coverage data 
+    rm $reportPOMFile -force | Out-Null
+}
 
 if($isCoverageEnabled)
 {
@@ -183,24 +200,6 @@ ElseIf ($codeCoverageTool -eq "Cobertura")
 
 # Run SonarQube analysis by invoking Maven with the "sonar:sonar" goal
 RunSonarQubeAnalysis $sqAnalysisEnabled $sqConnectedServiceName $sqDbDetailsRequired $sqDbUrl $sqDbUsername $sqDbPassword $options $mavenPOMFile $execFileJacoco
-
-if(Test-Path $reportDirectory)
-{
-    # delete any previous code coverage data 
-    rm -r $reportDirectory -force | Out-Null
-}
-
-if(Test-Path $reportDirectoryCobertura)
-{
-    # delete any previous code coverage data from Cobertura
-    rm -r $reportDirectoryCobertura -force | Out-Null
-}
-
-if(Test-Path $reportPOMFile)
-{
-    # delete any previous code coverage data 
-    rm $reportPOMFile -force | Out-Null
-}
 
 Write-Verbose "Leaving script Maven.ps1"
 

--- a/Tasks/Maven/maven.ps1
+++ b/Tasks/Maven/maven.ps1
@@ -109,9 +109,9 @@ import-module "Microsoft.TeamFoundation.DistributedTask.Task.TestResults"
 
 
 $buildRootPath = Split-Path $mavenPOMFile -Parent
-$reportDirectoryName = "ReportDirectory"
+$reportDirectoryName = "ReportDirectory_C91CDE2D-CC66-4541-9C27-E3EF6CB3DB16"
 $reportDirectoryNameCobertura = "target\site\cobertura"
-$reportPOMFileName = "ReportPOMFile.xml"
+$reportPOMFileName = "ReportPOMFile_4E52C1C4-8C32-4580-A54D-41D5E9ED1F74.xml"
 $reportPOMFile = Join-Path $buildRootPath $reportPOMFileName
 $reportDirectory = Join-Path $buildRootPath $reportDirectoryName
 $reportDirectoryCobertura = Join-Path $buildRootPath $reportDirectoryNameCobertura

--- a/Tasks/Maven/maven.ps1
+++ b/Tasks/Maven/maven.ps1
@@ -111,6 +111,7 @@ import-module "Microsoft.TeamFoundation.DistributedTask.Task.TestResults"
 $buildRootPath = Split-Path $mavenPOMFile -Parent
 $reportDirectoryName = "ReportDirectory"
 $reportDirectoryNameCobertura = "target\site\cobertura"
+$reportPOMFileName = "ReportPOMFile.xml"
 $reportPOMFile = Join-Path $buildRootPath $reportPOMFileName
 $reportDirectory = Join-Path $buildRootPath $reportDirectoryName
 $reportDirectoryCobertura = Join-Path $buildRootPath $reportDirectoryNameCobertura

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 53
+        "Patch": 54
     },
     "minimumAgentVersion": "1.89.0",
     "instanceNameFormat": "Maven $(mavenPOMFile)",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 53
+    "Patch": 54
   },
   "minimumAgentVersion": "1.89.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
Problem: The java tasks (ant/maven/gradle) are broken for windows coreclr agent with ps1 implementation. 
Fix: The core clr agent asynchronously published build artifacts and we were deleting the directories at the end of the task in ps1 implementation. Moved the deletions to the beginning of the task.
Testing: Manually on AppFabric