### PR TITLE
Allow NuGet tasks to work in Release Management...

### DIFF
--- a/Tasks/Common/nuget-task-common/NuGetConfigHelper.ts
+++ b/Tasks/Common/nuget-task-common/NuGetConfigHelper.ts
@@ -24,7 +24,7 @@ export class NuGetConfigHelper {
     private _authInfo: auth.NuGetAuthInfo;
     private _environmentSettings: ngToolRunner.NuGetEnvironmentSettings;
 
-    private tempNugetConfigDir = path.join(tl.getVariable('agent.buildDirectory'), 'Nuget');
+    private tempNugetConfigDir = path.join(tl.getVariable('system.defaultWorkingDirectory') || process.cwd(), 'Nuget');
     private tempNugetConfigFileName = 'tempNuGet_' + tl.getVariable('build.buildId') + '.config';
     public tempNugetConfigPath = path.join(this.tempNugetConfigDir, this.tempNugetConfigFileName);
 

--- a/Tasks/NuGetInstaller/task.json
+++ b/Tasks/NuGetInstaller/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 2
+        "Patch": 3
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NuGetInstaller/task.loc.json
+++ b/Tasks/NuGetInstaller/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 2
+    "Patch": 3
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [

--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "Cmd"

--- a/Tasks/NugetPublisher/task.loc.json
+++ b/Tasks/NugetPublisher/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "Cmd"


### PR DESCRIPTION
... by using System.DefaultWorkingDirectory instead of Agent.BuildDirectory