### PR TITLE
initial commit

### DIFF
--- a/Tasks/VsTest/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VsTest/Strings/resources.resjson/en-US/resources.resjson
@@ -40,7 +40,6 @@
   "loc.input.help.configuration": "Configuration against which the tests should be reported. If you have defined a variable for configuration in your build task, use that here.",
   "loc.input.label.publishRunAttachments": "Upload Test Attachments",
   "loc.input.help.publishRunAttachments": "Opt in/out of publishing test run level attachments.",
-  "loc.messages.AccessDeniedToPath": "%s path does not exist.",
   "loc.messages.PathDoesNotExist": "%s path does not exist.",
   "loc.messages.VstestReturnCode": "Vstest exited with return code: %d.",
   "loc.messages.NoMatchingTestAssemblies": "No test assemblies found matching the pattern: %s.",
@@ -59,7 +58,11 @@
   "loc.messages.ErrorWhileUpdatingResponseFile": "Error occurred while updating the response file '%s'. All the tests will be executed for this run.",
   "loc.messages.ErrorWhilePublishingCodeChanges": "Error occurred while publishing the code changes. All the tests will be executed for this run.",
   "loc.messages.ErrorWhileListingDiscoveredTests": "Error occured while discovering the tests. All the tests will be exexuted for this run.",
-  "loc.messages.PublishCodeChangesPerfTime": "Total time taken to publish code changes: %d milliseconds",
-  "loc.messages.GenerateResponseFilePerfTime": "Total time taken to get response file: %d milliseconds",
-  "loc.messages.UploadTestResultsPerfTime": "Total time taken to upload test results: %d milliseconds"
+  "loc.messages.PublishCodeChangesPerfTime": "Total time taken to publish code changes: %d milliseconds.",
+  "loc.messages.GenerateResponseFilePerfTime": "Total time taken to get response file: %d milliseconds.",
+  "loc.messages.UploadTestResultsPerfTime": "Total time taken to upload test results: %d milliseconds.",
+  "loc.messages.ErrorReadingVstestVersion": "Error reading the version of vstest.console.exe.",
+  "loc.messages.UnexpectedVersionString": "Unexpected version string detected for vstest.console.exe: %s.",
+  "loc.messages.UnexpectedVersionNumber": "Unexpected version number detected for vstest.console.exe: %s.",
+  "loc.messages.VstestDiagNotSupported": "vstest.console.exe version does not support the /diag flag. Enable diagnositics via the exe.config files"
 }

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 67
+        "Patch": 68
     },
     "demands": [
         "vstest"
@@ -240,8 +240,12 @@
         "ErrorWhileUpdatingResponseFile": "Error occurred while updating the response file '%s'. All the tests will be executed for this run.",
         "ErrorWhilePublishingCodeChanges": "Error occurred while publishing the code changes. All the tests will be executed for this run.",
         "ErrorWhileListingDiscoveredTests": "Error occured while discovering the tests. All the tests will be exexuted for this run.",
-        "PublishCodeChangesPerfTime": "Total time taken to publish code changes: %d milliseconds",
-        "GenerateResponseFilePerfTime": "Total time taken to get response file: %d milliseconds",
-        "UploadTestResultsPerfTime": "Total time taken to upload test results: %d milliseconds"
+        "PublishCodeChangesPerfTime": "Total time taken to publish code changes: %d milliseconds.",
+        "GenerateResponseFilePerfTime": "Total time taken to get response file: %d milliseconds.",
+        "UploadTestResultsPerfTime": "Total time taken to upload test results: %d milliseconds.",
+        "ErrorReadingVstestVersion": "Error reading the version of vstest.console.exe.",
+        "UnexpectedVersionString": "Unexpected version string detected for vstest.console.exe: %s.",
+        "UnexpectedVersionNumber": "Unexpected version number detected for vstest.console.exe: %s.",
+        "VstestDiagNotSupported": "vstest.console.exe version does not support the /diag flag. Enable diagnositics via the exe.config files"
     }
 }

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 67
+    "Patch": 68
   },
   "demands": [
     "vstest"
@@ -244,6 +244,10 @@
     "ErrorWhileListingDiscoveredTests": "ms-resource:loc.messages.ErrorWhileListingDiscoveredTests",
     "PublishCodeChangesPerfTime": "ms-resource:loc.messages.PublishCodeChangesPerfTime",
     "GenerateResponseFilePerfTime": "ms-resource:loc.messages.GenerateResponseFilePerfTime",
-    "UploadTestResultsPerfTime": "ms-resource:loc.messages.UploadTestResultsPerfTime"
+    "UploadTestResultsPerfTime": "ms-resource:loc.messages.UploadTestResultsPerfTime",
+    "ErrorReadingVstestVersion": "ms-resource:loc.messages.ErrorReadingVstestVersion",
+    "UnexpectedVersionString": "ms-resource:loc.messages.UnexpectedVersionString",
+    "UnexpectedVersionNumber": "ms-resource:loc.messages.UnexpectedVersionNumber",
+    "VstestDiagNotSupported": "ms-resource:loc.messages.VstestDiagNotSupported"
   }
 }

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -40,6 +40,7 @@ try {
     var sourcesDir = tl.getVariable('build.sourcesdirectory');
     var runIdFile = path.join(os.tmpdir(), uuid.v1() + ".txt");
     var baseLineBuildIdFile = path.join(os.tmpdir(), uuid.v1() + ".txt");
+    var vstestDiagFile = path.join(os.tmpdir(), uuid.v1() + ".txt");
     var useNewCollectorFlag = tl.getVariable('tia.useNewCollector');
 
     var useNewCollector = true;
@@ -60,24 +61,29 @@ try {
                             publishTestResults(resultsDirectory);
                         }
                         tl.setResult(code, tl.loc('VstestReturnCode', code));
+                        deleteVstestDiagFile();
                     }
                     catch (error) {
+                        deleteVstestDiagFile();
                         tl._writeLine("##vso[task.logissue type=error;code=" + error + ";TaskName=VSTest]");
                         throw error;
                     }
                 })
                 .fail(function (err) {
+                    deleteVstestDiagFile();
                     tl._writeLine("##vso[task.logissue type=error;code=" + err + ";TaskName=VSTest]");
                     throw err;
                 });
         });
     }
     else {
+        deleteVstestDiagFile();
         tl._writeLine("##vso[task.logissue type=warning;code=002004;]");
         tl.warning(tl.loc('NoMatchingTestAssemblies', testAssembly));
     }
 }
 catch (error) {
+    deleteVstestDiagFile();
     tl._writeLine("##vso[task.logissue type=error;code=" + error + ";TaskName=VSTest]");
     throw error;
 }
