### PR TITLE
Fix "Executable script code found in signature block" error on deploy

### DIFF
--- a/Tasks/AzureRmWebAppDeployment/Utility.ps1
+++ b/Tasks/AzureRmWebAppDeployment/Utility.ps1
@@ -299,7 +299,7 @@ function Update-DeploymentStatus
             $securePwd = ConvertTo-SecureString $azureRMWebAppConnectionDetails.UserPassword -AsPlainText -Force
             $credential = New-Object System.Management.Automation.PSCredential ($username, $securePwd)
 
-            # Get autor of build or release
+            ### Get author of build or release
             $author = Get-VstsTaskVariable -Name "build.sourceVersionAuthor"
             if([string]::IsNullOrEmpty($author)) {
                 # fall back to build/release requestedfor


### PR DESCRIPTION
For some reason, the single hash makes this script un-runnable. Adding one or more to this line fixes it. Also, I'm assuming "autor" means "author"? If so, also fixed the spelling.
