### PR TITLE
Improve performance of downloading previous artifact

### DIFF
--- a/Tasks/ServiceFabricUpdateAppVersions/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ServiceFabricUpdateAppVersions/Strings/resources.resjson/en-US/resources.resjson
@@ -25,6 +25,8 @@
   "loc.messages.BuildNumberNotSpecified": "Build Number cannot be null or empty.",
   "loc.messages.VstsRestApiFailed": "Failed to communicate with VSTS: {0}",
   "loc.messages.DownloadingArtifact": "Downloading artifact '{0}'...",
+  "loc.messages.DownloadingArtifactProgress": "Progress update: '{0}' bytes received...",
+  "loc.messages.FinishedDownloadingArtifact": "Finished downloading artifact '{0}'.",
   "loc.messages.UnrecognizedArtifactType": "Unrecognized artifact type '{0}'",
   "loc.messages.PreviousBuildNumberLabel": "Previous build number: '{0}'",
   "loc.messages.PreviousBuildLocationLabel": "Previous build location: '{0}'",

--- a/Tasks/ServiceFabricUpdateAppVersions/task.json
+++ b/Tasks/ServiceFabricUpdateAppVersions/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 4
+        "Patch": 5
     },
     "minimumAgentVersion": "1.95.0",
     "instanceNameFormat": "Update Service Fabric App Versions",
@@ -97,6 +97,8 @@
         "BuildNumberNotSpecified": "Build Number cannot be null or empty.",
         "VstsRestApiFailed": "Failed to communicate with VSTS: {0}",
         "DownloadingArtifact": "Downloading artifact '{0}'...",
+        "DownloadingArtifactProgress": "Progress update: '{0}' bytes received...",
+        "FinishedDownloadingArtifact": "Finished downloading artifact '{0}'.",
         "UnrecognizedArtifactType": "Unrecognized artifact type '{0}'",
         "PreviousBuildNumberLabel": "Previous build number: '{0}'",
         "PreviousBuildLocationLabel": "Previous build location: '{0}'",

--- a/Tasks/ServiceFabricUpdateAppVersions/task.loc.json
+++ b/Tasks/ServiceFabricUpdateAppVersions/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 4
+    "Patch": 5
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -97,6 +97,8 @@
     "BuildNumberNotSpecified": "ms-resource:loc.messages.BuildNumberNotSpecified",
     "VstsRestApiFailed": "ms-resource:loc.messages.VstsRestApiFailed",
     "DownloadingArtifact": "ms-resource:loc.messages.DownloadingArtifact",
+    "DownloadingArtifactProgress": "ms-resource:loc.messages.DownloadingArtifactProgress",
+    "FinishedDownloadingArtifact": "ms-resource:loc.messages.FinishedDownloadingArtifact",
     "UnrecognizedArtifactType": "ms-resource:loc.messages.UnrecognizedArtifactType",
     "PreviousBuildNumberLabel": "ms-resource:loc.messages.PreviousBuildNumberLabel",
     "PreviousBuildLocationLabel": "ms-resource:loc.messages.PreviousBuildLocationLabel",


### PR DESCRIPTION
A customer ran into a failure for a 59MB drop.  I tested my fix on a 69MB zip file and it went from over 5 minutes (and failing) to about 50 seconds