### PR TITLE
Adding support for custom adapters

### DIFF
--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 66
+        "Patch": 67
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 66
+    "Patch": 67
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -366,6 +366,21 @@ function getVstestTestsList(vsVersion: number): Q.Promise<string> {
     if (testFiltercriteria) {
         argsArray.push("/TestCaseFilter:" + testFiltercriteria);
     }
+    if (pathtoCustomTestAdapters) {
+        if (pathExistsAsDirectory(pathtoCustomTestAdapters)) {
+            argsArray.push("/TestAdapterPath:\"" + pathtoCustomTestAdapters + "\"");
+        }
+        else {
+            argsArray.push("/TestAdapterPath:\"" + path.dirname(pathtoCustomTestAdapters) + "\"");
+        }
+    }
+    else if (sourcesDirectory && isNugetRestoredAdapterPresent(sourcesDirectory)) {
+        argsArray.push("/TestAdapterPath:\"" + sourcesDirectory + "\"");
+    }
+
+    if ((otherConsoleOptions && otherConsoleOptions.toLowerCase().indexOf("usevsixextensions:true") != -1) || (pathtoCustomTestAdapters && pathtoCustomTestAdapters.toLowerCase().indexOf("usevsixextensions:true") != -1)){
+        argsArray.push("/UseVsixExtensions:true");
+    }
 
     try {
         vstestLocation = getVSTestLocation(vsVersion);


### PR DESCRIPTION
Problem: Currently the vstest task with TIA enabled doesnt support custom adapter or use of vsix extensions. This change enables it for TIA enabled builds

Testing: Manual