### PR TITLE
Resolving bug #1660

### DIFF
--- a/Tasks/AzureFileCopy/task.json
+++ b/Tasks/AzureFileCopy/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 73
+    "Patch": 74
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopy/task.loc.json
+++ b/Tasks/AzureFileCopy/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 73
+    "Patch": 74
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
Issue Link => [https://github.com/Microsoft/vsts-tasks/issues/1660]

If the version is greater than 1.4.0, then **$storageKeyDetails.Value[0]** should be used.
For other versions, **$storageKeyDetails.Key1** should be used.
Refer : `(https://msdn.microsoft.com/en-us/library/mt607145.aspx)`