### PR TITLE
Jenkins tasks: bump version and call setResourcePath()

### DIFF
--- a/Tasks/JenkinsDownloadArtifacts/task.json
+++ b/Tasks/JenkinsDownloadArtifacts/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "groups": [
         {

--- a/Tasks/JenkinsDownloadArtifacts/task.loc.json
+++ b/Tasks/JenkinsDownloadArtifacts/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 1
+    "Patch": 2
   },
   "groups": [
     {

--- a/Tasks/JenkinsQueueJob/jenkinsqueuejobtask.ts
+++ b/Tasks/JenkinsQueueJob/jenkinsqueuejobtask.ts
@@ -87,6 +87,8 @@ export class TaskOptions {
 
 async function doWork() {
     try {
+        tl.setResourcePath(path.join( __dirname, 'task.json'));
+        
         var taskOptions: TaskOptions = new TaskOptions();
 
         var jobQueue: JobQueue = new JobQueue(taskOptions);

--- a/Tasks/JenkinsQueueJob/task.json
+++ b/Tasks/JenkinsQueueJob/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 1
+        "Patch": 2
     },
     "groups": [
         {

--- a/Tasks/JenkinsQueueJob/task.loc.json
+++ b/Tasks/JenkinsQueueJob/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 1
+    "Patch": 2
   },
   "groups": [
     {


### PR DESCRIPTION
Tested by uploading the new versions to the xplatdemo account with a build visible at:
https://xplatdemo.visualstudio.com/JavaDevOps/_build/index?buildId=188&_a=summary
