### PR TITLE
Users/prmutn/find files legacy fix

### DIFF
--- a/Tasks/Common/find-files-legacy/findfiles.legacy.ts
+++ b/Tasks/Common/find-files-legacy/findfiles.legacy.ts
@@ -35,7 +35,7 @@ export function findFiles(pattern: any, includeDir: boolean, cwd?: string): stri
 
 function appendCwd(filterPattern: string[], cwd: string): string[] {
     let result: string[] = [];
-    filterPattern.forEach(p => p.startsWith('*') ? result.push(path.join(cwd, p)) : result.push(p));
+    filterPattern.forEach(p => result.push(path.isAbsolute(p) ? p : path.join(cwd, p)));
     return result;
 }
 

--- a/Tests/L0/Common-FindFiles-Legacy/_suite.ts
+++ b/Tests/L0/Common-FindFiles-Legacy/_suite.ts
@@ -70,31 +70,41 @@ describe('Code Coverage enable tool tests', function () {
     });
 
     it('Search recursively with include files', (done) => {
-        let test = ff.findFiles(['+:' + path.join(data, '**\\*.log')]);
+        let test = ff.findFiles(['+:' + path.join(data, '**', '*.log')]);
         assert(test.length === 4);
         done();
     });
 
     it('Search recursively with exclude files', (done) => {
-        let test = ff.findFiles([path.join(data, '**\\*'), '-:' + path.join(data, '**\\*.log')]);
+        let test = ff.findFiles([path.join(data, '**', '*'), '-:' + path.join(data, '**', '*.log')]);
         assert(test.length === 6);
         done();
     });
 
     it('Search recursively with include files and exclude files', (done) => {
-        let test = ff.findFiles(['+:' + path.join(data, '**\\*.log'), '-:' + path.join(data, '**\\a*')]);
+        let test = ff.findFiles(['+:' + path.join(data, '**', '*.log'), '-:' + path.join(data, '**', 'a*')]);
         assert(test.length === 2);
         done();
     });
 
     it('Search recursively with exclude files with ignore dir', (done) => {
-        let test = ff.findFiles([path.join(data, '**\\*'), '-:' + path.join(data, '**\\*.log')], true);
+        let test = ff.findFiles([path.join(data, '**', '*'), '-:' + path.join(data, '**', '*.log')], true);
         assert(test.length === 7);
         done();
     });
 
+    it('Search simple pattern (relative path) starting with ..', (done) => {
+        let relativePath = path.relative(process.cwd(), path.join(__dirname, 'data', '*.log'));
+        let test = ff.findFiles(relativePath);
+        assert(test.length === 2);
+        assert(test[0] === posixFormat(path.join(data, 'a.log')));
+        assert(test[1] === posixFormat(path.join(data, 'b.log')));
+        done();
+    });
+
     it('Search simple pattern (relative path)', (done) => {
-        let test = ff.findFiles('..\\_test\\Tests\\L0\\Common-FindFiles-Legacy\\data\\*.log');
+        let relativePath = path.relative(process.cwd(), path.join(__dirname, 'data', '*.log'));
+        let test = ff.findFiles(path.join('L0', '..' , relativePath));
         assert(test.length === 2);
         assert(test[0] === posixFormat(path.join(data, 'a.log')));
         assert(test[1] === posixFormat(path.join(data, 'b.log')));

--- a/Tests/L0/Common-FindFiles-Legacy/_suite.ts
+++ b/Tests/L0/Common-FindFiles-Legacy/_suite.ts
@@ -93,6 +93,14 @@ describe('Code Coverage enable tool tests', function () {
         done();
     });
 
+    it('Search simple pattern (relative path)', (done) => {
+        let test = ff.findFiles('..\\_test\\Tests\\L0\\Common-FindFiles-Legacy\\data\\*.log');
+        assert(test.length === 2, 'count should be 2');
+        assert(test[0] === posixFormat(path.join(data, 'a.log')));
+        assert(test[1] === posixFormat(path.join(data, 'b.log')));
+        done();
+    });
+
 });
 
 function posixFormat(p: string): string {

--- a/Tests/L0/Common-FindFiles-Legacy/_suite.ts
+++ b/Tests/L0/Common-FindFiles-Legacy/_suite.ts
@@ -95,7 +95,7 @@ describe('Code Coverage enable tool tests', function () {
 
     it('Search simple pattern (relative path)', (done) => {
         let test = ff.findFiles('..\\_test\\Tests\\L0\\Common-FindFiles-Legacy\\data\\*.log');
-        assert(test.length === 2, 'count should be 2');
+        assert(test.length === 2);
         assert(test[0] === posixFormat(path.join(data, 'a.log')));
         assert(test[1] === posixFormat(path.join(data, 'b.log')));
         done();


### PR DESCRIPTION
`abc\\*xyz` was recognized as an absolute path. It should be converted into `$(currentWorkingDirectory)\\abc\\*xyz`.

- fixed
- added test