### PR TITLE
Fix issue #1986 - sometimes PRCA cannot find changes in a file

### DIFF
--- a/Tasks/SonarQubePostTest/PRCA/PostComments-Module.psm1
+++ b/Tasks/SonarQubePostTest/PRCA/PostComments-Module.psm1
@@ -418,7 +418,13 @@ function CreateDiscussionThreads
         
         if ($script:pullRequest.CodeReviewId -gt 0)
         {
-            $changeTrackingId = GetCodeFlowChangeTrackingId $changes $message.RelativePath
+            $changeTrackingId = 0;
+            if (!(TryGetCodeFlowChangeTrackingId($changes, $message.RelativePath, [Ref]$changeTrackingId)))
+            {
+                Write-Warning "Cannot post a comment for the file $($message.RelativePath) because no changes could be found";
+                continue;
+            } 
+
             AddCodeFlowProperties $message $iterationId $changeTrackingId $properties
         } 
         else

--- a/Tasks/SonarQubePostTest/PRCA/PostComments-Server.ps1
+++ b/Tasks/SonarQubePostTest/PRCA/PostComments-Server.ps1
@@ -142,7 +142,13 @@ function GetModifiedFilesInPR
 #
 function PostDiscussionThreads
 {
-    param ([ValidateNotNull()][Microsoft.VisualStudio.Services.CodeReview.Discussion.WebApi.DiscussionThreadCollection]$threads)
+    param ([Microsoft.VisualStudio.Services.CodeReview.Discussion.WebApi.DiscussionThreadCollection]$threads)
+
+    if (($threads -eq $null) -or ($threads.Count -eq 0))
+    {
+        Write-Debug "No threads to post"
+        return;
+    }
     
     $vssJsonThreadCollection = New-Object -TypeName "Microsoft.VisualStudio.Services.WebApi.VssJsonCollectionWrapper[Microsoft.VisualStudio.Services.CodeReview.Discussion.WebApi.DiscussionThreadCollection]" -ArgumentList @(,$threads)
     [void]$script:discussionClient.CreateThreadsAsync($vssJsonThreadCollection, $null, [System.Threading.CancellationToken]::None).Result
@@ -273,16 +279,19 @@ function GetCodeFlowChanges
      return $changes
 }
 
-function GetCodeFlowChangeTrackingId
+
+function TryGetCodeFlowChangeTrackingId
 {
-    param ([Microsoft.VisualStudio.Services.CodeReview.WebApi.IterationChanges]$changes, [string]$path)
-    
+    param ($changes, [string]$path, [Ref][int]$changeId)
     $change = $changes.ChangeEntries | Where-Object {$_.Modified.Path -eq $path}
+
+    if (($change -eq $null) -or ($change.Count -ne 1))
+    {
+        return $false;
+    }
     
-    Assert ($change -ne $null) "No changes found for $path"
-    Assert ($change.Count -eq 1) "Expecting exactly 1 change for $path but found $($change.Count)"
-    
-    return $change.ChangeTrackingId
+    $changeId.Value = $change.ChangeTrackingId;
+    return $true;
 } 
 
 #endregion 

--- a/Tasks/SonarQubePostTest/task.json
+++ b/Tasks/SonarQubePostTest/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 53
+    "Patch": 54
   },
   "minimumAgentVersion": "1.99.0",
   "demands": [

--- a/Tasks/SonarQubePostTest/task.loc.json
+++ b/Tasks/SonarQubePostTest/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 53
+    "Patch": 54
   },
   "minimumAgentVersion": "1.99.0",
   "demands": [


### PR DESCRIPTION
This does not happen very often so in the short term we'll ignore those comments. In the long term we are looking at using a higher level API to post comments that should circumvent this problem. 