### PR TITLE
Fix winrm command line for MaxEnvelopeSizeKb, surround key/value pair…

### DIFF
--- a/Tasks/PowerShellOnTargetMachines/ConfigureWinRM.ps1
+++ b/Tasks/PowerShellOnTargetMachines/ConfigureWinRM.ps1
@@ -150,7 +150,7 @@ winrm quickconfig
 
 # The default MaxEnvelopeSizekb on Windows Server is 500 Kb which is very less. It needs to be at 8192 Kb. The small envelop size if not changed
 # results in WS-Management service responding with error that the request size exceeded the configured MaxEnvelopeSize quota.
-winrm set winrm/config @{MaxEnvelopeSizekb = "8192"}
+winrm set winrm/config '@{MaxEnvelopeSizekb = "8192"}'
 
 # Validate script arguments
 if(-not (Is-InputValid -hostname $hostname))


### PR DESCRIPTION
… in single quotes.  This command was failing with the following error:
Error: Invalid use of command line. Type "winrm -?" for help.