### PR TITLE
ExtractFiles: correctly load 7-zip location

### DIFF
--- a/Tasks/ExtractFiles/extractfilestask.ts
+++ b/Tasks/ExtractFiles/extractfilestask.ts
@@ -19,7 +19,7 @@ var xpTarLocation : string;
 var xpUnzipLocation : string;
 // 7zip
 var xpSevenZipLocation: string;
-var winSevenZipLocation: string = '7zip/7z.exe';
+var winSevenZipLocation: string = path.join(__dirname, '7zip/7z.exe');
 
 function getSevenZipLocation() : string {
     if(win){

--- a/Tasks/ExtractFiles/task.json
+++ b/Tasks/ExtractFiles/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "instanceNameFormat": "Extract files $(message)",
     "inputs": [

--- a/Tasks/ExtractFiles/task.loc.json
+++ b/Tasks/ExtractFiles/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 3
+    "Patch": 4
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [


### PR DESCRIPTION
This is the same change made to correctly load 7-zip that was made to ArchiveFiles: https://github.com/Microsoft/vsts-tasks/issues/2242