### PR TITLE
ArchiveFiles: fails with file and no root folder

### DIFF
--- a/Tasks/ArchiveFiles/archivefiles.ts
+++ b/Tasks/ArchiveFiles/archivefiles.ts
@@ -59,12 +59,20 @@ function makeAbsolute(normalizedPath: string): string {
 }
 
 function getOptions() {
+    var dirName: string;
     if (includeRootFolder) {
-        tl.debug("cwd (include root folder)= " + path.dirname(rootFolder));
-        return { cwd: path.dirname(rootFolder) };
+        dirName = path.dirname(rootFolder);
+        tl.debug("cwd (include root folder)= " + dirName);
+        return { cwd: dirName };
     } else {
-        tl.debug("cwd (exclude root folder)= " + rootFolder);
-        return { cwd: rootFolder };
+        var stats: tl.FsStats = tl.stats(rootFolder);
+        if (stats.isFile) {
+            dirName = path.dirname(rootFolder);
+        } else {
+            dirName = rootFolder;
+        }
+        tl.debug("cwd (exclude root folder)= " + dirName);
+        return { cwd: dirName };
     }
 }
 
@@ -260,7 +268,7 @@ function doWork() {
         if (tl.exist(archiveFile)) {
             if (replaceExistingArchive) {
                 try {
-                    var stats = tl.stats(archiveFile);
+                    var stats: tl.FsStats = tl.stats(archiveFile);
                     if (stats.isFile) {
                         console.log('removing existing archive file before creation: ' + archiveFile);
                     } else {

--- a/Tasks/ArchiveFiles/package.json
+++ b/Tasks/ArchiveFiles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ArchiveFiles",
-  "version": "1.0.1",
+  "version": "1.0.5",
   "description": "Archive Files Task",
   "main": "archivefilestask.js",
   "repository": {

--- a/Tasks/ArchiveFiles/task.json
+++ b/Tasks/ArchiveFiles/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "groups": [
         {

--- a/Tasks/ArchiveFiles/task.loc.json
+++ b/Tasks/ArchiveFiles/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 4
+    "Patch": 5
   },
   "groups": [
     {


### PR DESCRIPTION
If the specified folder to create is a file, and the do not include root folder option is set, then the task was failing because it was attempting set the current working directory the file instead of its parent directory.