### PR TITLE
Discontinue Code Coverage enable support for Ant builds

### DIFF
--- a/Tasks/ANT/anttask.ts
+++ b/Tasks/ANT/anttask.ts
@@ -110,90 +110,6 @@ function readJavaHomeFromRegistry(jdkVersion: string, arch: string): string {
 
 async function doWork() {
 
-    function execEnableCodeCoverage(): Q.Promise<string> {
-        return enableCodeCoverage()
-            .then(function (resp) {
-                tl.debug("Enabled code coverage successfully");
-                return "CodeCoverage_9064e1d0";
-            }).catch(function (err) {
-                tl.warning("Failed to enable code coverage: " + err);
-                return "";
-            });
-    };
-
-    function enableCodeCoverage(): Q.Promise<any> {
-        if (!isCodeCoverageOpted) {
-            return Q.resolve(true);
-        }
-
-        var classFilter: string = tl.getInput('classFilter');
-        var classFilesDirectories: string = tl.getInput('classFilesDirectories', true);
-        var sourceDirectories: string = tl.getInput('srcDirectories');
-        // appending with small guid to keep it unique. Avoiding full guid to ensure no long path issues.
-        var reportDirectoryName = "CCReport43F6D5EF";
-        reportDirectory = path.join(buildRootPath, reportDirectoryName);
-        var reportBuildFileName = "CCReportBuildA4D283EG.xml";
-        reportBuildFile = path.join(buildRootPath, reportBuildFileName);
-        var summaryFileName = "coverage.xml";
-        summaryFile = path.join(buildRootPath, reportDirectoryName);
-        summaryFile = path.join(summaryFile, summaryFileName);
-        var coberturaCCFile = path.join(buildRootPath, "cobertura.ser");
-        var instrumentedClassesDirectory = path.join(buildRootPath, "InstrumentedClasses");
-
-        // clean any previous reports.
-        try {
-            tl.rmRF(coberturaCCFile, true);
-            tl.rmRF(reportDirectory, true);
-            tl.rmRF(reportBuildFile, true);
-            tl.rmRF(instrumentedClassesDirectory, true);
-        } catch (err) {
-            tl.debug("Error removing previous cc files: " + err);
-        }
-
-        var buildProps: { [key: string]: string } = {};
-        buildProps['buildfile'] = antBuildFile;
-        buildProps['classfilter'] = classFilter
-        buildProps['classfilesdirectories'] = classFilesDirectories;
-        buildProps['sourcedirectories'] = sourceDirectories;
-        buildProps['summaryfile'] = summaryFileName;
-        buildProps['reportdirectory'] = reportDirectory;
-        buildProps['ccreporttask'] = "CodeCoverage_9064e1d0"
-        buildProps['reportbuildfile'] = reportBuildFile;
-
-        let ccEnabler = new CodeCoverageEnablerFactory().getTool("ant", ccTool.toLowerCase());
-        return ccEnabler.enableCodeCoverage(buildProps);
-    }
-
-    function publishCodeCoverage(codeCoverageOpted: boolean, ccReportTask: string) {
-        if (codeCoverageOpted && ccReportTask) {
-            tl.debug("Collecting code coverage reports");
-            var antRunner = tl.tool(anttool);
-            antRunner.arg('-buildfile');
-            if (pathExistsAsFile(reportBuildFile)) {
-                antRunner.arg(reportBuildFile);
-                antRunner.arg(ccReportTask);
-            }
-            else {
-                antRunner.arg(antBuildFile);
-                antRunner.arg(ccReportTask);
-            }
-            antRunner.exec().then(function (code) {
-                if (pathExistsAsFile(summaryFile)) {
-                    tl.debug("Summary file = " + summaryFile);
-                    tl.debug("Report directory = " + reportDirectory);
-                    tl.debug("Publishing code coverage results to TFS");
-                    var ccPublisher = new tl.CodeCoveragePublisher();
-                    ccPublisher.publish(ccTool, summaryFile, reportDirectory, "");
-                }
-                else {
-                    tl.warning("No code coverage results found to be published. This could occur if there were no tests executed or there was a build failure. Check the ant output for details.");
-                }
-            }).fail(function (err) {
-                tl.warning("No code coverage results found to be published. This could occur if there were no tests executed or there was a build failure. Check the ant output for details.");
-            });
-        }
-    }
-
     try {
         var anttool = tl.which('ant', true);
         var antv = tl.tool(anttool);
@@ -263,15 +179,12 @@ async function doWork() {
         var ccTool = tl.getInput('codeCoverageTool');
         var isCodeCoverageOpted = (typeof ccTool != "undefined" && ccTool && ccTool.toLowerCase() != 'none');
         var buildRootPath = path.dirname(antBuildFile);
-        
-        var summaryFile: string = null;
-        var reportDirectory: string = null;
-        var ccReportTask: string = null;
-        var reportBuildFile: string = null;
         var publishJUnitResults = tl.getInput('publishJUnitResults');
         var testResultsFiles = tl.getInput('testResultsFiles', true);
 
-        ccReportTask = await execEnableCodeCoverage();
+        if(isCodeCoverageOpted){
+            tl.warning('We are discontinuing the support of Automated code coverage report generation for Ant projects. Please refer https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/ANT/README.md for more details.');
+        }
 
         await antv.exec();
         var buffer;
@@ -291,7 +204,6 @@ async function doWork() {
         antb.exec()
             .then(function (code) {
                 publishTestResults(publishJUnitResults, testResultsFiles);
-                publishCodeCoverage(isCodeCoverageOpted, ccReportTask);
                 tl.setResult(tl.TaskResult.Succeeded, "Task succeeded");
             })
             .fail(function (err) {

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 54
+        "Patch": 55
     },
     "demands": [
         "ant"
@@ -23,11 +23,6 @@
         {
             "name": "junitTestResults",
             "displayName": "JUnit Test Results",
-            "isExpanded": true
-        },
-        {
-            "name": "codeCoverage",
-            "displayName": "Code Coverage",
             "isExpanded": true
         },
         {
@@ -90,50 +85,6 @@
             "groupName": "junitTestResults",
             "helpMarkDown": "Provide a name for the test run.",
             "visibleRule": "publishJUnitResults = true"
-        },
-        {
-            "name": "codeCoverageTool",
-            "type": "pickList",
-            "label": "Code Coverage Tool",
-            "required": false,
-            "groupName": "codeCoverage",
-            "defaultValue": "None",
-            "helpMarkDown": "Select the code coverage tool. For on-premises agent support, refer to the `More Information` link below.",
-            "options": {
-                "None": "None",
-                "Cobertura": "Cobertura",
-                "JaCoCo": "JaCoCo"
-            }
-        },
-        {
-            "name": "classFilesDirectories",
-            "type": "string",
-            "label": "Class Files Directories",
-            "defaultValue": ".",
-            "required": true,
-            "groupName": "codeCoverage",
-            "helpMarkDown": "Comma-separated list of relative paths from the Ant build file to directories containing class files and archive files (JAR, WAR, etc.). Code coverage is reported for class files in these directories. For example: target/classes,target/testClasses.",
-            "visibleRule": "codeCoverageTool != None"
-        },
-        {
-            "name": "classFilter",
-            "type": "string",
-            "label": "Class Inclusion/Exclusion Filters",
-            "defaultValue": "",
-            "required": false,
-            "groupName": "codeCoverage",
-            "helpMarkDown": "Comma-separated list of filters to include or exclude classes from collecting code coverage. For example: +:com.*,+:org.*,-:my.app*.*.",
-            "visibleRule": "codeCoverageTool != None"
-        },
-        {
-            "name": "srcDirectories",
-            "type": "string",
-            "label": "Source Files Directories",
-            "defaultValue": "",
-            "required": false,
-            "groupName": "codeCoverage",
-            "helpMarkDown": "Comma-separated list of relative paths from the Ant build file to source code directories. Code coverage reports will use these to highlight source code. For example: src/java,src/Test.",
-            "visibleRule": "codeCoverageTool != None"
         },
         {
             "name": "antHomeUserInputPath",

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 54
+    "Patch": 55
   },
   "demands": [
     "ant"
@@ -23,11 +23,6 @@
     {
       "name": "junitTestResults",
       "displayName": "ms-resource:loc.group.displayName.junitTestResults",
-      "isExpanded": true
-    },
-    {
-      "name": "codeCoverage",
-      "displayName": "ms-resource:loc.group.displayName.codeCoverage",
       "isExpanded": true
     },
     {
@@ -90,50 +85,6 @@
       "groupName": "junitTestResults",
       "helpMarkDown": "ms-resource:loc.input.help.testRunTitle",
       "visibleRule": "publishJUnitResults = true"
-    },
-    {
-      "name": "codeCoverageTool",
-      "type": "pickList",
-      "label": "ms-resource:loc.input.label.codeCoverageTool",
-      "required": false,
-      "groupName": "codeCoverage",
-      "defaultValue": "None",
-      "helpMarkDown": "ms-resource:loc.input.help.codeCoverageTool",
-      "options": {
-        "None": "None",
-        "Cobertura": "Cobertura",
-        "JaCoCo": "JaCoCo"
-      }
-    },
-    {
-      "name": "classFilesDirectories",
-      "type": "string",
-      "label": "ms-resource:loc.input.label.classFilesDirectories",
-      "defaultValue": ".",
-      "required": true,
-      "groupName": "codeCoverage",
-      "helpMarkDown": "ms-resource:loc.input.help.classFilesDirectories",
-      "visibleRule": "codeCoverageTool != None"
-    },
-    {
-      "name": "classFilter",
-      "type": "string",
-      "label": "ms-resource:loc.input.label.classFilter",
-      "defaultValue": "",
-      "required": false,
-      "groupName": "codeCoverage",
-      "helpMarkDown": "ms-resource:loc.input.help.classFilter",
-      "visibleRule": "codeCoverageTool != None"
-    },
-    {
-      "name": "srcDirectories",
-      "type": "string",
-      "label": "ms-resource:loc.input.label.srcDirectories",
-      "defaultValue": "",
-      "required": false,
-      "groupName": "codeCoverage",
-      "helpMarkDown": "ms-resource:loc.input.help.srcDirectories",
-      "visibleRule": "codeCoverageTool != None"
     },
     {
       "name": "antHomeUserInputPath",

--- a/Tests/L0/Common-CodeCoverageEnabler/_suite.ts
+++ b/Tests/L0/Common-CodeCoverageEnabler/_suite.ts
@@ -11,7 +11,7 @@ import tl = require('../../lib/vsts-task-lib/toolRunner');
 // Paths aren't the same between compile time and run time. This will need some work
 let realrequire = require;
 function myrequire(module: string): any {
-    return realrequire(path.join(__dirname, "../../../Tasks/Ant/node_modules", module));
+    return realrequire(path.join(__dirname, "../../../Tasks/Maven/node_modules", module));
 }
 require = <typeof require>myrequire;
 import { CodeCoverageEnablerFactory } from 'codecoverage-tools/codecoveragefactory';
@@ -188,38 +188,6 @@ describe('Code Coverage enable tool tests', function () {
             assert.notEqual(content.indexOf(`cobertura.coverageIncludes = ['.*com.abc']`), -1, "Include filter must be present");
             assert.notEqual(content.indexOf(`cobertura.coverageExcludes = ['.*com.xyz']`), -1, "Exclude filter must be present");
             assert.notEqual(content.indexOf(`net.saliman:gradle-cobertura-plugin`), -1, "Cobertura Plugin must be present");
-            done();
-        }).catch(function (err) {
-            done(err);
-        });
-    })
-
-    /* Ant build tool - Code Coverage */
-    it('Ant build file with Jacoco CC', (done) => {
-        let buildFile = path.join(data, "ant_build.xml");
-        buildProps['buildfile'] = buildFile;
-
-        let ccEnabler = new CodeCoverageEnablerFactory().getTool("ant", "jacoco");
-        ccEnabler.enableCodeCoverage(buildProps).then(function (resp) {
-            let content = fs.readFileSync(buildFile, "utf-8");
-            assert.notEqual(content.indexOf(`excludes="**/com/xyz.class"`), -1, "Exclude filter must be present");
-            assert.notEqual(content.indexOf(`includes="**/com/abc.class"`), -1, "Include filter must be present");
-            assert.notEqual(content.indexOf(`jacoco:coverage destfile="jacoco.exec"`), -1, "Jacoco Plugin must be present");
-            done();
-        }).catch(function (err) {
-            done(err);
-        });
-    })
-
-    it('Ant build file with Cobertura CC', (done) => {
-        let buildFile = path.join(data, "ant_build.xml");
-        buildProps['buildfile'] = buildFile;
-
-        let ccEnabler = new CodeCoverageEnablerFactory().getTool("ant", "cobertura");
-        ccEnabler.enableCodeCoverage(buildProps).then(function (resp) {
-            let content = fs.readFileSync(buildFile, "utf-8");
-            assert.notEqual(fs.existsSync(path.join(data, buildProps['reportbuildfile'])), true, "Report file must be present");
-            assert.notEqual(content.indexOf(`cobertura-classpath`), -1, "Jacoco Plugin must be present");
             done();
         }).catch(function (err) {
             done(err);

--- a/common.json
+++ b/common.json
@@ -108,11 +108,5 @@
             "module": "codecoverage-tools",
             "dest": "node_modules"  
         }
-    ],
-    "Ant" : [
-        {
-            "module": "codecoverage-tools",
-            "dest": "node_modules"  
-        }
     ]
 }


### PR DESCRIPTION
* We will not be able to support Ant CC plugin due to technical issues/complexity of Ant build files
* Throw warning for existing build definitions if CC is already enabled
* New build definitions will not have option to enable the same