### PR TITLE
Changing from System.ArtifactsDirectory to Common.TestResultsDirectory

### DIFF
--- a/Tasks/VsTest/VSTest.ps1
+++ b/Tasks/VsTest/VSTest.ps1
@@ -92,9 +92,7 @@ try
             $vsTestVersion = $null
         }
 
-        $artifactsDirectory = Get-TaskVariable -Context $distributedTaskContext -Name "System.ArtifactsDirectory" -Global $FALSE
-
-        $workingDirectory = $artifactsDirectory
+        $workingDirectory = Get-TaskVariable -Context $distributedTaskContext -Name "Agent.BuildDirectory"
 
         if($runInParallel -eq "True")
         {
@@ -109,15 +107,8 @@ try
         $defaultCpuCount = "0"    
         $runSettingsFileWithParallel = [string](SetupRunSettingsFileForParallel $runInParallel $runSettingsFile $defaultCpuCount)
 
-        #If there is settings file and no override parameters, try to get the custom resutls location
-        if(![System.String]::IsNullOrWhiteSpace($runSettingsFileWithParallel) -and !$overrideTestrunParameters)
-        {
-            $testResultsDirectory = Get-ResultsLocation $runSettingsFileWithParallel 
-        }
-        if(!$testResultsDirectory)
-        {
-            $testResultsDirectory = $workingDirectory + [System.IO.Path]::DirectorySeparatorChar + "TestResults"
-        } 
+        # There is a global TestResultsDirectory variable that TestResults need to be placed within
+        $testResultsDirectory = Get-TaskVariable -Context $distributedTaskContext -Name "Common.TestResultsDirectory"
         Write-Verbose "Test results directory: $testResultsDirectory"
 
         

--- a/Tests/L0/VsTest/Compat.OptOutOfPublishNotInCmdlet.ProvidedByTask.ps1
+++ b/Tests/L0/VsTest/Compat.OptOutOfPublishNotInCmdlet.ProvidedByTask.ps1
@@ -14,13 +14,15 @@ Register-Mock Get-LocalizedString
 Register-Mock Write-Warning
 
 $sourcesDirectory = 'c:\temp'
+$workingDirectory = 'c:\temp'
+$testResultsDirectory = $workingDirectory + [System.IO.Path]::DirectorySeparatorChar + "TestResults"
 $distributedTaskContext = 'Some distributed task context'
 Register-Mock Get-TaskVariable { $sourcesDirectory } -- -Context $distributedTaskContext -Name "Build.SourcesDirectory"
-Register-Mock Get-TaskVariable { $sourcesDirectory } -- -Context $distributedTaskContext -Name "System.ArtifactsDirectory" -Global $FALSE
+Register-Mock Get-TaskVariable { $workingDirectory } -- -Context $distributedTaskContext -Name "Agent.BuildDirectory"
+Register-Mock Get-TaskVariable { $testResultsDirectory } -- -Context $distributedTaskContext -Name "Common.TestResultsDirectory"
 
 Register-Mock Find-Files { $true } -- -SearchPattern $testAssembly -RootFolder $sourcesDirectory
-$testResultsDirectory=$sourcesDirectory + [System.IO.Path]::DirectorySeparatorChar + "TestResults"
-$resultFiles='c:\results.trx'
+$resultFiles='c:\temp\TestResults\results.trx'
 Register-Mock Find-Files { $resultFiles } -- -SearchPattern "*.trx" -RootFolder $testResultsDirectory
 
 Register-Mock Convert-String { $true }

--- a/Tests/L0/VsTest/Compat.TestRunTitleNotInCmdlet.ProvidedByTask.ps1
+++ b/Tests/L0/VsTest/Compat.TestRunTitleNotInCmdlet.ProvidedByTask.ps1
@@ -14,13 +14,15 @@ Register-Mock Get-LocalizedString
 Register-Mock Write-Warning
 
 $sourcesDirectory = 'c:\temp'
+$workingDirectory = 'c:\temp'
+$testResultsDirectory = $workingDirectory + [System.IO.Path]::DirectorySeparatorChar + "TestResults"
 $distributedTaskContext = 'Some distributed task context'
 Register-Mock Get-TaskVariable { $sourcesDirectory } -- -Context $distributedTaskContext -Name "Build.SourcesDirectory"
-Register-Mock Get-TaskVariable { $sourcesDirectory } -- -Context $distributedTaskContext -Name "System.ArtifactsDirectory" -Global $FALSE
+Register-Mock Get-TaskVariable { $workingDirectory } -- -Context $distributedTaskContext -Name "Agent.BuildDirectory"
+Register-Mock Get-TaskVariable { $testResultsDirectory } -- -Context $distributedTaskContext -Name "Common.TestResultsDirectory"
 
 Register-Mock Find-Files { $true } -- -SearchPattern $testAssembly -RootFolder $sourcesDirectory
-$testResultsDirectory=$sourcesDirectory + [System.IO.Path]::DirectorySeparatorChar + "TestResults"
-$resultFiles='c:\results.trx'
+$resultFiles='c:\temp\TestResults\results.trx'
 Register-Mock Find-Files { $resultFiles } -- -SearchPattern "*.trx" -RootFolder $testResultsDirectory
 
 Register-Mock Convert-String { $true }

--- a/Tests/L0/VsTest/NoTestAssemblies.PrintsWarning.ps1
+++ b/Tests/L0/VsTest/NoTestAssemblies.PrintsWarning.ps1
@@ -9,12 +9,14 @@ Register-Mock Get-LocalizedString
 Register-Mock Write-Warning
 
 $sourcesDirectory = 'c:\temp'
+$workingDirectory = 'c:\temp'
+$testResultsDirectory = $sourcesDirectory + [System.IO.Path]::DirectorySeparatorChar + "TestResults"
 $distributedTaskContext = 'Some distributed task context'
 Register-Mock Get-TaskVariable { $sourcesDirectory } -- -Context $distributedTaskContext -Name "Build.SourcesDirectory"
-Register-Mock Get-TaskVariable { $sourcesDirectory } -- -Context $distributedTaskContext -Name "System.ArtifactsDirectory" -Global $FALSE
+Register-Mock Get-TaskVariable { $workingDirectory } -- -Context $distributedTaskContext -Name "Agent.BuildDirectory"
+Register-Mock Get-TaskVariable { $testResultsDirectory } -- -Context $distributedTaskContext -Name "Common.TestResultsDirectory"
 
 Register-Mock Find-Files { $true } -- -SearchPattern $testAssembly -RootFolder $sourcesDirectory
-$testResultsDirectory=$sourcesDirectory + [System.IO.Path]::DirectorySeparatorChar + "TestResults"
 Register-Mock Find-Files { $false } -- -SearchPattern "*.trx" -RootFolder $testResultsDirectory
 
 Register-Mock Convert-String { $true }

--- a/Tests/L0/VsTest/TestResultsDirectoryVariableIsUsedIfOverrideParamsAreUsed.ps1
+++ b/Tests/L0/VsTest/TestResultsDirectoryVariableIsUsedIfOverrideParamsAreUsed.ps1
@@ -4,7 +4,12 @@ param()
 . $PSScriptRoot\..\..\lib\Initialize-Test.ps1
 . $PSScriptRoot\..\..\..\Tasks\VsTest\Helpers.ps1
 
-Register-Mock Get-TaskVariable { "c:\testSource" }
+$sourcesDirectory = 'c:\temp'
+$workingDirectory = 'c:\temp'
+$testResultsDirectory = $workingDirectory + [System.IO.Path]::DirectorySeparatorChar + "TestResults"
+Register-Mock Get-TaskVariable { $sourcesDirectory } -- -Context $distributedTaskContext -Name "Build.SourcesDirectory"
+Register-Mock Get-TaskVariable { $workingDirectory } -- -Context $distributedTaskContext -Name "Agent.BuildDirectory"
+Register-Mock Get-TaskVariable { $testResultsDirectory } -- -Context $distributedTaskContext -Name "Common.TestResultsDirectory"
 Register-Mock Convert-String { $true }
 Register-Mock Find-Files { $true }
 Register-Mock CmdletHasMember { $true }
@@ -16,7 +21,7 @@ $input = @{
 'vsTestVersion'='14.0'
 'testAssembly'='asd.dll'
 'testFiltercriteria'=''
-'runSettingsFile'=''
+'runSettingsFile'='asd'
 'codeCoverageEnabled'='false'
 'pathtoCustomTestAdapters'=''
 'overrideTestrunParameters'='asd'
@@ -30,5 +35,5 @@ $input = @{
 & $PSScriptRoot\..\..\..\Tasks\VsTest\VSTest.ps1 @input
 
 Assert-WasCalled Invoke-VSTest -ParametersEvaluator {
-	$TestResultsFolder -eq 'c:\testSource\TestResults'
+	$TestResultsFolder -eq $testResultsDirectory
 }

--- a/Tests/L0/VsTest/TestResultsDirectoryVariableIsUsedIfnorunsettings.ps1
+++ b/Tests/L0/VsTest/TestResultsDirectoryVariableIsUsedIfnorunsettings.ps1
@@ -4,7 +4,12 @@ param()
 . $PSScriptRoot\..\..\lib\Initialize-Test.ps1
 . $PSScriptRoot\..\..\..\Tasks\VsTest\Helpers.ps1
 
-Register-Mock Get-TaskVariable { "c:\testSource" }
+$sourcesDirectory = 'c:\temp'
+$workingDirectory = 'c:\temp'
+$testResultsDirectory = $workingDirectory + [System.IO.Path]::DirectorySeparatorChar + "TestResults"
+Register-Mock Get-TaskVariable { $sourcesDirectory } -- -Context $distributedTaskContext -Name "Build.SourcesDirectory"
+Register-Mock Get-TaskVariable { $workingDirectory } -- -Context $distributedTaskContext -Name "Agent.BuildDirectory"
+Register-Mock Get-TaskVariable { $testResultsDirectory } -- -Context $distributedTaskContext -Name "Common.TestResultsDirectory"
 Register-Mock Convert-String { $true }
 Register-Mock Find-Files { $true }
 Register-Mock CmdletHasMember { $true }
@@ -16,7 +21,7 @@ $input = @{
 'vsTestVersion'='14.0'
 'testAssembly'='asd.dll'
 'testFiltercriteria'=''
-'runSettingsFile'='asd'
+'runSettingsFile'=''
 'codeCoverageEnabled'='false'
 'pathtoCustomTestAdapters'=''
 'overrideTestrunParameters'='asd'
@@ -30,5 +35,5 @@ $input = @{
 & $PSScriptRoot\..\..\..\Tasks\VsTest\VSTest.ps1 @input
 
 Assert-WasCalled Invoke-VSTest -ParametersEvaluator {
-	$TestResultsFolder -eq 'c:\testSource\TestResults'
+	$TestResultsFolder -eq $testResultsDirectory
 }

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -115,12 +115,12 @@ describe('VsTest Suite', function () {
             psr.run(path.join(__dirname, 'GetResultsLocationReturnsNullForEmptyPath.ps1'), done);
         })
 
-        it('(DefaultTestResultsDirectoryIsUsedIfnorunsettings) vstest invoked with  default test results directory if no settings is specified', (done) => {
-            psr.run(path.join(__dirname, 'DefaultTestResultsDirectoryIsUsedIfnorunsettings.ps1'), done);
+        it('(TestResultsDirectoryVariableIsUsedIfnorunsettings) vstest invoked with  default test results directory if no settings is specified', (done) => {
+            psr.run(path.join(__dirname, 'TestResultsDirectoryVariableIsUsedIfnorunsettings.ps1'), done);
         })
 
-        it('(DefaultTestResultsDirectoryIsUsedIfOverrideParamsAreUsed) vstest invoked with  default test results directory if override run parameters is used', (done) => {
-            psr.run(path.join(__dirname, 'DefaultTestResultsDirectoryIsUsedIfOverrideParamsAreUsed.ps1'), done);
+        it('(TestResultsDirectoryVariableIsUsedIfOverrideParamsAreUsed) vstest invoked with  default test results directory if override run parameters is used', (done) => {
+            psr.run(path.join(__dirname, 'TestResultsDirectoryVariableIsUsedIfOverrideParamsAreUsed.ps1'), done);
         })
 
         it('(EnableDiagCheckReturnsFalseInNonDebugMode) diag flag should not be used in non-debug mode', (done) => {


### PR DESCRIPTION
#1975 indicates a simple problem where the test results started to be placed in the Artifacts Directory. VSTS provides a `Common.TestResultsDirectory` variable and other processes (such as SonarQube) expect test results to be located in this directory. It is therefore imperative that the VSTest runner use this directory for storing test results, regardless of the inbound configuration.
