### PR TITLE
Make parallel build checkbox label more clear

### DIFF
--- a/Tasks/VSBuild/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VSBuild/Strings/resources.resjson/en-US/resources.resjson
@@ -11,7 +11,7 @@
   "loc.input.label.platform": "Platform",
   "loc.input.label.configuration": "Configuration",
   "loc.input.label.clean": "Clean",
-  "loc.input.label.maximumCpuCount": "Maximum CPU Count",
+  "loc.input.label.maximumCpuCount": "Build in parallel",
   "loc.input.help.maximumCpuCount": "If your MSBuild target configuration is compatible with building in parallel, you can optionally check this input to pass the /m switch to MSBuild (Windows only). If you're target configuration is not compatible with building in parallel, checking this option may cause your build to result in file-in-use errors, or intermittent or inconsistent build failures.",
   "loc.input.label.restoreNugetPackages": "Restore NuGet Packages",
   "loc.input.help.restoreNugetPackages": "This option is deprecated. To restore NuGet packages, add a NuGet Installer step before the build.",

--- a/Tasks/VSBuild/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VSBuild/Strings/resources.resjson/en-US/resources.resjson
@@ -12,7 +12,7 @@
   "loc.input.label.configuration": "Configuration",
   "loc.input.label.clean": "Clean",
   "loc.input.label.maximumCpuCount": "Maximum CPU Count",
-  "loc.input.help.maximumCpuCount": "If you're MSBuild target configuration is compatible with building in parallel, you can optionally check this input to pass the /m switch to MSBuild (Windows only). If you're target configuration is not compatible with building in parallel, checking this option may cause your build to result in file-in-use errors, or intermittent or inconsistent build failures.",
+  "loc.input.help.maximumCpuCount": "If your MSBuild target configuration is compatible with building in parallel, you can optionally check this input to pass the /m switch to MSBuild (Windows only). If you're target configuration is not compatible with building in parallel, checking this option may cause your build to result in file-in-use errors, or intermittent or inconsistent build failures.",
   "loc.input.label.restoreNugetPackages": "Restore NuGet Packages",
   "loc.input.help.restoreNugetPackages": "This option is deprecated. To restore NuGet packages, add a NuGet Installer step before the build.",
   "loc.input.label.vsVersion": "Visual Studio Version",


### PR DESCRIPTION
"Maximum CPU Count" makes it sound like I get to set that value (a number!). But in fact, this is just a checkbox, and it's an indicator of whether to build in parallel or not.
The `/m` switch allows specifying a value. But since this build task doesn't accept a value, renaming it to "Build in parallel" (IMO) much better helps people know what the checkbox means without having to study the long documentary explanation.