### PR TITLE
Provide better error message if app parameter file is directory

### DIFF
--- a/Tasks/ServiceFabricDeploy/deploy.ps1
+++ b/Tasks/ServiceFabricDeploy/deploy.ps1
@@ -89,6 +89,7 @@ try {
     elseif ($publishProfile)
     {
         $applicationParameterFile = $publishProfile.ApplicationParameterFile
+        Assert-VstsPath -LiteralPath $applicationParameterFile -PathType Leaf
     }
     else
     {

--- a/Tasks/ServiceFabricDeploy/task.json
+++ b/Tasks/ServiceFabricDeploy/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [

--- a/Tasks/ServiceFabricDeploy/task.loc.json
+++ b/Tasks/ServiceFabricDeploy/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "1.95.0",
   "groups": [


### PR DESCRIPTION
Users ran into a [confusing error message](http://stackoverflow.com/questions/39392682/issue-with-service-fabric-applicaiton-deployment-task-in-visual-studio-team-stud?stw=2) "Access to the path is denied" when they specified a folder instead of a file.

They should now see a message like "Leaf path not found" which is better and consistent with other asserts.