### PR TITLE
Only match files in the pattern provided in NuGet tasks

### DIFF
--- a/Tasks/Common/nuget-task-common/Utility.ts
+++ b/Tasks/Common/nuget-task-common/Utility.ts
@@ -104,6 +104,9 @@ export function resolveWildcardPath(pattern: string, allowEmptyWildcardMatch?: b
 
         filesList = allFiles.filter(patternFilter);
 
+        // Avoid matching anything other than files
+        filesList = filesList.filter(x => tl.stats(x).isFile());
+
         // Fail if no matching .sln files were found
         if (!allowEmptyWildcardMatch && (!filesList || filesList.length == 0)) {
             throw new Error('No matching files were found with search pattern: ' + pattern);


### PR DESCRIPTION
There was a bug where we were matching also directories causing the tasks to fail.