### PR TITLE
Fixing Run Functional tasks issue

### DIFF
--- a/Tasks/RunDistributedTests/RunDistributedTests.ps1
+++ b/Tasks/RunDistributedTests/RunDistributedTests.ps1
@@ -26,14 +26,9 @@ Function CmdletHasMember($memberName) {
 
 Function ModifyTestSettingsForDeploymentItems() {
 
-    if([System.String]::IsNullOrWhiteSpace($runSettingsFile) -Or ([string]::Compare([io.path]::GetExtension($runSettingsFile), ".runsettings", $True) -eq 0) -Or (Test-Path $runSettingsFile -pathtype container))
+    if(!([System.String]::IsNullOrWhiteSpace($runSettingsFile)) -And !(Test-Path $runSettingsFile -pathtype container) -And ([string]::Compare([io.path]::GetExtension($runSettingsFile), ".testsettings", $True) -eq 0))
     {
-        Write-Verbose "No modifications to test settings required"
-    }
-    else{
-        if (([string]::Compare([io.path]::GetExtension($runSettingsFile), ".testsettings", $True) -eq 0)) {
-            
-            $runSettingsContent = [System.Xml.XmlDocument](Get-Content $runSettingsFile)
+        $runSettingsContent = [System.Xml.XmlDocument](Get-Content $runSettingsFile)
 			$runConfigurationElement = $runSettingsContent.SelectNodes("/*/*/*[local-name()='DeploymentItem']")
             
             For ($index=0; $index -lt $runConfigurationElement.Count; $index++)
@@ -52,8 +47,8 @@ Function ModifyTestSettingsForDeploymentItems() {
             $runSettingsContent.Save($tempFile)
             Write-Verbose "Temporary runsettings file created at $tempFile"
             return $tempFile
-        }        
-    }
+        
+    }    
 
     return 	$runSettingsFile
 }
@@ -207,4 +202,10 @@ else
             throw
         }
     }
+}
+
+if (([string]::Compare([io.path]::GetExtension($runSettingsFile), ".tmp", $True) -eq 0))
+{
+    Write-Host "Removing temp settings file"
+    Remove-Item $runSettingsFile
 }

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 41
+        "Patch": 42
     },
     "demands": [
     ],

--- a/Tasks/RunDistributedTests/task.loc.json
+++ b/Tasks/RunDistributedTests/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 41
+    "Patch": 42
   },
   "demands": [],
   "minimumAgentVersion": "1.104.0",


### PR DESCRIPTION
Problem: Currently default working directory for RunFunctionalTests task on remote test agents is temp directory and the test settigns file is created there. Therefore, if any deployment items are specified within the test settings file with relative path, they are searched within the temp and not in the test drop location.

Issue Link: https://github.com/Microsoft/vsts-tasks/issues/1638

Fix: Checking if the path of depoyment items is not absolute and then prefixing them with test drop location, generating absolute path in the process.

Testing: Manual