### PR TITLE
Maven when matching error should consider drive letters

### DIFF
--- a/Tasks/Maven/maventask.ts
+++ b/Tasks/Maven/maventask.ts
@@ -74,7 +74,7 @@ else {
 }
 
 // On Windows, append .cmd or .bat to the executable as necessary
-if (os.type().match(/^Win/) &&
+if (isWindows &&
     !mvnExec.toLowerCase().endsWith('.cmd') &&
     !mvnExec.toLowerCase().endsWith('.bat')) {
     if (tl.exist(mvnExec + '.cmd')) {
@@ -362,13 +362,16 @@ function processMavenOutput(data) {
             severity = data.substring(1, rightIndex);
 
             if (severity === 'ERROR' || severity === 'WARNING') {
-                // Try to match output like:
-                // /Users/user/agent/_work/4/s/project/src/main/java/com/contoso/billingservice/file.java:[linenumber, columnnumber] error message here
+                // Try to match Posix output like:
+                // /Users/user/agent/_work/4/s/project/src/main/java/com/contoso/billingservice/file.java:[linenumber, columnnumber] error message here 
+                // or Windows output like:
+                // /C:/a/1/s/project/src/main/java/com/contoso/billingservice/file.java:[linenumber, columnnumber] error message here 
                 // A successful match will return an array of 5 strings - full matched string, file path, line number, column number, error message
                 input = input.substring(rightIndex + 1);
                 var match: any;
                 var matches: any[] = [];
-                var compileErrorsRegex = /([a-zA-Z0-9_ \-\/.]+):\[([0-9]+),([0-9]+)\](.*)/g;
+                var compileErrorsRegex = isWindows ? /\/([^:]+:[^:]+):\[([\d]+),([\d]+)\](.*)/g   //Windows path format - leading slash with drive letter
+                                                   : /([a-zA-Z0-9_ \-\/.]+):\[([0-9]+),([0-9]+)\](.*)/g;  // Posix path format
                 while (match = compileErrorsRegex.exec(input.toString())) {
                     matches = matches.concat(match);
                 }


### PR DESCRIPTION
Before this, on windows we are showing:
![image](https://cloud.githubusercontent.com/assets/10119737/19119817/f5a1a430-8aee-11e6-8336-7f6c3713b7d4.png)

Now we show:
![image](https://cloud.githubusercontent.com/assets/10119737/19119836/00ab7342-8aef-11e6-8897-5ab457256ca6.png)

The link in first screenshot leads to wrong url.  