### PR TITLE
JenkinsQueueJob: download and extract results

### DIFF
--- a/Tasks/JenkinsQueueJob/externals.json
+++ b/Tasks/JenkinsQueueJob/externals.json
@@ -1,0 +1,9 @@
+{
+    "archivePackages": [
+        {
+            "archiveName": "7zip.zip",
+            "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip",
+            "dest": "./"
+        }
+    ]
+}

--- a/Tasks/JenkinsQueueJob/jenkinsqueuejobtask.ts
+++ b/Tasks/JenkinsQueueJob/jenkinsqueuejobtask.ts
@@ -43,6 +43,9 @@ export class TaskOptions {
     teamJobQueueUrl: string = util.addUrlSegment(this.serverEndpointUrl, '/team-build/build/' + this.jobName + '?delay=0sec');
     teamPluginUrl: string = util.addUrlSegment(this.serverEndpointUrl, '/pluginManager/available');
 
+    teamBuildPluginAvailable: boolean = false;
+    saveResultsTo: string = path.join(tl.getVariable('Build.StagingDirectory'), 'jenkinsResults');
+
     strictSSL: boolean = ("true" !== tl.getEndpointDataParameter(this.serverEndpoint, "acceptUntrustedCerts", true));
 
     NO_CRUMB: string = 'NO_CRUMB';

--- a/Tasks/JenkinsQueueJob/jobqueue.ts
+++ b/Tasks/JenkinsQueueJob/jobqueue.ts
@@ -83,7 +83,7 @@ export class JobQueue {
         var running = [];
         for (var i in this.allJobs) {
             var job = this.allJobs[i];
-            if (job.state == JobState.Streaming || job.state == JobState.Finishing) {
+            if (job.state == JobState.Streaming || job.state==JobState.Downloading || job.state == JobState.Finishing) {
                 running.push(job);
             }
         }

--- a/Tasks/JenkinsQueueJob/package.json
+++ b/Tasks/JenkinsQueueJob/package.json
@@ -2,6 +2,6 @@
   "name": "vsts-tasks-jenkinsqueuejob",
   "dependencies": {
     "request": "^2.65.0",
-    "vsts-task-lib": "0.8.3"
+    "vsts-task-lib": "0.8.5"
   }
 }

--- a/Tasks/JenkinsQueueJob/task.json
+++ b/Tasks/JenkinsQueueJob/task.json
@@ -13,8 +13,8 @@
     "demands": [],
     "version": {
         "Major": 1,
-        "Minor": 0,
-        "Patch": 7
+        "Minor": 1,
+        "Patch": 0
     },
     "groups": [
         {

--- a/Tasks/JenkinsQueueJob/task.loc.json
+++ b/Tasks/JenkinsQueueJob/task.loc.json
@@ -13,8 +13,8 @@
   "demands": [],
   "version": {
     "Major": 1,
-    "Minor": 0,
-    "Patch": 7
+    "Minor": 1,
+    "Patch": 0
   },
   "groups": [
     {

--- a/Tasks/JenkinsQueueJob/unzip.ts
+++ b/Tasks/JenkinsQueueJob/unzip.ts
@@ -1,0 +1,71 @@
+
+import tl = require('vsts-task-lib/task');
+import tr = require('vsts-task-lib/toolrunner');
+
+import path = require('path');
+
+import unzip = require('./unzip');
+
+import * as Util from './util';
+
+
+var win = tl.osType().match(/^Win/);
+tl.debug('win: ' + win);
+
+// extractors
+var xpUnzipLocation: string = win ? null : xpUnzipLocation = tl.which('unzip', false);
+var winSevenZipLocation: string = path.join(__dirname, '7zip/7z.exe');
+
+export function unzip(file: string, destinationFolder: string) {
+    if (win) {
+        sevenZipExtract(file, destinationFolder);
+    } else {
+        unzipExtract(file, destinationFolder);
+    }
+}
+
+function unzipExtract(file: string, destinationFolder: string) {
+    tl.debug('Extracting file: ' + file);
+    if (typeof xpUnzipLocation == "undefined") {
+        xpUnzipLocation = tl.which('unzip', true);
+    }
+    var unzip = tl.createToolRunner(xpUnzipLocation);
+    unzip.arg(file);
+    unzip.arg('-d');
+    unzip.arg(destinationFolder);
+
+    return handleExecResult(unzip.execSync(getOptions()), file);
+}
+
+function sevenZipExtract(file: string, destinationFolder: string) {
+    tl.debug('Extracting file: ' + file);
+    var sevenZip = tl.createToolRunner(winSevenZipLocation);
+    sevenZip.arg('x');
+    sevenZip.arg('-o' + destinationFolder);
+    sevenZip.arg(file);
+    return handleExecResult(sevenZip.execSync(getOptions()), file);
+}
+
+function handleExecResult(execResult: tr.IExecResult, file: string) {
+    if (execResult.code != tl.TaskResult.Succeeded) {
+        tl.debug('execResult: ' + JSON.stringify(execResult));
+        var message = 'Extraction failed for file: ' + file +
+            '\ncode: ' + execResult.code +
+            '\nstdout: ' + execResult.stdout +
+            '\nstderr: ' + execResult.stderr +
+            '\nerror: ' + execResult.error;
+        throw new UnzipError(message);
+    }
+}
+
+function getOptions(): tr.IExecOptions {
+    var execOptions: tr.IExecOptions = {
+        silent: true,
+        outStream: new Util.StringWritable({ decodeStrings: false }),
+        errStream: new Util.StringWritable({ decodeStrings: false }),
+    };
+    return execOptions;
+}
+
+export class UnzipError extends Error {
+}


### PR DESCRIPTION
Added new capability to download and extract team-results.zip from the TFS Jenkins plugin if it is available.  This is done via 7zip on windows or unzip on Linux/mac.  Each Jenkins Job in the pipeline may have its own set of results which if they exist will be downloaded to $(Build.StagingDirectory)/jenkinsResults/jobName/team-results.zip, and then extracted to the same folder. 

 If the TFS Jenkins plugin is not available, there is no change.