@@ -115,6 +121,42 @@ function getTestAssemblies(): Set<string> {
         });
     }
     return new Set(testAssemblyFiles);
+}
+
+function addVstestDiagOption(argsArray: string[]) {
+    let sysDebug = tl.getVariable("System.Debug");
+    if (sysDebug.toLowerCase() === "true") {
+        let vstestLocationEscaped = vstestLocation.replace(/\\/g, "\\\\");
+        let wmicTool = tl.createToolRunner("wmic");
+        let wmicArgs = ["datafile", "where", "name='".concat(vstestLocationEscaped, "'"), "get", "Version", "/Value"];
+        wmicTool.arg(wmicArgs);
+        let output = wmicTool.execSync();
+
+        let verSplitArray = output.stdout.split("=");
+        if (verSplitArray.length == 2) {
+            let versionArray = verSplitArray[1].split(".");
+            if (versionArray.length == 4) {
+                let productMajorPart = parseInt(versionArray[0]);
+                let productMinorPart = parseInt(versionArray[1]);
+                let productBuildPart = parseInt(versionArray[2]);
+
+                if (!isNaN(productMajorPart) && !isNaN(productMinorPart) && !isNaN(productBuildPart)) {
+                    if (productMajorPart > 15 || (productMajorPart == 15 && (productMinorPart > 0 || productBuildPart > 25428))) {
+                        argsArray.push("/diag:" + vstestDiagFile);
+                    } else {
+                        tl.warning(tl.loc("ErrorReadingVstestVersion"));
+                    }
+                } else {
+                    tl.warning(tl.loc("UnexpectedVersionNumber", verSplitArray[1]));
+                }
+
+            } else {
+                tl.warning(tl.loc("UnexpectedVersionString", output.stdout));
+            }
+        } else {
+            tl.warning(tl.loc("ErrorReadingVstestVersion"));
+        }
+    }
 }
 
 function getVstestArguments(settingsFile: string, tiaEnabled: boolean): string[] {
@@ -160,6 +202,7 @@ function getVstestArguments(settingsFile: string, tiaEnabled: boolean): string[]
     else if (sourcesDirectory && isNugetRestoredAdapterPresent(sourcesDirectory)) {
         argsArray.push("/TestAdapterPath:\"" + sourcesDirectory + "\"");
     }
+    addVstestDiagOption(argsArray);
     return argsArray;
 }
 
