### PR TITLE
SonarQube build breaker delivers build summary before failing.

### DIFF
--- a/Tasks/Gradle/CodeAnalysis/SonarQube/common.ts
+++ b/Tasks/Gradle/CodeAnalysis/SonarQube/common.ts
@@ -47,9 +47,10 @@ export function processSonarQubeIntegration(sqBuildFolder:string):Q.Promise<void
     // Wait for all promises to complete before proceeding (even if one or more promises reject).
     return Q.allSettled([
         VstsServerUtils.processSonarQubeBuildSummary(sqRunSettings, sqMetrics),
-        VstsServerUtils.processSonarQubeBuildBreaker(sqRunSettings, sqMetrics),
     ])
         .then(() => {
+            // Apply the build breaker at the end, since breaking the build exits the build process.
+            VstsServerUtils.processSonarQubeBuildBreaker(sqRunSettings, sqMetrics);
         })
 }
 

--- a/Tasks/Gradle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Gradle/Strings/resources.resjson/en-US/resources.resjson
@@ -76,7 +76,7 @@
   "loc.messages.sqAnalysis_AnalysisTimeout": "The analysis did not complete in the allotted time of %d seconds.",
   "loc.messages.sqAnalysis_IsPullRequest_SkippingBuildSummary": "Pull request build: detailed SonarQube build summary will not be available.",
   "loc.messages.sqAnalysis_IsPullRequest_SkippingBuildBreaker": "Pull request build: build will not be broken if quality gate fails.",
-  "loc.messages.sqAnalysis_BuildBrokenDueToQualityGateFailure": "The SonarQube quality gate associated with this build has failed. For more details see %s",
+  "loc.messages.sqAnalysis_BuildBrokenDueToQualityGateFailure": "The SonarQube quality gate associated with this build has failed.",
   "loc.messages.sqAnalysis_QualityGatePassed": "The SonarQube quality gate associated with this build has passed (status %s)",
   "loc.messages.codeAnalysisBuildSummaryLine_SomeViolationsSomeFiles": "%s found %d violations in %d files.",
   "loc.messages.codeAnalysisBuildSummaryLine_SomeViolationsOneFile": "%s found %d violations in 1 file.",

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -348,7 +348,7 @@
         "sqAnalysis_AnalysisTimeout": "The analysis did not complete in the allotted time of %d seconds.",
         "sqAnalysis_IsPullRequest_SkippingBuildSummary": "Pull request build: detailed SonarQube build summary will not be available.",
         "sqAnalysis_IsPullRequest_SkippingBuildBreaker": "Pull request build: build will not be broken if quality gate fails.",
-        "sqAnalysis_BuildBrokenDueToQualityGateFailure": "The SonarQube quality gate associated with this build has failed. For more details see %s",
+        "sqAnalysis_BuildBrokenDueToQualityGateFailure": "The SonarQube quality gate associated with this build has failed.",
         "sqAnalysis_QualityGatePassed": "The SonarQube quality gate associated with this build has passed (status %s)",
         "codeAnalysisBuildSummaryLine_SomeViolationsSomeFiles": "%s found %d violations in %d files.",
         "codeAnalysisBuildSummaryLine_SomeViolationsOneFile": "%s found %d violations in 1 file.",

--- a/Tasks/Maven/CodeAnalysis/SonarQube/common.ts
+++ b/Tasks/Maven/CodeAnalysis/SonarQube/common.ts
@@ -47,9 +47,10 @@ export function processSonarQubeIntegration(sqBuildFolder:string):Q.Promise<void
     // Wait for all promises to complete before proceeding (even if one or more promises reject).
     return Q.allSettled([
         VstsServerUtils.processSonarQubeBuildSummary(sqRunSettings, sqMetrics),
-        VstsServerUtils.processSonarQubeBuildBreaker(sqRunSettings, sqMetrics),
     ])
         .then(() => {
+            // Apply the build breaker at the end, since breaking the build exits the build process.
+            VstsServerUtils.processSonarQubeBuildBreaker(sqRunSettings, sqMetrics);
         })
 }
 

--- a/Tasks/Maven/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Maven/Strings/resources.resjson/en-US/resources.resjson
@@ -74,7 +74,7 @@
   "loc.messages.sqAnalysis_AnalysisTimeout": "The analysis did not complete in the allotted time of %d seconds.",
   "loc.messages.sqAnalysis_IsPullRequest_SkippingBuildSummary": "Pull request build: detailed SonarQube build summary will not be available.",
   "loc.messages.sqAnalysis_IsPullRequest_SkippingBuildBreaker": "Pull request build: build will not be broken if quality gate fails.",
-  "loc.messages.sqAnalysis_BuildBrokenDueToQualityGateFailure": "The SonarQube quality gate associated with this build has failed. For more details see %s",
+  "loc.messages.sqAnalysis_BuildBrokenDueToQualityGateFailure": "The SonarQube quality gate associated with this build has failed.",
   "loc.messages.sqAnalysis_QualityGatePassed": "The SonarQube quality gate associated with this build has passed (status %s)",
   "loc.messages.codeAnalysisBuildSummaryLine_SomeViolationsSomeFiles": "%s found %d violations in %d files.",
   "loc.messages.codeAnalysisBuildSummaryLine_SomeViolationsOneFile": "%s found %d violations in 1 file.",

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -346,7 +346,7 @@
         "sqAnalysis_AnalysisTimeout": "The analysis did not complete in the allotted time of %d seconds.",
         "sqAnalysis_IsPullRequest_SkippingBuildSummary": "Pull request build: detailed SonarQube build summary will not be available.",
         "sqAnalysis_IsPullRequest_SkippingBuildBreaker": "Pull request build: build will not be broken if quality gate fails.",
-        "sqAnalysis_BuildBrokenDueToQualityGateFailure": "The SonarQube quality gate associated with this build has failed. For more details see %s",
+        "sqAnalysis_BuildBrokenDueToQualityGateFailure": "The SonarQube quality gate associated with this build has failed.",
         "sqAnalysis_QualityGatePassed": "The SonarQube quality gate associated with this build has passed (status %s)",
         "codeAnalysisBuildSummaryLine_SomeViolationsSomeFiles": "%s found %d violations in %d files.",
         "codeAnalysisBuildSummaryLine_SomeViolationsOneFile": "%s found %d violations in 1 file.",


### PR DESCRIPTION
Also removes the URL from the failure message as it is in the build summary