### PR TITLE
Display incorrect port warning since it is a common mistake

### DIFF
--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/en-US/resources.resjson
@@ -50,6 +50,7 @@
   "loc.messages.PublishProfileRequiredServerThumbprint": "A server certificate thumbprint must be defined on the endpoint or a publish profile must be specified in the VSTS task.",
   "loc.messages.PublishProfileRequiredAppParams": "An application parameters file or a publish profile must be specified in the VSTS task.",
   "loc.messages.PublishProfileRequiredUpgrade": "Upgrade settings must be overridden or a publish profile must be specified in the VSTS task.",
+  "loc.messages.DefaultPortWarning": "The port '{0}' specified on your connection endpoint does not match the default ClientConnectionEndpoint of '19000'. This might have caused cluster communication failure.",
   "loc.messages.SFSDK_InvalidSFPackage": "{0} is not a valid Service Fabric application package.",
   "loc.messages.SFSDK_PackageValidationFailed": "Validation failed for package: {0}",
   "loc.messages.SFSDK_UnableToVerifyClusterConnection": "Unable to verify connection to Service Fabric cluster.",

--- a/Tasks/ServiceFabricDeploy/deploy.ps1
+++ b/Tasks/ServiceFabricDeploy/deploy.ps1
@@ -33,8 +33,9 @@ try {
         throw (Get-VstsLocString -Key ServiceFabricSDKNotInstalled)
     }
 
+    $connectionEndpointUrl = [System.Uri]$connectedServiceEndpoint.url
     # Override the publish profile's connection endpoint with the one defined on the associated service endpoint
-    $clusterConnectionParameters["ConnectionEndpoint"] = ([System.Uri]$connectedServiceEndpoint.url).Authority # Authority includes just the hostname and port
+    $clusterConnectionParameters["ConnectionEndpoint"] = $connectionEndpointUrl.Authority # Authority includes just the hostname and port
 
     # Configure cluster connection pre-reqs
     if ($connectedServiceEndpoint.Auth.Scheme -ne "None")
@@ -76,7 +77,17 @@ try {
     }
 
     # Connect to cluster
-    [void](Connect-ServiceFabricCluster @clusterConnectionParameters)
+    try {
+        [void](Connect-ServiceFabricCluster @clusterConnectionParameters)
+    }
+    catch {
+        if ($connectionEndpointUrl.Port -ne "19000") {
+            Write-Warning (Get-VstsLocString -Key DefaultPortWarning $connectionEndpointUrl.Port)
+        }
+
+        throw $_
+    }
+    
     Write-Host (Get-VstsLocString -Key ConnectedToCluster)
     
     . "$PSScriptRoot\ServiceFabricSDK\ServiceFabricSDK.ps1"

--- a/Tasks/ServiceFabricDeploy/task.json
+++ b/Tasks/ServiceFabricDeploy/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [
@@ -254,6 +254,7 @@
         "PublishProfileRequiredServerThumbprint": "A server certificate thumbprint must be defined on the endpoint or a publish profile must be specified in the VSTS task.",
         "PublishProfileRequiredAppParams": "An application parameters file or a publish profile must be specified in the VSTS task.",
         "PublishProfileRequiredUpgrade": "Upgrade settings must be overridden or a publish profile must be specified in the VSTS task.",
+        "DefaultPortWarning": "The port '{0}' specified on your connection endpoint does not match the default ClientConnectionEndpoint of '19000'. This might have caused cluster communication failure.",
         "SFSDK_InvalidSFPackage": "{0} is not a valid Service Fabric application package.",
         "SFSDK_PackageValidationFailed": "Validation failed for package: {0}",
         "SFSDK_UnableToVerifyClusterConnection": "Unable to verify connection to Service Fabric cluster.",

--- a/Tasks/ServiceFabricDeploy/task.loc.json
+++ b/Tasks/ServiceFabricDeploy/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "1.95.0",
   "groups": [
@@ -254,6 +254,7 @@
     "PublishProfileRequiredServerThumbprint": "ms-resource:loc.messages.PublishProfileRequiredServerThumbprint",
     "PublishProfileRequiredAppParams": "ms-resource:loc.messages.PublishProfileRequiredAppParams",
     "PublishProfileRequiredUpgrade": "ms-resource:loc.messages.PublishProfileRequiredUpgrade",
+    "DefaultPortWarning": "ms-resource:loc.messages.DefaultPortWarning",
     "SFSDK_InvalidSFPackage": "ms-resource:loc.messages.SFSDK_InvalidSFPackage",
     "SFSDK_PackageValidationFailed": "ms-resource:loc.messages.SFSDK_PackageValidationFailed",
     "SFSDK_UnableToVerifyClusterConnection": "ms-resource:loc.messages.SFSDK_UnableToVerifyClusterConnection",


### PR DESCRIPTION
Several users were incorrectly using the HttpGatewayEndpoint port of 19080 and customer support asked us to add a message so that users can hopefully fix this faster.