### PR TITLE
Fixing issues and adding capability to point to a collector

### DIFF
--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 54
+        "Patch": 55
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 54
+    "Patch": 55
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
For supporting Test Impact we should be able to point to the new test collector which collects file hash on demand. This change allws that plus some bug fixes.