### PR TITLE
Fix value for Service Fabric upgrade mode

### DIFF
--- a/Tasks/ServiceFabricDeploy/task.json
+++ b/Tasks/ServiceFabricDeploy/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [

--- a/Tasks/ServiceFabricDeploy/task.loc.json
+++ b/Tasks/ServiceFabricDeploy/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "1.95.0",
   "groups": [

--- a/Tasks/ServiceFabricDeploy/utilities.ps1
+++ b/Tasks/ServiceFabricDeploy/utilities.ps1
@@ -237,7 +237,7 @@ function Get-VstsUpgradeParameters
 
     $upgradeMode = Get-VstsInput -Name upgradeMode -Require
 
-    $parameters[$upgradeMode] = $null
+    $parameters[$upgradeMode] = $true
 
     if ($upgradeMode -eq "Monitored")
     {


### PR DESCRIPTION
When I originally implemented this I was thinking of powershell switch parameters (which don't need a value), but since we pass in the hashtable of parameters as-is, we have to specify a boolean value. This fixes issue #2654 