### PR TITLE
	SonarQube analysis on Maven and Gradle fails if the SQ server is over https

### DIFF
--- a/Tasks/Gradle/CodeAnalysis/SonarQube/endpoint.ts
+++ b/Tasks/Gradle/CodeAnalysis/SonarQube/endpoint.ts
@@ -15,6 +15,8 @@ export class SonarQubeEndpoint {
         var genericEndpointName: string = tl.getInput('sqConnectedServiceName');
         var hostUrl = tl.getEndpointUrl(genericEndpointName, false);
 
+        tl.debug(`[SQ] SonarQube endpoint: ${hostUrl}`);
+
         // Currently the username and the password are required, but in the future they will not be mandatory
         // - so not validating the values here
         var hostUsername = SonarQubeEndpoint.getSonarQubeAuthParameter(genericEndpointName, 'username');

--- a/Tasks/Gradle/CodeAnalysis/SonarQube/metrics.ts
+++ b/Tasks/Gradle/CodeAnalysis/SonarQube/metrics.ts
@@ -69,9 +69,16 @@ export class SonarQubeMetrics {
      * @returns {Promise<string>} The quality gate status, as reported by the SonarQube server.
      */
     public getQualityGateStatus(): Q.Promise<string> {
+
+        tl.debug(`[SQ] Getting the quality gate status `);
+
         return this.getAnalysisId()
             .then((analysisId:string) => {
-                return this.getAnalysisStatus(analysisId);
+                tl.debug(`[SQ] Analysis ID: ${analysisId}`);
+                var status =  this.getAnalysisStatus(analysisId);
+                tl.debug(`[SQ] Analysis status: ${status}`);
+
+                return status;
             })
     }
 
@@ -97,8 +104,11 @@ export class SonarQubeMetrics {
      * @returns A promise resolving true if the task finished or rejecting if there was an error or the timeout was exceeded.
      */
     private waitForTaskCompletion(timeout?:number, delay?:number):Q.Promise<boolean> {
+        tl.debug(`[SQ] Waiting for SonarQube analysis to complete `);
+
         // If we have previously waited, then we can immediately return true.
         if (this.analysisComplete) {
+            tl.debug(`[SQ] Analysis complete check already performed `);
             return Q.when(true);
         }
 
@@ -113,6 +123,7 @@ export class SonarQubeMetrics {
             this.isTaskComplete()
                 .then((isDone:boolean) => {
                     if (isDone) {
+                        tl.debug(`[SQ] Analysis complete`);
                         // analysis is complete, set the cache (there should be no further state changes)
                         this.analysisComplete = true;
                         this.getTaskDetails()
@@ -159,6 +170,7 @@ export class SonarQubeMetrics {
         return this.getTaskDetails()
             .then((responseJson:any) => {
                 var taskStatus:string = responseJson.task.status;
+                tl.debug(`[SQ] Analysis status: ${taskStatus} `);
                 return (taskStatus.toUpperCase() == 'SUCCESS');
             });
     }

--- a/Tasks/Gradle/CodeAnalysis/SonarQube/server.ts
+++ b/Tasks/Gradle/CodeAnalysis/SonarQube/server.ts
@@ -1,9 +1,7 @@
 import Q = require('q');
-import url = require('url');
-import https = require('https');
-import http = require('http');
+//import url = require('url');
+import request = require('request');
 import {IncomingMessage} from 'http';
-
 import {SonarQubeEndpoint} from './endpoint';
 
 import tl = require('vsts-task-lib/task');
@@ -12,101 +10,58 @@ export interface ISonarQubeServer {
     /**
      * Invoke a REST endpoint on the SonarQube server.
      * @param path The host-relative path to the REST endpoint (e.g. /api/ce/task)
-     * @returns A promise, resolving with a JSON object representation of the response. Rejects on error or non-200 header.
+     * @returns A promise, resolving with a JSON object representation of the response. Rejects on error or non-2xx header.
      */
-    invokeApiCall(path:string):Q.Promise<Object>;
+    invokeApiCall(path: string): Q.Promise<Object>;
 }
 
 export class SonarQubeServer implements ISonarQubeServer {
 
-    private endpoint:SonarQubeEndpoint;
+    private endpoint: SonarQubeEndpoint;
 
-    constructor(endpoint:SonarQubeEndpoint) {
+    constructor(endpoint: SonarQubeEndpoint) {
         this.endpoint = endpoint;
     }
 
-    public invokeApiCall(path:string):Q.Promise<Object> {
+    public invokeApiCall(path: string): Q.Promise<Object> {
 
-        tl.debug(`[SQ] Calling a REST API: ${path}`);
+        tl.debug(`[SQ] Invoking API at: ${path}`);
 
-        var defer = Q.defer<Object>();
-        var options:any = this.createSonarQubeHttpRequestOptions(path);
+        var deferred = Q.defer<Object>();
 
-        // Dynamic switching - we cannot use https.request() for http:// calls or vice versa
-        var protocolToUse;
-        switch (options.protocol) {
-            case 'http:':
-                protocolToUse = http;
-                break;
-            case 'https:':
-                protocolToUse = https;
-                break;
-            default:
-                tl.debug(`[SQ] Cannot recognize http protocol ${options.protocol} - falling back to http`)
-                protocolToUse = http;
-                break;
-        }
-
-         tl.debug(`[SQ] Protocol to use: ${protocolToUse}`);
-
-        var responseBody:string = '';
-        var request = protocolToUse.request(options, (response:IncomingMessage) => {
-
-            response.on('data', function (body) {
-                responseBody += body;
-            });
-
-            response.on('end', function () {
-                var serverResponseString:string = response.statusCode + " " + http.STATUS_CODES[response.statusCode];
-
-                // HTTP response codes between 200 and 299 inclusive are successes
-                if (!(response.statusCode >= 200 && response.statusCode < 300)) {
-                    defer.reject(new Error('Server responded with ' + serverResponseString));
-                } else {
-                    tl.debug('[SQ] Got response: ' + serverResponseString + " from " + path);
-
-                    if (!responseBody || responseBody.length < 1) {
-                        defer.resolve({});
-                    } else {
-                        defer.resolve(JSON.parse(responseBody));
-                    }
-                }
-            });
-        });
-
-        request.on('error', (error) => {
-            tl.debug('Failed to call ' + path);
-            defer.reject(error);
-        });
-
-        tl.debug('Sending request to: ' + path);
-        request.end();
-        return defer.promise;
-    }
-
-    /**
-     * Constructs the options object used by the http/https request() method.
-     * Defaults to an HTTP request on port 80 to the relative path '/'.
-     * @param path The host-relative path to the REST endpoint (e.g. /api/ce/task)
-     * @returns An options object to be passed to the request() method
-     */
-    private createSonarQubeHttpRequestOptions(path?:string):Object {
-        var hostUrl:url.Url = url.parse(this.endpoint.Url);
         var authUser = this.endpoint.Username || '';
         var authPass = this.endpoint.Password || '';
 
-        tl.debug(`[SQ] Host url protocol: ${hostUrl.protocol}`)
-
-        var options = {
+        request.get({
             method: 'GET',
-            protocol: hostUrl.protocol || 'http',
-            host: hostUrl.hostname,
-            port: hostUrl.port || 80,
-            path: path || '/',
-            auth: authUser + ':' + authPass,
-            headers: {}
-        };
+            baseUrl: this.endpoint.Url,
+            uri: path,
+            json: true,
+            'auth': {
+                'user': authUser,
+                'pass': authPass,
+            }            
+        }, (error, response, body) => {
+            if (error) {
+                tl.debug(`Request failed because of error: ${error}`);
+                deferred.reject(error);
+            }
 
-        return options;
+            if (response.statusCode < 200 || response.statusCode >= 300) {
+                tl.debug(`Request failed because the status code was: ${response.statusCode}`);
+                deferred.reject(new Error(`Request failed because the status code was: ${response.statusCode}`));
+            }
+
+            if (!body || body.length < 1) {
+                deferred.resolve({});
+            } else {
+                deferred.resolve(body);
+            }
+        });
+
+
+        return deferred.promise;
+      
     }
+
 }

--- a/Tasks/Gradle/CodeAnalysis/SonarQube/server.ts
+++ b/Tasks/Gradle/CodeAnalysis/SonarQube/server.ts
@@ -1,7 +1,5 @@
 import Q = require('q');
-//import url = require('url');
 import request = require('request');
-import {IncomingMessage} from 'http';
 import {SonarQubeEndpoint} from './endpoint';
 
 import tl = require('vsts-task-lib/task');

--- a/Tasks/Gradle/package.json
+++ b/Tasks/Gradle/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/Microsoft/vso-agent-tasks/issues"
   },
   "dependencies": {
-    "xml2js": "^0.4.16"
+    "xml2js": "^0.4.16",
+    "request": "^2.74.0"
   }
 }

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 53
+        "Patch": 54
     },
     "demands": [
         "java"

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 53
+    "Patch": 54
   },
   "demands": [
     "java"

--- a/Tasks/Maven/CodeAnalysis/SonarQube/endpoint.ts
+++ b/Tasks/Maven/CodeAnalysis/SonarQube/endpoint.ts
@@ -15,6 +15,8 @@ export class SonarQubeEndpoint {
         var genericEndpointName: string = tl.getInput('sqConnectedServiceName');
         var hostUrl = tl.getEndpointUrl(genericEndpointName, false);
 
+        tl.debug(`[SQ] SonarQube endpoint: ${hostUrl}`);
+
         // Currently the username and the password are required, but in the future they will not be mandatory
         // - so not validating the values here
         var hostUsername = SonarQubeEndpoint.getSonarQubeAuthParameter(genericEndpointName, 'username');

--- a/Tasks/Maven/CodeAnalysis/SonarQube/metrics.ts
+++ b/Tasks/Maven/CodeAnalysis/SonarQube/metrics.ts
@@ -69,9 +69,16 @@ export class SonarQubeMetrics {
      * @returns {Promise<string>} The quality gate status, as reported by the SonarQube server.
      */
     public getQualityGateStatus(): Q.Promise<string> {
+
+        tl.debug(`[SQ] Getting the quality gate status `);
+
         return this.getAnalysisId()
             .then((analysisId:string) => {
-                return this.getAnalysisStatus(analysisId);
+                tl.debug(`[SQ] Analysis ID: ${analysisId}`);
+                var status =  this.getAnalysisStatus(analysisId);
+                tl.debug(`[SQ] Analysis status: ${status}`);
+
+                return status;
             })
     }
 
@@ -97,8 +104,11 @@ export class SonarQubeMetrics {
      * @returns A promise resolving true if the task finished or rejecting if there was an error or the timeout was exceeded.
      */
     private waitForTaskCompletion(timeout?:number, delay?:number):Q.Promise<boolean> {
+        tl.debug(`[SQ] Waiting for SonarQube analysis to complete `);
+
         // If we have previously waited, then we can immediately return true.
         if (this.analysisComplete) {
+            tl.debug(`[SQ] Analysis complete check already performed `);
             return Q.when(true);
         }
 
@@ -113,6 +123,7 @@ export class SonarQubeMetrics {
             this.isTaskComplete()
                 .then((isDone:boolean) => {
                     if (isDone) {
+                        tl.debug(`[SQ] Analysis complete`);
                         // analysis is complete, set the cache (there should be no further state changes)
                         this.analysisComplete = true;
                         this.getTaskDetails()
@@ -159,6 +170,7 @@ export class SonarQubeMetrics {
         return this.getTaskDetails()
             .then((responseJson:any) => {
                 var taskStatus:string = responseJson.task.status;
+                tl.debug(`[SQ] Analysis status: ${taskStatus} `);
                 return (taskStatus.toUpperCase() == 'SUCCESS');
             });
     }

--- a/Tasks/Maven/CodeAnalysis/SonarQube/server.ts
+++ b/Tasks/Maven/CodeAnalysis/SonarQube/server.ts
@@ -1,9 +1,7 @@
 import Q = require('q');
-import url = require('url');
-import https = require('https');
-import http = require('http');
+//import url = require('url');
+import request = require('request');
 import {IncomingMessage} from 'http';
-
 import {SonarQubeEndpoint} from './endpoint';
 
 import tl = require('vsts-task-lib/task');
@@ -12,101 +10,58 @@ export interface ISonarQubeServer {
     /**
      * Invoke a REST endpoint on the SonarQube server.
      * @param path The host-relative path to the REST endpoint (e.g. /api/ce/task)
-     * @returns A promise, resolving with a JSON object representation of the response. Rejects on error or non-200 header.
+     * @returns A promise, resolving with a JSON object representation of the response. Rejects on error or non-2xx header.
      */
-    invokeApiCall(path:string):Q.Promise<Object>;
+    invokeApiCall(path: string): Q.Promise<Object>;
 }
 
 export class SonarQubeServer implements ISonarQubeServer {
 
-    private endpoint:SonarQubeEndpoint;
+    private endpoint: SonarQubeEndpoint;
 
-    constructor(endpoint:SonarQubeEndpoint) {
+    constructor(endpoint: SonarQubeEndpoint) {
         this.endpoint = endpoint;
     }
 
-    public invokeApiCall(path:string):Q.Promise<Object> {
+    public invokeApiCall(path: string): Q.Promise<Object> {
 
-        tl.debug(`[SQ] Calling a REST API: ${path}`);
+        tl.debug(`[SQ] Invoking API at: ${path}`);
 
-        var defer = Q.defer<Object>();
-        var options:any = this.createSonarQubeHttpRequestOptions(path);
+        var deferred = Q.defer<Object>();
 
-        // Dynamic switching - we cannot use https.request() for http:// calls or vice versa
-        var protocolToUse;
-        switch (options.protocol) {
-            case 'http:':
-                protocolToUse = http;
-                break;
-            case 'https:':
-                protocolToUse = https;
-                break;
-            default:
-                tl.debug(`[SQ] Cannot recognize http protocol ${options.protocol} - falling back to http`)
-                protocolToUse = http;
-                break;
-        }
-
-         tl.debug(`[SQ] Protocol to use: ${protocolToUse}`);
-
-        var responseBody:string = '';
-        var request = protocolToUse.request(options, (response:IncomingMessage) => {
-
-            response.on('data', function (body) {
-                responseBody += body;
-            });
-
-            response.on('end', function () {
-                var serverResponseString:string = response.statusCode + " " + http.STATUS_CODES[response.statusCode];
-
-                // HTTP response codes between 200 and 299 inclusive are successes
-                if (!(response.statusCode >= 200 && response.statusCode < 300)) {
-                    defer.reject(new Error('Server responded with ' + serverResponseString));
-                } else {
-                    tl.debug('[SQ] Got response: ' + serverResponseString + " from " + path);
-
-                    if (!responseBody || responseBody.length < 1) {
-                        defer.resolve({});
-                    } else {
-                        defer.resolve(JSON.parse(responseBody));
-                    }
-                }
-            });
-        });
-
-        request.on('error', (error) => {
-            tl.debug('Failed to call ' + path);
-            defer.reject(error);
-        });
-
-        tl.debug('Sending request to: ' + path);
-        request.end();
-        return defer.promise;
-    }
-
-    /**
-     * Constructs the options object used by the http/https request() method.
-     * Defaults to an HTTP request on port 80 to the relative path '/'.
-     * @param path The host-relative path to the REST endpoint (e.g. /api/ce/task)
-     * @returns An options object to be passed to the request() method
-     */
-    private createSonarQubeHttpRequestOptions(path?:string):Object {
-        var hostUrl:url.Url = url.parse(this.endpoint.Url);
         var authUser = this.endpoint.Username || '';
         var authPass = this.endpoint.Password || '';
 
-        tl.debug(`[SQ] Host url protocol: ${hostUrl.protocol}`)
-
-        var options = {
+        request.get({
             method: 'GET',
-            protocol: hostUrl.protocol || 'http',
-            host: hostUrl.hostname,
-            port: hostUrl.port || 80,
-            path: path || '/',
-            auth: authUser + ':' + authPass,
-            headers: {}
-        };
+            baseUrl: this.endpoint.Url,
+            uri: path,
+            json: true,
+            'auth': {
+                'user': authUser,
+                'pass': authPass,
+            }            
+        }, (error, response, body) => {
+            if (error) {
+                tl.debug(`Request failed because of error: ${error}`);
+                deferred.reject(error);
+            }
 
-        return options;
+            if (response.statusCode < 200 || response.statusCode >= 300) {
+                tl.debug(`Request failed because the status code was: ${response.statusCode}`);
+                deferred.reject(new Error(`Request failed because the status code was: ${response.statusCode}`));
+            }
+
+            if (!body || body.length < 1) {
+                deferred.resolve({});
+            } else {
+                deferred.resolve(body);
+            }
+        });
+
+
+        return deferred.promise;
+      
     }
+
 }

--- a/Tasks/Maven/CodeAnalysis/SonarQube/server.ts
+++ b/Tasks/Maven/CodeAnalysis/SonarQube/server.ts
@@ -1,7 +1,5 @@
 import Q = require('q');
-//import url = require('url');
 import request = require('request');
-import {IncomingMessage} from 'http';
 import {SonarQubeEndpoint} from './endpoint';
 
 import tl = require('vsts-task-lib/task');

--- a/Tasks/Maven/package.json
+++ b/Tasks/Maven/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/Microsoft/vso-agent-tasks/issues"
   },
   "dependencies": {
-    "xml2js": "^0.4.16"
+    "xml2js": "^0.4.16",
+    "request": "^2.74.0"
   }
 }

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 59
+        "Patch": 60
     },
     "minimumAgentVersion": "1.89.0",
     "instanceNameFormat": "Maven $(mavenPOMFile)",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 59
+    "Patch": 60
   },
   "minimumAgentVersion": "1.89.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/definitions/form-data.d.ts
+++ b/definitions/form-data.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for form-data
+// Project: https://github.com/felixge/node-form-data
+// Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>, Leon Yu <https://github.com/leonyu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Imported from: https://github.com/soywiz/typescript-node-definitions/form-data.d.ts
+
+declare module "form-data" {
+    class FormData {
+        append(key: string, value: any, options?: any): void;
+        getHeaders(): FormData.Dictionary<string>;
+        // TODO expand pipe
+        pipe(to: any): any;
+        submit(params: string | Object, callback: (error: any, response: any) => void): any;
+        getBoundary(): string;
+    }
+
+    namespace FormData {
+        interface Dictionary<T> {
+            [key: string]: T;
+        }
+    }
+
+    export = FormData;
+}

--- a/definitions/request.d.ts
+++ b/definitions/request.d.ts
@@ -1,0 +1,262 @@
+// Type definitions for request
+// Project: https://github.com/request/request
+// Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>, bonnici <https://github.com/bonnici>, Bart van der Schoor <https://github.com/Bartvds>, Joe Skeen <http://github.com/joeskeen>, Christopher Currens <https://github.com/ccurrens>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Imported from: https://github.com/soywiz/typescript-node-definitions/d.ts
+
+/// <reference path="./node.d.ts" />
+/// <reference path="./form-data.d.ts" />
+
+declare module 'request' {
+	import stream = require('stream');
+	import http = require('http');
+	import https = require('https');
+	import url = require('url');
+	import fs = require('fs');
+	import FormData = require('form-data');
+
+	namespace request {
+		export interface RequestAPI<TRequest extends Request,
+			TOptions extends CoreOptions,
+			TUriUrlOptions> {
+
+			defaults(options: TOptions): RequestAPI<TRequest, TOptions, RequiredUriUrl>;
+			defaults(options: RequiredUriUrl & TOptions): DefaultUriUrlRequestApi<TRequest, TOptions, OptionalUriUrl>;
+
+			(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+			(uri: string, callback?: RequestCallback): TRequest;
+			(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+
+			get(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+			get(uri: string, callback?: RequestCallback): TRequest;
+			get(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+
+			post(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+			post(uri: string, callback?: RequestCallback): TRequest;
+			post(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+
+			put(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+			put(uri: string, callback?: RequestCallback): TRequest;
+			put(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+
+			head(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+			head(uri: string, callback?: RequestCallback): TRequest;
+			head(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+
+			patch(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+			patch(uri: string, callback?: RequestCallback): TRequest;
+			patch(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+
+			del(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+			del(uri: string, callback?: RequestCallback): TRequest;
+			del(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+
+			forever(agentOptions: any, optionsArg: any): TRequest;
+			jar(): CookieJar;
+			cookie(str: string): Cookie;
+
+			initParams: any;
+			debug: boolean;
+		}
+
+		interface DefaultUriUrlRequestApi<TRequest extends Request,
+			TOptions extends CoreOptions,
+			TUriUrlOptions>	extends RequestAPI<TRequest, TOptions, TUriUrlOptions> {
+
+			defaults(options: TOptions): DefaultUriUrlRequestApi<TRequest, TOptions, OptionalUriUrl>;
+			(): TRequest;
+			get(): TRequest;
+			post(): TRequest;
+			put(): TRequest;
+			head(): TRequest;
+			patch(): TRequest;
+			del(): TRequest;
+		}
+
+		interface CoreOptions {
+			baseUrl?: string;
+			callback?: (error: any, response: http.IncomingMessage, body: any) => void;
+			jar?: any; // CookieJar
+			formData?: any; // Object
+			form?: any; // Object or string
+			auth?: AuthOptions;
+			oauth?: OAuthOptions;
+			aws?: AWSOptions;
+			hawk?: HawkOptions;
+			qs?: any;
+			json?: any;
+			multipart?: RequestPart[] | Multipart;
+			agent?: http.Agent | https.Agent;
+			agentOptions?: any;
+			agentClass?: any;
+			forever?: any;
+			host?: string;
+			port?: number;
+			method?: string;
+			headers?: Headers;
+			body?: any;
+			followRedirect?: boolean | ((response: http.IncomingMessage) => boolean);
+			followAllRedirects?: boolean;
+			maxRedirects?: number;
+			encoding?: string;
+			pool?: any;
+			timeout?: number;
+			proxy?: any;
+			strictSSL?: boolean;
+			gzip?: boolean;
+			preambleCRLF?: boolean;
+			postambleCRLF?: boolean;
+			key?: Buffer;
+			cert?: Buffer;
+			passphrase?: string;
+			ca?: string | Buffer | string[] | Buffer[];
+			har?: HttpArchiveRequest;
+			useQuerystring?: boolean;
+		}
+
+		interface UriOptions {
+			uri: string;
+		}
+		interface UrlOptions {
+			url: string;
+		}
+		export type RequiredUriUrl = UriOptions | UrlOptions;
+
+		interface OptionalUriUrl {
+			uri?: string;
+			url?: string;
+		}
+
+        export type OptionsWithUri = UriOptions & CoreOptions;
+        export type OptionsWithUrl = UrlOptions & CoreOptions;
+        export type Options = OptionsWithUri | OptionsWithUrl;
+
+		export interface RequestCallback {
+			(error: any, response: http.IncomingMessage, body: any): void;
+		}
+
+		export interface HttpArchiveRequest {
+			url?: string;
+			method?: string;
+			headers?: NameValuePair[];
+			postData?: {
+				mimeType?: string;
+				params?: NameValuePair[];
+			}
+		}
+
+		export interface NameValuePair {
+			name: string;
+			value: string;
+		}
+
+		export interface Multipart {
+			chunked?: boolean;
+			data?: {
+				'content-type'?: string,
+				body: string
+			}[];
+		}
+
+		export interface RequestPart {
+			headers?: Headers;
+			body: any;
+		}
+
+		export interface Request extends stream.Stream {
+			readable: boolean;
+			writable: boolean;
+
+			getAgent(): http.Agent;
+			//start(): void;
+			//abort(): void;
+			pipeDest(dest: any): void;
+			setHeader(name: string, value: string, clobber?: boolean): Request;
+			setHeaders(headers: Headers): Request;
+			qs(q: Object, clobber?: boolean): Request;
+			form(): FormData;
+			form(form: any): Request;
+			multipart(multipart: RequestPart[]): Request;
+			json(val: any): Request;
+			aws(opts: AWSOptions, now?: boolean): Request;
+			auth(username: string, password: string, sendInmediately?: boolean, bearer?: string): Request;
+			oauth(oauth: OAuthOptions): Request;
+			jar(jar: CookieJar): Request;
+
+			on(event: string, listener: Function): this;
+			on(event: 'request', listener: (req: http.ClientRequest) => void): this;
+			on(event: 'response', listener: (resp: http.IncomingMessage) => void): this;
+			on(event: 'data', listener: (data: Buffer | string) => void): this;
+			on(event: 'error', listener: (e: Error) => void): this;
+			on(event: 'complete', listener: (resp: http.IncomingMessage, body?: string | Buffer) => void): this;
+
+			write(buffer: Buffer, cb?: Function): boolean;
+			write(str: string, cb?: Function): boolean;
+			write(str: string, encoding: string, cb?: Function): boolean;
+			write(str: string, encoding?: string, fd?: string): boolean;
+			end(): void;
+			end(chunk: Buffer, cb?: Function): void;
+			end(chunk: string, cb?: Function): void;
+			end(chunk: string, encoding: string, cb?: Function): void;
+			pause(): void;
+			resume(): void;
+			abort(): void;
+			destroy(): void;
+			toJSON(): Object;
+		}
+
+		export interface Headers {
+			[key: string]: any;
+		}
+
+		export interface AuthOptions {
+			user?: string;
+			username?: string;
+			pass?: string;
+			password?: string;
+			sendImmediately?: boolean;
+			bearer?: string;
+		}
+
+		export interface OAuthOptions {
+			callback?: string;
+			consumer_key?: string;
+			consumer_secret?: string;
+			token?: string;
+			token_secret?: string;
+			verifier?: string;
+		}
+
+		export interface HawkOptions {
+			credentials: any;
+		}
+
+		export interface AWSOptions {
+			secret: string;
+			bucket?: string;
+		}
+
+		export interface CookieJar {
+			setCookie(cookie: Cookie, uri: string | url.Url, options?: any): void
+			getCookieString(uri: string | url.Url): string
+			getCookies(uri: string | url.Url): Cookie[]
+		}
+
+		export interface CookieValue {
+			name: string;
+			value: any;
+			httpOnly: boolean;
+		}
+
+		export interface Cookie extends Array<CookieValue> {
+			constructor(name: string, req: Request): void;
+			str: string;
+			expires: Date;
+			path: string;
+			toString(): string;
+		}
+	}
+	var request: request.RequestAPI<request.Request, request.CoreOptions, request.RequiredUriUrl>;
+	export = request;
+}


### PR DESCRIPTION
Replace the use of the low-level http and https modules with a higher level request module. 