### PR TITLE
nuget-task-common: Negate hasOwnProperty check

### DIFF
--- a/Tasks/Common/nuget-task-common/NuGetToolRunner.ts
+++ b/Tasks/Common/nuget-task-common/NuGetToolRunner.ts
@@ -24,7 +24,7 @@ function prepareNuGetExeEnvironment(
     let env: EnvironmentDictionary = {};
     let originalCredProviderPath: string;
     for (let e in input) {
-        if(input.hasOwnProperty(e)) {
+        if (!input.hasOwnProperty(e)) {
             continue;
         }
         // NuGet.exe extensions only work with a single specific version of nuget.exe. This causes problems

--- a/Tasks/NuGetInstaller/task.json
+++ b/Tasks/NuGetInstaller/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 14
+        "Patch": 15
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NuGetInstaller/task.loc.json
+++ b/Tasks/NuGetInstaller/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 14
+    "Patch": 15
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [

--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 14
+        "Patch": 15
     },
     "demands": [
         "Cmd"

--- a/Tasks/NugetPublisher/task.loc.json
+++ b/Tasks/NugetPublisher/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 14
+    "Patch": 15
   },
   "demands": [
     "Cmd"


### PR DESCRIPTION
All environment variables are getting filtered out when running nuget.exe due to an incorrect check.

@zjrunner 