### PR TITLE
move away from taef based parellization

### DIFF
--- a/Tasks/VsTest/Helpers.ps1
+++ b/Tasks/VsTest/Helpers.ps1
@@ -70,11 +70,17 @@ function IsVisualStudio2015Update1OrHigherInstalled {
 	}
 	
 	$version = [int]($vsTestVersion)
-	if($version -ge 14)
+	# with dev15 we are back to vstest and away from taef
+	if($version -ge 15)
+	{
+		return $true
+	}
+
+	if($version -eq 14)
 	{
 		# checking for dll introduced in vs2015 update1
 		# since path of the dll will change in dev15+ using vstestversion>14 as a blanket yes
-		if((Test-Path -Path "$env:VS140COMNTools\..\IDE\CommonExtensions\Microsoft\TestWindow\TE.TestModes.dll") -Or ($version -gt 14))
+		if(Test-Path -Path "$env:VS140COMNTools\..\IDE\CommonExtensions\Microsoft\TestWindow\TE.TestModes.dll")
 		{
 			# ensure the registry is set otherwise you need to launch VSIDE
 			SetRegistryKeyForParallel $vsTestVersion

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 50
+        "Patch": 51
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 50
+    "Patch": 51
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -899,8 +899,13 @@ function saveToFile(fileContents: string, extension: string): Q.Promise<string> 
 function setRunInParallellIfApplicable(vsVersion: number) {
     if (runInParallel) {
         if (!isNaN(vsVersion) && vsVersion >= 14) {
+            if (vsVersion >= 15) { // moved away from taef
+                return;
+            }
+
+            // in 14.0 taef parellization needed taef enabled
             var vs14Common = tl.getVariable("VS140COMNTools");
-            if (vsVersion > 14 || (vs14Common && pathExistsAsFile(path.join(vs14Common, "..\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\TE.TestModes.dll")))) {
+            if (vs14Common && pathExistsAsFile(path.join(vs14Common, "..\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\TE.TestModes.dll"))) {
                 setRegistryKeyForParallelExecution(vsVersion);
                 return;
             }


### PR DESCRIPTION
since we move back to vstest in 15.0 we will no longer need the taef
flag