@@ -317,13 +360,6 @@ function getVSTestLocation(vsVersion: number): string {
 
 function executeVstest(testResultsDirectory: string, parallelRunSettingsFile: string, vsVersion: number, argsArray: string[]): Q.Promise<number> {
     var defer = Q.defer<number>();
-    try {
-        vstestLocation = getVSTestLocation(vsVersion);
-    } catch (e) {
-        tl.error(e.message);
-        defer.resolve(1);
-        return defer.promise;
-    }
     var vstest = tl.createToolRunner(vstestLocation);
     addVstestArgs(argsArray, vstest);
 
@@ -369,14 +405,6 @@ function getVstestTestsList(vsVersion: number): Q.Promise<string> {
         argsArray.push("/TestCaseFilter:" + testFiltercriteria);
     }
 
-    try {
-        vstestLocation = getVSTestLocation(vsVersion);
-    } catch (e) {
-        tl.error(e.message);
-        defer.resolve(e.message);
-        return defer.promise;
-    }
-
     var vstest = tl.createToolRunner(vstestLocation);
     addVstestArgs(argsArray, vstest);
 
@@ -394,12 +422,19 @@ function getVstestTestsList(vsVersion: number): Q.Promise<string> {
 }
 
 function cleanFiles(responseFile: string, listFile: string): void {
-    tl.debug("Deleting the response file" + responseFile);
+    tl.debug("Deleting the response file " + responseFile);
     tl.rmRF(responseFile, true);
-    tl.debug("Deleting the discovered tests file" + listFile);
+    tl.debug("Deleting the discovered tests file " + listFile);
     tl.rmRF(listFile, true);
-    tl.debug("Deleting the baseline build id file" + baseLineBuildIdFile);
+    tl.debug("Deleting the baseline build id file " + baseLineBuildIdFile);
     tl.rmRF(baseLineBuildIdFile, true);
+}
+
+function deleteVstestDiagFile(): void {
+    if (pathExistsAsFile(vstestDiagFile)) {
+        tl.debug("Deleting vstest diag file " + vstestDiagFile);
+        tl.rmRF(vstestDiagFile, true);
+    }
 }
 
 function runVStest(testResultsDirectory: string, settingsFile: string, vsVersion: number): Q.Promise<number> {
@@ -591,6 +626,13 @@ function invokeVSTest(testResultsDirectory: string): Q.Promise<number> {
         .then(function (overriddenSettingsFile) {
             locateVSVersion()
                 .then(function (vsVersion) {
+                    try {
+                        vstestLocation = getVSTestLocation(vsVersion);
+                    } catch (e) {
+                        tl.error(e.message);
+                        defer.resolve(1);
+                        return defer.promise;
+                    }
                     setupSettingsFileForTestImpact(vsVersion, overriddenSettingsFile)
                         .then(function (runSettingswithTestImpact) {
                             setRunInParallellIfApplicable(vsVersion);

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -650,7 +650,6 @@ function runVStest(testResultsDirectory: string, settingsFile: string, vsVersion
 }
 
 function invokeVSTest(testResultsDirectory: string): Q.Promise<number> {
-    var defer = Q.defer<number>();
     if (vsTestVersion.toLowerCase() == "latest") {
         vsTestVersion = null;
     }
@@ -662,7 +661,7 @@ function invokeVSTest(testResultsDirectory: string): Q.Promise<number> {
                         vstestLocation = getVSTestLocation(vsVersion);
                     } catch (e) {
                         tl.error(e.message);
-                        return defer.resolve(1);
+                        return Q.resolve(1);
                     }
                     setupSettingsFileForTestImpact(vsVersion, overriddenSettingsFile)
                         .then(function (runSettingswithTestImpact) {
@@ -671,33 +670,33 @@ function invokeVSTest(testResultsDirectory: string): Q.Promise<number> {
                                 .then(function (parallelRunSettingsFile) {
                                     runVStest(testResultsDirectory, parallelRunSettingsFile, vsVersion)
                                         .then(function (code) {
-                                            return defer.resolve(code);
+                                            return Q.resolve(code);
                                         })
                                         .fail(function (code) {
-                                            return defer.resolve(code);
+                                            return Q.resolve(code);
                                         });
                                 })
                                 .fail(function (err) {
                                     tl.error(err);
-                                    return defer.resolve(1);
+                                    return Q.resolve(1);
                                 });
                         })
                         .fail(function (err) {
                             tl.error(err);
-                            return defer.resolve(1);
+                            return Q.resolve(1);
                         });
                 })
                 .fail(function (err) {
                     tl.error(err);
-                    return defer.resolve(1);
+                    return Q.resolve(1);
                 });
         })
         .fail(function (err) {
             tl.error(err);
-            return defer.resolve(1);
+            return Q.resolve(1);
         });
 
-    return defer.promise;
+    return Q.resolve(0);
 }
 
 function publishTestResults(testResultsDirectory: string) {

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -138,7 +138,7 @@ function getTestAssemblies(): Set<string> {
 
 function addVstestDiagOption(argsArray: string[]) {
     let sysDebug = tl.getVariable("System.Debug");
-    if (sysDebug.toLowerCase() === "true") {
+    if (sysDebug !== undefined && sysDebug.toLowerCase() === "true") {
         let vstestLocationEscaped = vstestLocation.replace(/\\/g, "\\\\");
         let wmicTool = tl.createToolRunner("wmic");
         let wmicArgs = ["datafile", "where", "name='".concat(vstestLocationEscaped, "'"), "get", "Version", "/Value"];

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -696,7 +696,7 @@ function invokeVSTest(testResultsDirectory: string): Q.Promise<number> {
             return Q.resolve(1);
         });
 
-    return Q.resolve(0);
+    return Q.resolve(1);
 }
 
 function publishTestResults(testResultsDirectory: string) {

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -644,4 +644,44 @@ describe('VsTest Suite', function () {
                 done(err);
             });
     });
+
+    it('Vstest task should not use diag option when system.debug is not set', (done) => {
+        setResponseFile('vstestGood.json');
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('vstestLocationMethod', 'location');
+        tr.setInput('vstestLocation', '\\path\\to\\vstest\\directory');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('vsTestVersion', '14.0');
+        tr.run()
+            .then(() => {
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\path\\to\\vstest\\directory\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.indexOf('/diag') < 0, '/diag option should not be used for vstest.console.exe');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    });
+
+    it('Vstest task should not use diag option when system.debug is set to false', (done) => {
+        setResponseFile('vstestGood.json');
+        var tr = new trm.TaskRunner('VSTest');
+        tr.setInput('vstestLocationMethod', 'location');
+        tr.setInput('vstestLocation', '\\path\\to\\vstest\\directory');
+        tr.setInput('testAssembly', 'path/to/file');
+        tr.setInput('vsTestVersion', '14.0');
+        tr.run()
+            .then(() => {
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran('\\path\\to\\vstest\\directory\\vstest.console.exe path/to/file /logger:trx'), 'should have run vstest');
+                assert(tr.stdout.indexOf('/diag') < 0, '/diag option should not be used for vstest.console.exe');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    });
 });

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -666,7 +666,7 @@ describe('VsTest Suite', function () {
     });
 
     it('Vstest task should not use diag option when system.debug is set to false', (done) => {
-        setResponseFile('vstestGood.json');
+        setResponseFile('vstestGoodSysDebugFalse.json');
         var tr = new trm.TaskRunner('VSTest');
         tr.setInput('vstestLocationMethod', 'location');
         tr.setInput('vstestLocation', '\\path\\to\\vstest\\directory');

--- a/Tests/L0/VsTest/vstestGood.json
+++ b/Tests/L0/VsTest/vstestGood.json
@@ -3,7 +3,8 @@
         "System.DefaultWorkingDirectory": "/source/dir",
         "VS150COMNTools": "/vs/path",
         "VS140COMNTools": "/vs/path",
-        "VS120COMNTools": "/vs/path"
+        "VS120COMNTools": "/vs/path",
+        "System.Debug": false
     },
     "find": {
         "/source/dir": [

--- a/Tests/L0/VsTest/vstestGoodSysDebugFalse.json
+++ b/Tests/L0/VsTest/vstestGoodSysDebugFalse.json
@@ -3,7 +3,8 @@
         "System.DefaultWorkingDirectory": "/source/dir",
         "VS150COMNTools": "/vs/path",
         "VS140COMNTools": "/vs/path",
-        "VS120COMNTools": "/vs/path"
+        "VS120COMNTools": "/vs/path",
+        "System.Debug": "false"
     },
     "find": {
         "/source/dir": [


### PR DESCRIPTION
VSTest Task doesn't add `diag` when system.debug is true for typescript implementation.
Using wmic command to get the veriosn of vstest console executable and add the option accordingly.
Initial commit, will be adding tests
