### PR TITLE
Display warning if service fabric package contains pdb files

### DIFF
--- a/Tasks/ServiceFabricUpdateAppVersions/Find-FileChanges.psm1
+++ b/Tasks/ServiceFabricUpdateAppVersions/Find-FileChanges.psm1
@@ -1,7 +1,6 @@
 ﻿function Get-PackageFiles ($Path)
 {
-    # List all files except '.pdb' files because their content changes every build even with the 'deterministic' compiler flag
-    Find-VstsFiles -LiteralDirectory $Path -LegacyPattern "**;-:**\*.pdb" -Force |
+    Find-VstsFiles -LiteralDirectory $Path -LegacyPattern "**" -Force |
         ForEach-Object { $_.ToLower() } |
         Sort-Object
 }
@@ -32,6 +31,11 @@ function Find-FileChanges
     Trace-VstsEnteringInvocation $MyInvocation
     try {
         $LogIndent += "".PadLeft(2)
+
+        if (Find-VstsFiles -LiteralDirectory $NewPackageRoot -LegacyPattern "**\*.pdb" -Force)
+        {
+            Write-Warning (Get-VstsLocString -Key PdbWarning)
+        }
 
         $newFilesQueue = [System.Collections.Queue] @(Get-PackageFiles $NewPackageRoot)
         $oldFilesQueue = [System.Collections.Queue] @(Get-PackageFiles $OldPackageRoot)

--- a/Tasks/ServiceFabricUpdateAppVersions/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ServiceFabricUpdateAppVersions/Strings/resources.resjson/en-US/resources.resjson
@@ -49,5 +49,6 @@
   "loc.messages.FileRemoved": "The file '{0}' has been removed.",
   "loc.messages.FileAdded": "The file '{0}' has been added.",
   "loc.messages.FileChanged": "The file '{0}' has changed.",
-  "loc.messages.NoChanges": "Found no changes."
+  "loc.messages.NoChanges": "Found no changes.",
+  "loc.messages.PdbWarning": "This package contains '*.pdb' files, which will change in every build even if the 'deterministic' compiler flag is used.  Exclude these files from your package in order to accurately detect if the package has changed."
 }

--- a/Tasks/ServiceFabricUpdateAppVersions/task.json
+++ b/Tasks/ServiceFabricUpdateAppVersions/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 5
+        "Patch": 6
     },
     "minimumAgentVersion": "1.95.0",
     "instanceNameFormat": "Update Service Fabric App Versions",
@@ -132,6 +132,7 @@
         "FileRemoved": "The file '{0}' has been removed.",
         "FileAdded": "The file '{0}' has been added.",
         "FileChanged": "The file '{0}' has changed.",
-        "NoChanges": "Found no changes."
+        "NoChanges": "Found no changes.",
+        "PdbWarning": "This package contains '*.pdb' files, which will change in every build even if the 'deterministic' compiler flag is used.  Exclude these files from your package in order to accurately detect if the package has changed."
     }
 }

--- a/Tasks/ServiceFabricUpdateAppVersions/task.loc.json
+++ b/Tasks/ServiceFabricUpdateAppVersions/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 5
+    "Patch": 6
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -132,6 +132,7 @@
     "FileRemoved": "ms-resource:loc.messages.FileRemoved",
     "FileAdded": "ms-resource:loc.messages.FileAdded",
     "FileChanged": "ms-resource:loc.messages.FileChanged",
-    "NoChanges": "ms-resource:loc.messages.NoChanges"
+    "NoChanges": "ms-resource:loc.messages.NoChanges",
+    "PdbWarning": "ms-resource:loc.messages.PdbWarning"
   }
 }

--- a/Tests/L0/ServiceFabricUpdateAppVersions/Test-FileChanges.ps1
+++ b/Tests/L0/ServiceFabricUpdateAppVersions/Test-FileChanges.ps1
@@ -42,7 +42,8 @@ Register-Mock Get-VstsLocString
 
 $NewFiles = $NewFiles | ForEach-Object { "$newPkg\$_" }
 $OldFiles = $OldFiles | ForEach-Object { "$oldPkg\$_" }
-Register-Mock Find-VstsFiles { $NewFiles } -ArgumentsEvaluator { $args[1] -eq $newPkg }
+Register-Mock Find-VstsFiles { $NewFiles } -- -LiteralDirectory $newPkg -LegacyPattern "**" -Force
+Register-Mock Find-VstsFiles { $null } -- -LiteralDirectory $newPkg -LegacyPattern "**\*.pdb" -Force
 Register-Mock Find-VstsFiles { $OldFiles } -ArgumentsEvaluator { $args[1] -eq $oldPkg }
 
 $ChangedFiles = $ChangedFiles | ForEach-Object { "$newPkg\$_" }


### PR DESCRIPTION
A user ran into an error at deploy time because the pdb files changed, but we didn't update the version. The solution was to move the pdb files to a different build artifact (or just delete them if they don't want them).