### PR TITLE
Users/yacao/fixarchivefiletests

### DIFF
--- a/Tests/L0/ArchiveFiles/_suite.ts
+++ b/Tests/L0/ArchiveFiles/_suite.ts
@@ -27,7 +27,6 @@ describe('ArchiveFiles Suite', function () {
     });
 
     var tests = [
-        /*
         {
             'file': 'test.zip',
             'type': 'zip',
@@ -63,14 +62,13 @@ describe('ArchiveFiles Suite', function () {
             'type': 'tar',
             'tarCompression': 'xz'
         }
-        */
     ]
 
     tests.forEach((test) => {
         it('test root windows: archive ' + test.file, (done) => {
             setResponseFile('archiveFilesWin.json');
 
-            var tr = new trm.TaskRunner('ArchiveFiles', true);
+            var tr = new trm.TaskRunner('ArchiveFiles', true, true);
             tr.setInput('rootFolder', 'testRootFolder');
             tr.setInput('includeRootFolder', 'true');
             tr.setInput('archiveType', test.type);
@@ -99,7 +97,7 @@ describe('ArchiveFiles Suite', function () {
         it('test no root windows: archive ' + test.file, (done) => {
             setResponseFile('archiveFilesWin.json');
 
-            var tr = new trm.TaskRunner('ArchiveFiles', true);
+            var tr = new trm.TaskRunner('ArchiveFiles', true, true);
             tr.setInput('rootFolder', 'testRootFolder');
             tr.setInput('includeRootFolder', 'false');
             tr.setInput('archiveType', test.type);
@@ -130,7 +128,7 @@ describe('ArchiveFiles Suite', function () {
         it('test root linux: archive ' + test.file, (done) => {
             setResponseFile('archiveFilesLinux.json');
 
-            var tr = new trm.TaskRunner('ArchiveFiles', true);
+            var tr = new trm.TaskRunner('ArchiveFiles', true, true);
             tr.setInput('rootFolder', 'testRootFolder');
             tr.setInput('includeRootFolder', 'true');
             tr.setInput('archiveType', test.type);
@@ -151,7 +149,7 @@ describe('ArchiveFiles Suite', function () {
         it('test no root linux: archive ' + test.file, (done) => {
             setResponseFile('archiveFilesLinux.json');
 
-            var tr = new trm.TaskRunner('ArchiveFiles', true);
+            var tr = new trm.TaskRunner('ArchiveFiles', true, true);
             tr.setInput('rootFolder', 'testRootFolder');
             tr.setInput('includeRootFolder', 'false');
             tr.setInput('archiveType', test.type);

--- a/Tests/L0/ArchiveFiles/archiveFilesWin.json
+++ b/Tests/L0/ArchiveFiles/archiveFilesWin.json
@@ -1,7 +1,4 @@
 {
-    "cwd" : {
-        "cwd" : "mockedTaskRoot"
-    },
     "osType" : {
         "osType" : "Windows"
     },
@@ -22,57 +19,57 @@
         }
     },
     "exec": {
-        "mockedTaskRoot/7zip/7z.exe a -tzip test.zip testRootFolder": {
+        "/ArchiveFiles/7zip/7z.exe a -tzip test.zip testRootFolder": {
             "code": 0,
             "stdout": "created test.zip testRootFolder",
             "stderr": ""
         },
-        "mockedTaskRoot/7zip/7z.exe a -t7z test.7z testRootFolder": {
+        "/ArchiveFiles/7zip/7z.exe a -t7z test.7z testRootFolder": {
             "code": 0,
             "stdout": "created test.7z testRootFolder",
             "stderr": ""
         },
-        "mockedTaskRoot/7zip/7z.exe a -twim test.wim testRootFolder": {
+        "/ArchiveFiles/7zip/7z.exe a -twim test.wim testRootFolder": {
             "code": 0,
             "stdout": "created test.wim testRootFolder",
             "stderr": ""
         },
-        "mockedTaskRoot/7zip/7z.exe a -ttar test.tar testRootFolder": {
+        "/ArchiveFiles/7zip/7z.exe a -ttar test.tar testRootFolder": {
             "code": 0,
             "stdout": "created test.tar testRootFolder",
             "stderr": ""
         },
-        "mockedTaskRoot/7zip/7z.exe a -tgzip test.tar.gz test.tar": {
+        "/ArchiveFiles/7zip/7z.exe a -tgzip test.tar.gz test.tar": {
             "code": 0,
             "stdout": "created test.tar.gz test.tar",
             "stderr": ""
         },
-        "mockedTaskRoot/7zip/7z.exe a -tbzip2 test.tar.bz2 test.tar": {
+        "/ArchiveFiles/7zip/7z.exe a -tbzip2 test.tar.bz2 test.tar": {
             "code": 0,
             "stdout": "created test.tar.bz2 test.tar",
             "stderr": ""
         },
-        "mockedTaskRoot/7zip/7z.exe a -txz test.tar.xz test.tar": {
+        "/ArchiveFiles/7zip/7z.exe a -txz test.tar.xz test.tar": {
             "code": 0,
             "stdout": "created test.tar.xz test.tar",
             "stderr": ""
         },
-        "mockedTaskRoot/7zip/7z.exe a -tzip test.zip one two three": {
+        "/ArchiveFiles/7zip/7z.exe a -tzip test.zip one two three": {
             "code": 0,
             "stdout": "created test.zip one two three",
             "stderr": ""
         },
-        "mockedTaskRoot/7zip/7z.exe a -t7z test.7z one two three": {
+        "/ArchiveFiles/7zip/7z.exe a -t7z test.7z one two three": {
             "code": 0,
             "stdout": "created test.7z one two three",
             "stderr": ""
         },
-        "mockedTaskRoot/7zip/7z.exe a -twim test.wim one two three": {
+        "/ArchiveFiles/7zip/7z.exe a -twim test.wim one two three": {
             "code": 0,
             "stdout": "created test.wim one two three",
             "stderr": ""
         },
-        "mockedTaskRoot/7zip/7z.exe a -ttar test.tar one two three": {
+        "/ArchiveFiles/7zip/7z.exe a -ttar test.tar one two three": {
             "code": 0,
             "stdout": "created test.tar one two three",
             "stderr": ""

--- a/Tests/lib/vsts-task-lib/toolrunner.ts
+++ b/Tests/lib/vsts-task-lib/toolrunner.ts
@@ -151,6 +151,17 @@ export class ToolRunner extends events.EventEmitter {
         }
     }
 
+    private ignoreTempPath(cmdString: string): string {
+        this._debug('ignoreTempPath=' + process.env['MOCK_IGNORE_TEMP_PATH']);
+        this._debug('tempPath=' + process.env['MOCK_TEMP_PATH']);
+        if (process.env['MOCK_IGNORE_TEMP_PATH'] === 'true') {
+            // Using split/join to replace the temp path
+            cmdString = cmdString.split(process.env['MOCK_TEMP_PATH']).join('');
+        }
+
+        return cmdString;
+    } 
+
     //
     // Exec - use for long running tools where you need to stream live output as it runs
     //        returns a promise with return code.
@@ -183,12 +194,8 @@ export class ToolRunner extends events.EventEmitter {
             cmdString += (' ' + argString);
         }
 
-        this._debug('ignoreTempPath=' + process.env['MOCK_IGNORE_TEMP_PATH']);
-        this._debug('tempPath=' + process.env['MOCK_TEMP_PATH']);
-        if (process.env['MOCK_IGNORE_TEMP_PATH'] === 'true') {
-            // Using split/join to replace the temp path
-            cmdString = cmdString.split(process.env['MOCK_TEMP_PATH']).join('');
-        }
+        // Using split/join to replace the temp path
+        cmdString = this.ignoreTempPath(cmdString);
 
         if (!ops.silent) {
             ops.outStream.write('[command]' + cmdString + os.EOL);
@@ -264,6 +271,10 @@ export class ToolRunner extends events.EventEmitter {
 
         var argString = this.args.join(' ') || '';
         var cmdString = this.toolPath;
+
+        // Using split/join to replace the temp path
+        cmdString = this.ignoreTempPath(cmdString);
+
         if (argString) {
             cmdString += (' ' + argString);
         }


### PR DESCRIPTION
Ignore temp path is only enabled on exec() call in tool runner.  Add this ability to the execSync() version and use it to re-enable tests for ArchiveFiles task.