### PR TITLE
Get version info from vstest.console.exe instead of devenv.exe

### DIFF
--- a/Tasks/VsTest/Helpers.ps1
+++ b/Tasks/VsTest/Helpers.ps1
@@ -57,7 +57,7 @@ function IsVisualStudio2015Update1OrHigherInstalled {
 		$teModesDll = [io.path]::Combine("$env:VS140COMNTools", "..", "IDE", "CommonExtensions", "Microsoft", "TestWindow", "TE.TestModes.dll");
 		if(Test-Path -Path $teModesDll)
 		{
-			$devenvExe = [io.path]::Combine("$env:VS140COMNTools", "..", "IDE", "devenv.exe");
+			$devenvExe = [io.path]::Combine("$env:VS140COMNTools", "..", "IDE", "CommonExtensions", "Microsoft", "TestWindow", "vstest.console.exe");
 			$devenvVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($devenvExe);
 			if($devenvVersion.ProductBuildPart -lt 25420) #update3 build#
 			{

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 60
+        "Patch": 61
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 60
+    "Patch": 61
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
On build servers where the VS Test Tools are installed, but Visual Studio itself is not, you cannot use  `devenv.exe` to check for the Visual Studio version number because `devenv.exe` is not available.

`vstest.console.exe`, however, is available, so use that executable to get the VS version number.

Fixes #2524

/cc @allendm-msft ; 98cb01d41f51600735588ccbbd3d035d96d21a43 broke my build server and this should fix it :)
