### PR TITLE
Fix regressions in NuGet tasks

### DIFF
--- a/Tasks/NuGetInstaller/nugetinstaller.ts
+++ b/Tasks/NuGetInstaller/nugetinstaller.ts
@@ -66,9 +66,8 @@ if (!tl.filePathSupplied('nuGetPath')) {
 var serviceUri = tl.getEndpointUrl("SYSTEMVSSCONNECTION", false);
 
 //find nuget location to use
-var nuGetExeVariants = ['nuget.exe', 'NuGet.exe', 'nuget', 'NuGet']
-var nuGetPathToUse = ngToolRunner.locateTool(nuGetExeVariants, {userPath: userNuGetPath, fallbackToSystemPath: os.platform() !== 'win32'});
-var credProviderPath = ngToolRunner.locateTool('CredentialProvider.TeamBuild.exe', {optional: true});
+var nuGetPathToUse = ngToolRunner.locateNuGetExe(userNuGetPath);
+var credProviderPath = ngToolRunner.locateCredentialProvider();
 
 var credProviderDir: string = null;
 if (credProviderPath) {

--- a/Tasks/NuGetInstaller/nugetinstaller.ts
+++ b/Tasks/NuGetInstaller/nugetinstaller.ts
@@ -14,6 +14,7 @@ import * as ngToolRunner from 'nuget-task-common/NuGetToolRunner';
 import * as nutil from 'nuget-task-common/Utility';
 import * as auth from 'nuget-task-common/Authentication'
 import {NuGetConfigHelper} from 'nuget-task-common/NuGetConfigHelper'
+import * as os from 'os';
 
 class RestoreOptions {
     constructor(
@@ -65,8 +66,9 @@ if (!tl.filePathSupplied('nuGetPath')) {
 var serviceUri = tl.getEndpointUrl("SYSTEMVSSCONNECTION", false);
 
 //find nuget location to use
-var nuGetPathToUse = ngToolRunner.locateTool('nuget.exe', userNuGetPath);
-var credProviderPath = ngToolRunner.locateTool('CredentialProvider.TeamBuild.exe', null, true);
+var nuGetExeVariants = ['nuget.exe', 'NuGet.exe', 'nuget', 'NuGet']
+var nuGetPathToUse = ngToolRunner.locateTool(nuGetExeVariants, {userPath: userNuGetPath, fallbackToSystemPath: os.platform() !== 'win32'});
+var credProviderPath = ngToolRunner.locateTool('CredentialProvider.TeamBuild.exe', {optional: true});
 
 var credProviderDir: string = null;
 if (credProviderPath) {

--- a/Tasks/NuGetInstaller/task.json
+++ b/Tasks/NuGetInstaller/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NuGetInstaller/task.loc.json
+++ b/Tasks/NuGetInstaller/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [

--- a/Tasks/NugetPublisher/nugetpublisher.ts
+++ b/Tasks/NugetPublisher/nugetpublisher.ts
@@ -63,9 +63,8 @@ if (!tl.filePathSupplied('nuGetPath')) {
 var serviceUri = tl.getEndpointUrl("SYSTEMVSSCONNECTION", false);
 
 //find nuget location to use
-var nuGetExeVariants = ['nuget.exe', 'NuGet.exe', 'nuget', 'NuGet']
-var nuGetPathToUse = ngToolRunner.locateTool(nuGetExeVariants, {userPath: userNuGetPath, fallbackToSystemPath: os.platform() !== 'win32'});
-var credProviderPath = ngToolRunner.locateTool('CredentialProvider.TeamBuild.exe', {optional: true});
+var nuGetPathToUse = ngToolRunner.locateNuGetExe(userNuGetPath);
+var credProviderPath = ngToolRunner.locateCredentialProvider();
 
 var credProviderDir: string = null;
 if (credProviderPath) {

--- a/Tasks/NugetPublisher/nugetpublisher.ts
+++ b/Tasks/NugetPublisher/nugetpublisher.ts
@@ -15,6 +15,7 @@ import * as nutil from 'nuget-task-common/Utility';
 import * as auth from 'nuget-task-common/Authentication';
 import {NuGetConfigHelper} from 'nuget-task-common/NuGetConfigHelper';
 import * as locationApi from 'nuget-task-common/LocationApi';
+import * as os from 'os';
 
 class PublishOptions {
     constructor(
@@ -62,8 +63,9 @@ if (!tl.filePathSupplied('nuGetPath')) {
 var serviceUri = tl.getEndpointUrl("SYSTEMVSSCONNECTION", false);
 
 //find nuget location to use
-var nuGetPathToUse = ngToolRunner.locateTool('nuget.exe', userNuGetPath);
-var credProviderPath = ngToolRunner.locateTool('CredentialProvider.TeamBuild.exe', null, true);
+var nuGetExeVariants = ['nuget.exe', 'NuGet.exe', 'nuget', 'NuGet']
+var nuGetPathToUse = ngToolRunner.locateTool(nuGetExeVariants, {userPath: userNuGetPath, fallbackToSystemPath: os.platform() !== 'win32'});
+var credProviderPath = ngToolRunner.locateTool('CredentialProvider.TeamBuild.exe', {optional: true});
 
 var credProviderDir: string = null;
 if (credProviderPath) {

--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "Cmd"

--- a/Tasks/NugetPublisher/task.loc.json
+++ b/Tasks/NugetPublisher/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "Cmd"

--- a/definitions/nuget-task-common.d.ts
+++ b/definitions/nuget-task-common.d.ts
@@ -101,7 +101,12 @@ declare module 'nuget-task-common/NuGetToolRunner' {
 	    exec(options?: IExecOptions): Q.Promise<number>;
 	}
 	export function createNuGetToolRunner(nuGetExePath: string, settings: NuGetEnvironmentSettings): NuGetToolRunner;
-	export function locateTool(tool: string, userPath?: string, optional?: boolean): string;
+	export interface LocateOptions {
+	    optional?: boolean;
+	    userPath?: string;
+	    fallbackToSystemPath?: boolean;
+	}
+	export function locateTool(tool: string | string[], opts?: LocateOptions): string;
 
 }
 declare module 'nuget-task-common/NuGetConfigHelper' {

--- a/definitions/nuget-task-common.d.ts
+++ b/definitions/nuget-task-common.d.ts
@@ -101,12 +101,8 @@ declare module 'nuget-task-common/NuGetToolRunner' {
 	    exec(options?: IExecOptions): Q.Promise<number>;
 	}
 	export function createNuGetToolRunner(nuGetExePath: string, settings: NuGetEnvironmentSettings): NuGetToolRunner;
-	export interface LocateOptions {
-	    optional?: boolean;
-	    userPath?: string;
-	    fallbackToSystemPath?: boolean;
-	}
-	export function locateTool(tool: string | string[], opts?: LocateOptions): string;
+	export function locateNuGetExe(userNuGetExePath: string): string;
+	export function locateCredentialProvider(): string;
 
 }
 declare module 'nuget-task-common/NuGetConfigHelper' {


### PR DESCRIPTION
- Wildcarded UNC paths were emitted with forward slashes, which caused NuGet.exe to interpret them as switches
- The tasks no longer searched for nuget in the system path on non-Windows platforms 
  
  Notes:
    - NuGet has always been distributed with the agent on Windows, so we don't search the system path there.
    - The credential provider is always distributed with the agent (in versions where it exists), so we don't search the system path for that on any platform