### PR TITLE
Update agent version to 104 for consumers of Register-Environment command

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 35
+        "Patch": 36
     },
     "demands": [
 

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -18,7 +18,7 @@
     "demands": [
 
     ],
-    "minimumAgentVersion": "1.101.0",
+    "minimumAgentVersion": "1.104.0",
     "groups":  [
         {
             "name": "testMachineGroups",

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,10 +13,10 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 35
+    "Patch": 36
   },
   "demands": [],
-  "minimumAgentVersion": "1.101.0",
+  "minimumAgentVersion": "1.104.0",
   "groups": [
     {
       "name": "testMachineGroups",

--- a/Tasks/PowerShellOnTargetMachines/task.json
+++ b/Tasks/PowerShellOnTargetMachines/task.json
@@ -15,7 +15,7 @@
     "Minor": 0,
     "Patch": 39
   },
-  "minimumAgentVersion": "1.102.0",
+  "minimumAgentVersion": "1.104.0",
   "groups": [
     {
       "name": "deployment",

--- a/Tasks/PowerShellOnTargetMachines/task.json
+++ b/Tasks/PowerShellOnTargetMachines/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 39
+    "Patch": 40
   },
   "minimumAgentVersion": "1.104.0",
   "groups": [

--- a/Tasks/PowerShellOnTargetMachines/task.loc.json
+++ b/Tasks/PowerShellOnTargetMachines/task.loc.json
@@ -13,9 +13,9 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 39
+    "Patch": 40
   },
-  "minimumAgentVersion": "1.102.0",
+  "minimumAgentVersion": "1.104.0",
   "groups": [
     {
       "name": "deployment",

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -13,11 +13,11 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 40
+        "Patch": 41
     },
     "demands": [
     ],
-    "minimumAgentVersion": "1.101.0",
+    "minimumAgentVersion": "1.104.0",
     "groups": [
         {
             "name": "setupOptions",

--- a/Tasks/RunDistributedTests/task.loc.json
+++ b/Tasks/RunDistributedTests/task.loc.json
@@ -13,10 +13,10 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 40
+    "Patch": 41
   },
   "demands": [],
-  "minimumAgentVersion": "1.101.0",
+  "minimumAgentVersion": "1.104.0",
   "groups": [
     {
       "name": "setupOptions",

--- a/Tasks/WindowsMachineFileCopy/task.json
+++ b/Tasks/WindowsMachineFileCopy/task.json
@@ -15,7 +15,7 @@
         "Minor": 0,
         "Patch": 34
     },
-    "minimumAgentVersion": "1.102.0",
+    "minimumAgentVersion": "1.104.0",
     "groups": [
         {
             "name":"advanced",

--- a/Tasks/WindowsMachineFileCopy/task.json
+++ b/Tasks/WindowsMachineFileCopy/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 34
+        "Patch": 35
     },
     "minimumAgentVersion": "1.104.0",
     "groups": [

--- a/Tasks/WindowsMachineFileCopy/task.loc.json
+++ b/Tasks/WindowsMachineFileCopy/task.loc.json
@@ -13,9 +13,9 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 34
+    "Patch": 35
   },
-  "minimumAgentVersion": "1.102.0",
+  "minimumAgentVersion": "1.104.0",
   "groups": [
     {
       "name": "advanced",


### PR DESCRIPTION
Register-Environment for powershell tasks will get JSON string as input to deserialize Environment data. M104 legacy agent has the ability to consume JSON and produce an Environment object.