### PR TITLE
Hotfix NuGet Tasks to handle differences on V1 agent (#2599)

### DIFF
--- a/Tasks/NuGetInstaller/nugetinstaller.ts
+++ b/Tasks/NuGetInstaller/nugetinstaller.ts
@@ -73,7 +73,7 @@ async function main(): Promise<void> {
         // locateNuGetExe() will strip them and check for existence there.
         let nuGetPath = tl.getPathInput("nuGetPath", false, false);
         let userNuGetProvided = false;
-        if(tl.filePathSupplied("nuGetPath")){
+        if(nuGetPath !== null && tl.filePathSupplied("nuGetPath")){
             nuGetPath = nutil.stripLeadingAndTrailingQuotes(nuGetPath);
             // True if the user provided their own version of NuGet
             userNuGetProvided = true;

--- a/Tasks/NuGetInstaller/task.json
+++ b/Tasks/NuGetInstaller/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 16
+        "Patch": 17
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NuGetInstaller/task.loc.json
+++ b/Tasks/NuGetInstaller/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 16
+    "Patch": 17
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [

--- a/Tasks/NugetPublisher/nugetpublisher.ts
+++ b/Tasks/NugetPublisher/nugetpublisher.ts
@@ -68,7 +68,7 @@ async function main(): Promise<void> {
         let nuGetPath = tl.getPathInput("nuGetPath", false, false);
         let nugetVersion = tl.getInput("nuGetversion");
         let userNuGetProvided = false;
-        if (tl.filePathSupplied("nuGetPath")) {
+        if (nuGetPath !== null && tl.filePathSupplied("nuGetPath")) {
             nuGetPath = nutil.stripLeadingAndTrailingQuotes(nuGetPath);
             userNuGetProvided = true;
             if (nugetVersion !== "custom")

--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 16
+        "Patch": 17
     },
     "demands": [
         "Cmd"

--- a/Tasks/NugetPublisher/task.loc.json
+++ b/Tasks/NugetPublisher/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 16
+    "Patch": 17
   },
   "demands": [
     "Cmd"


### PR DESCRIPTION
Same taken to 106 and master, but needed in 105 for TFS RTW.
The version here is conflicting with master, but this will be followed up with an updated nuget.exe 3.5 rtm at which point we'll ensure a unique 105 version (.19?) and then also upgrade master to a higher version (.20?) to avoid overlap confusion.

This is also still the null check instead of moving the nuget version to a filePath type - as discussed we still want the minimal safest change here at this point in release.