### PR TITLE
Fixing Run Functional Test Task

### DIFF
--- a/Tasks/RunDistributedTests/RunDistributedTests.ps1
+++ b/Tasks/RunDistributedTests/RunDistributedTests.ps1
@@ -24,6 +24,35 @@ Function CmdletHasMember($memberName) {
     return $cmdletParameter
 }
 
+Function ModifyTestSettingsForDeploymentItems() {
+
+    if(!([System.String]::IsNullOrWhiteSpace($runSettingsFile)) -And !(Test-Path $runSettingsFile -pathtype container) -And ([string]::Compare([io.path]::GetExtension($runSettingsFile), ".testsettings", $True) -eq 0))
+    {
+        $runSettingsContent = [System.Xml.XmlDocument](Get-Content $runSettingsFile)
+			$runConfigurationElement = $runSettingsContent.SelectNodes("/*/*/*[local-name()='DeploymentItem']")
+            
+            For ($index=0; $index -lt $runConfigurationElement.Count; $index++)
+            {
+                if (!([string]::IsNullOrEmpty($runConfigurationElement[$index].Attributes["filename"].Value)))
+                {
+                    if (!([io.path]::IsPathRooted($runConfigurationElement[$index].Attributes["filename"].Value)))
+                    {
+                        $runConfigurationElement[$index].Attributes["filename"].Value = [io.path]::Combine($dropLocation, $runConfigurationElement[$index].Attributes["filename"].Value);                        
+                    }
+                }
+                
+            }
+            
+            $tempFile = [io.path]::GetTempFileName()
+            $runSettingsContent.Save($tempFile)
+            Write-Verbose "Temporary runsettings file created at $tempFile"
+            return $tempFile
+        
+    }    
+
+    return 	$runSettingsFile
+}
+
 Write-Verbose "Entering script RunDistributedTests.ps1"
 Write-Verbose "TestMachineGroup = $testMachineGroup"
 Write-Verbose "Test Drop Location = $dropLocation"
@@ -52,6 +81,9 @@ $currentDirectory = Convert-Path .
 $unregisterTestAgentScriptLocation = Join-Path -Path $currentDirectory -ChildPath "TestAgentUnRegistration.ps1"
 $checkTaCompatScriptLocation = Join-Path -Path $currentDirectory -ChildPath "CheckTestAgentCompat.ps1"
 Write-Verbose "UnregisterTestAgent script Path  = $unRegisterTestAgentLocation"
+
+Write-Verbose "Checking test settings for deployment items"
+$runSettingsFile = ModifyTestSettingsForDeploymentItems
 
 Write-Verbose "Calling Invoke-RunDistributedTests"
 
@@ -171,4 +203,10 @@ else
             throw
         }
     }
+}
+
+if (([string]::Compare([io.path]::GetExtension($runSettingsFile), ".tmp", $True) -eq 0))
+{
+    Write-Host "Removing temp settings file"
+    Remove-Item $runSettingsFile
 }

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 41
+        "Patch": 42
     },
     "demands": [
     ],

--- a/Tasks/RunDistributedTests/task.loc.json
+++ b/Tasks/RunDistributedTests/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 41
+    "Patch": 42
   },
   "demands": [],
   "minimumAgentVersion": "1.104.0",


### PR DESCRIPTION
Problem: Currently default working directory for RunFunctionalTests task on remote test agents is temp directory and the test settigns file is created there. Therefore, if any deployment items are specified within the test settings file with relative path, they are searched within the temp and not in the test drop location.

Issue Link: #1638 

Fix: Checking if the path of depoyment items is not absolute and then prefixing them with test drop location, generating absolute path in the process.

Testing: Manual