### PR TITLE
Protect UserName from shell interpretation in WindowsMachineFileCopy Task

### DIFF
--- a/Tasks/WindowsMachineFileCopy/RoboCopyJob.ps1
+++ b/Tasks/WindowsMachineFileCopy/RoboCopyJob.ps1
@@ -173,7 +173,7 @@ param (
         $command = "net use `"$machineShare`""
         if($userName)
         {
-            $command += " /user:`"$userName`" `'$($password -replace "['`]", '$&$&')`'"
+            $command += " /user:`'$userName`' `'$($password -replace "['`]", '$&$&')`'"
         }
         $command += " 2>&1"
         


### PR DESCRIPTION
If the username has an interpretable symbol like **$**... the RoboCopy.ps1 replace **$**... by the environment variable.

For example, if the user account is "admin$user" the script will try to mount the drive (net use ...) with the account admin instead of admin**$user**. 
