### PR TITLE
DTA Flow might fail if Test Agent is configured as Process

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -772,6 +772,11 @@ function InvokeDTAExecHostExe([string] $Version, [System.Management.Automation.P
     Try
     {
         $session = CreateNewSession -MachineCredential $MachineCredential
+        # Make sure DTA Agent Execution Service starts first before invoking DTA Execution Host
+        Invoke-Command -Session $session -ErrorAction SilentlyContinue -ErrorVariable err -OutVariable out { Start-Service -Name "DTAAgentExecutionService" }
+        Write-Verbose -Message ("Error : {0} " -f ($err | out-string)) -Verbose
+        Write-Verbose -Message ("Output : {0} " -f ($out | out-string)) -Verbose
+
         Invoke-Command -Session $session -ErrorAction SilentlyContinue -ErrorVariable err -OutVariable out -scriptBlock { schtasks.exe /create /TN:DTAConfig /TR:$args /F /RL:HIGHEST /SC:MONTHLY ; schtasks.exe /run /TN:DTAConfig ; Sleep 10 ; schtasks.exe /change /disable /TN:DTAConfig } -ArgumentList $exePath
         Write-Verbose -Message ("Error : {0} " -f ($err | out-string)) -Verbose
         Write-Verbose -Message ("Output : {0} " -f ($out | out-string)) -Verbose

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 32
+        "Patch": 33
     },
     "demands": [
 

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 32
+    "Patch": 33
   },
   "demands": [],
   "minimumAgentVersion": "1.101.0",


### PR DESCRIPTION
Fixed issue when Test Agent is running as Process, it may not acquire the PAT Token from DTA Service

* Found by: TIP Tests
* Verified Fix by manual testing
* master fix: https://github.com/Microsoft/vsts-tasks/pull/2007