### PR TITLE
Removing testsettings modification method to maintain previous behaviour

### DIFF
--- a/Tasks/RunDistributedTests/RunDistributedTests.ps1
+++ b/Tasks/RunDistributedTests/RunDistributedTests.ps1
@@ -24,35 +24,6 @@ Function CmdletHasMember($memberName) {
     return $cmdletParameter
 }
 
-Function ModifyTestSettingsForDeploymentItems() {
-
-    if(!([System.String]::IsNullOrWhiteSpace($runSettingsFile)) -And !(Test-Path $runSettingsFile -pathtype container) -And ([string]::Compare([io.path]::GetExtension($runSettingsFile), ".testsettings", $True) -eq 0))
-    {
-        $runSettingsContent = [System.Xml.XmlDocument](Get-Content $runSettingsFile)
-			$runConfigurationElement = $runSettingsContent.SelectNodes("/*/*/*[local-name()='DeploymentItem']")
-            
-            For ($index=0; $index -lt $runConfigurationElement.Count; $index++)
-            {
-                if (!([string]::IsNullOrEmpty($runConfigurationElement[$index].Attributes["filename"].Value)))
-                {
-                    if (!([io.path]::IsPathRooted($runConfigurationElement[$index].Attributes["filename"].Value)))
-                    {
-                        $runConfigurationElement[$index].Attributes["filename"].Value = [io.path]::Combine($dropLocation, $runConfigurationElement[$index].Attributes["filename"].Value);                        
-                    }
-                }
-                
-            }
-            
-            $tempFile = [io.path]::GetTempFileName()
-            $runSettingsContent.Save($tempFile)
-            Write-Verbose "Temporary runsettings file created at $tempFile"
-            return $tempFile
-        
-    }    
-
-    return 	$runSettingsFile
-}
-
 Write-Verbose "Entering script RunDistributedTests.ps1"
 Write-Verbose "TestMachineGroup = $testMachineGroup"
 Write-Verbose "Test Drop Location = $dropLocation"
@@ -80,9 +51,6 @@ $currentDirectory = Convert-Path .
 $unregisterTestAgentScriptLocation = Join-Path -Path $currentDirectory -ChildPath "TestAgentUnRegistration.ps1"
 $checkTaCompatScriptLocation = Join-Path -Path $currentDirectory -ChildPath "CheckTestAgentCompat.ps1"
 Write-Verbose "UnregisterTestAgent script Path  = $unRegisterTestAgentLocation"
-
-Write-Verbose "Checking test settings for deployment items"
-$runSettingsFile = ModifyTestSettingsForDeploymentItems
 
 Write-Verbose "Calling Invoke-RunDistributedTests"
 

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 44
+        "Patch": 45
     },
     "demands": [
     ],

--- a/Tasks/RunDistributedTests/task.loc.json
+++ b/Tasks/RunDistributedTests/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 44
+    "Patch": 45
   },
   "demands": [],
   "minimumAgentVersion": "1.104.0",


### PR DESCRIPTION
This fix removes a previous fix for a github issue where we were modifying the test settings file for deployment items. There are some cases where this may break existing scenarios and hence reverting.

Testing: Manual