### PR TITLE
changed JUnit test results files default value from TEST-* to test-*

### DIFF
--- a/Tasks/Grunt/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/Grunt/Strings/resources.resjson/de-de/resources.resjson
@@ -19,7 +19,7 @@
   "loc.input.label.publishJUnitResults": "In TFS/Team Services veröffentlichen",
   "loc.input.help.publishJUnitResults": "Wählen Sie diese Option aus, um JUnit-Testergebnisse, die vom Grunt-Build generiert wurden, in TFS/Team Services zu veröffentlichen.",
   "loc.input.label.testResultsFiles": "Test Results Files",
-  "loc.input.help.testResultsFiles": "Der Pfad der Testergebnisdateien. Platzhalter können verwendet werden. Beispiel: \"**/TEST-*.xml\" für alle XML-Dateien, deren Name mit \"TEST-\" beginnt.",
+  "loc.input.help.testResultsFiles": "Der Pfad der Testergebnisdateien. Platzhalter können verwendet werden. Beispiel: \"**/test-*.xml\" für alle XML-Dateien, deren Name mit \"test-\" beginnt.",
   "loc.input.label.testRunTitle": "Test Run Title",
   "loc.input.help.testRunTitle": "Geben Sie einen Namen für den Testlauf an.",
   "loc.input.label.enableCodeCoverage": "Code Coverage aktivieren",

--- a/Tasks/Grunt/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Grunt/Strings/resources.resjson/en-US/resources.resjson
@@ -19,7 +19,7 @@
   "loc.input.label.publishJUnitResults": "Publish to TFS/Team Services",
   "loc.input.help.publishJUnitResults": "Select this option to publish JUnit test results produced by the Grunt build to TFS/Team Services.",
   "loc.input.label.testResultsFiles": "Test Results Files",
-  "loc.input.help.testResultsFiles": "Test results files path. Wildcards can be used. For example, `**/TEST-*.xml` for all XML files whose name starts with TEST-.",
+  "loc.input.help.testResultsFiles": "Test results files path. Wildcards can be used. For example, `**/test-*.xml` for all XML files whose name starts with test-. (case sensitive match)",
   "loc.input.label.testRunTitle": "Test Run Title",
   "loc.input.help.testRunTitle": "Provide a name for the test run.",
   "loc.input.label.enableCodeCoverage": "Enable Code Coverage",

--- a/Tasks/Grunt/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/Grunt/Strings/resources.resjson/es-es/resources.resjson
@@ -19,7 +19,7 @@
   "loc.input.label.publishJUnitResults": "Publicar en TFS/Team Services",
   "loc.input.help.publishJUnitResults": "Seleccione esta opción para publicar en TFS/Team Services los resultados de pruebas JUnit generados por la compilación de Grunt.",
   "loc.input.label.testResultsFiles": "Test Results Files",
-  "loc.input.help.testResultsFiles": "Ruta de acceso a los archivos de resultados de pruebas. Se pueden usar caracteres comodín. Por ejemplo, \"**/TEST-*.xml\" para todos los archivos XML cuyos nombres empiecen por TEST-.",
+  "loc.input.help.testResultsFiles": "Ruta de acceso a los archivos de resultados de pruebas. Se pueden usar caracteres comodín. Por ejemplo, \"**/test-*.xml\" para todos los archivos XML cuyos nombres empiecen por test-.",
   "loc.input.label.testRunTitle": "Test Run Title",
   "loc.input.help.testRunTitle": "Asigne un nombre a la serie de pruebas.",
   "loc.input.label.enableCodeCoverage": "Habilitar Cobertura de código",

--- a/Tasks/Grunt/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/Grunt/Strings/resources.resjson/fr-fr/resources.resjson
@@ -19,7 +19,7 @@
   "loc.input.label.publishJUnitResults": "Publier sur TFS/Team Services",
   "loc.input.help.publishJUnitResults": "Sélectionnez cette option pour publier les résultats des tests JUnit produits par la build Grunt sur TFS/Team Services.",
   "loc.input.label.testResultsFiles": "Test Results Files",
-  "loc.input.help.testResultsFiles": "Chemin des fichiers de résultats des tests. Les caractères génériques sont autorisés. Par exemple, '**/TEST-*.xml' correspond à tous les fichiers XML dont le nom commence par TEST-.",
+  "loc.input.help.testResultsFiles": "Chemin des fichiers de résultats des tests. Les caractères génériques sont autorisés. Par exemple, '**/test-*.xml' correspond à tous les fichiers XML dont le nom commence par test-.",
   "loc.input.label.testRunTitle": "Test Run Title",
   "loc.input.help.testRunTitle": "Indiquez le nom de la série de tests.",
   "loc.input.label.enableCodeCoverage": "Activer la couverture du code",

--- a/Tasks/Grunt/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/Grunt/Strings/resources.resjson/it-IT/resources.resjson
@@ -19,7 +19,7 @@
   "loc.input.label.publishJUnitResults": "Pubblica in TFS/Team Services",
   "loc.input.help.publishJUnitResults": "Selezionare questa opzione per pubblicare in TFS/Team Services i risultati di test JUnit ottenuti con la compilazione Grunt.",
   "loc.input.label.testResultsFiles": "Test Results Files",
-  "loc.input.help.testResultsFiles": "Percorso dei file dei risultati del test. È possibile usare i caratteri jolly, ad esempio `**/TEST-*.xml` per individuare tutti i file XML il cui nome inizia con TEST-.",
+  "loc.input.help.testResultsFiles": "Percorso dei file dei risultati del test. È possibile usare i caratteri jolly, ad esempio `**/test-*.xml` per individuare tutti i file XML il cui nome inizia con test-.",
   "loc.input.label.testRunTitle": "Test Run Title",
   "loc.input.help.testRunTitle": "Consente di specificare un nome per l'esecuzione dei test.",
   "loc.input.label.enableCodeCoverage": "Abilita code coverage",

--- a/Tasks/Grunt/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/Grunt/Strings/resources.resjson/ja-jp/resources.resjson
@@ -19,7 +19,7 @@
   "loc.input.label.publishJUnitResults": "TFS/Team Services に発行する",
   "loc.input.help.publishJUnitResults": "Grunt のビルドによって生成される JUnit のテスト結果を TFS/Team Services に発行するには、このオプションを選びます。",
   "loc.input.label.testResultsFiles": "Test Results Files",
-  "loc.input.help.testResultsFiles": "テスト結果ファイルのパス。ワイルドカードを使用できます。たとえば、名前が TEST- で始まるすべての XML ファイルの場合は `**/TEST-*.xml` です。",
+  "loc.input.help.testResultsFiles": "テスト結果ファイルのパス。ワイルドカードを使用できます。たとえば、名前が test- で始まるすべての XML ファイルの場合は `**/test-*.xml` です。",
   "loc.input.label.testRunTitle": "Test Run Title",
   "loc.input.help.testRunTitle": "テストの実行の名前を指定します。",
   "loc.input.label.enableCodeCoverage": "コード カバレッジを有効にする",

--- a/Tasks/Grunt/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/Grunt/Strings/resources.resjson/ko-KR/resources.resjson
@@ -19,7 +19,7 @@
   "loc.input.label.publishJUnitResults": "TFS/Team Services에 게시",
   "loc.input.help.publishJUnitResults": "Grunt 빌드에서 생성된 JUnit 테스트 결과를 TFS/Team Services에 게시하려면 이 옵션을 선택하세요.",
   "loc.input.label.testResultsFiles": "Test Results Files",
-  "loc.input.help.testResultsFiles": "테스트 결과 파일 경로입니다. 와일드카드를 사용할 수 있습니다. 예를 들어, 이름이 TEST-로 시작하는 모든 XML 파일을 표시하기 위해 `**/TEST-*.xml`을 사용할 수 있습니다.",
+  "loc.input.help.testResultsFiles": "테스트 결과 파일 경로입니다. 와일드카드를 사용할 수 있습니다. 예를 들어, 이름이 test-로 시작하는 모든 XML 파일을 표시하기 위해 `**/test-*.xml`을 사용할 수 있습니다.",
   "loc.input.label.testRunTitle": "Test Run Title",
   "loc.input.help.testRunTitle": "테스트 실행의 이름을 지정하세요.",
   "loc.input.label.enableCodeCoverage": "코드 검사 사용",

--- a/Tasks/Grunt/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/Grunt/Strings/resources.resjson/ru-RU/resources.resjson
@@ -19,7 +19,7 @@
   "loc.input.label.publishJUnitResults": "Опубликовать в TFS или Team Services",
   "loc.input.help.publishJUnitResults": "Выберите этот параметр, чтобы опубликовать результаты тестов JUnit, созданные сборкой Grunt, в TFS или Team Services.",
   "loc.input.label.testResultsFiles": "Test Results Files",
-  "loc.input.help.testResultsFiles": "Путь к файлам результатов тестов. Можно использовать подстановочные знаки. Пример: \"**/TEST-*.xml\" для всех XML-файлов, имена которых начинаются с \"TEST-\".",
+  "loc.input.help.testResultsFiles": "Путь к файлам результатов тестов. Можно использовать подстановочные знаки. Пример: \"**/test-*.xml\" для всех XML-файлов, имена которых начинаются с \"test-\".",
   "loc.input.label.testRunTitle": "Test Run Title",
   "loc.input.help.testRunTitle": "Укажите имя для тестового запуска.",
   "loc.input.label.enableCodeCoverage": "Включить оценку объема протестированного кода",

--- a/Tasks/Grunt/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/Grunt/Strings/resources.resjson/zh-CN/resources.resjson
@@ -19,7 +19,7 @@
   "loc.input.label.publishJUnitResults": "发布到 TFS/Team Services",
   "loc.input.help.publishJUnitResults": "选择此选项将 Grunt 生成产生的 JUnit 测试结果发布到 TFS/Team Services。",
   "loc.input.label.testResultsFiles": "Test Results Files",
-  "loc.input.help.testResultsFiles": "测试结果文件路径。可以使用通配符。例如，\"**/TEST-*.xml\" 表示名称以 TEST- 开头的所有 XML 文件。",
+  "loc.input.help.testResultsFiles": "测试结果文件路径。可以使用通配符。例如，\"**/test-*.xml\" 表示名称以 test- 开头的所有 XML 文件。",
   "loc.input.label.testRunTitle": "Test Run Title",
   "loc.input.help.testRunTitle": "为测试运行提供一个名称。",
   "loc.input.label.enableCodeCoverage": "启用代码覆盖率",

--- a/Tasks/Grunt/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/Grunt/Strings/resources.resjson/zh-TW/resources.resjson
@@ -19,7 +19,7 @@
   "loc.input.label.publishJUnitResults": "發行至 TFS/Team Services",
   "loc.input.help.publishJUnitResults": "選取這個選項，以將 Grunt 組建所產生的 JUnit 測試結果發行至 TFS/Team Services。",
   "loc.input.label.testResultsFiles": "Test Results Files",
-  "loc.input.help.testResultsFiles": "測試結果檔案路徑。可使用萬用字元。例如 `**/TEST-*.xml` 即適用於所有名稱開頭為 TEST- 的 XML 檔案。",
+  "loc.input.help.testResultsFiles": "測試結果檔案路徑。可使用萬用字元。例如 `**/test-*.xml` 即適用於所有名稱開頭為 test- 的 XML 檔案。",
   "loc.input.label.testRunTitle": "Test Run Title",
   "loc.input.help.testRunTitle": "提供測試回合的名稱。",
   "loc.input.label.enableCodeCoverage": "啟用程式碼涵蓋範圍",

--- a/Tasks/Grunt/task.json
+++ b/Tasks/Grunt/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 0,
         "Minor": 5,
-        "Patch": 23
+        "Patch": 24
     },
     "demands": [
         "node.js"
@@ -91,10 +91,10 @@
             "name": "testResultsFiles",
             "type": "filePath",
             "label": "Test Results Files",
-            "defaultValue": "**/TEST-*.xml",
+            "defaultValue": "**/test-*.xml",
             "required": true,
             "groupName": "junitTestResults",
-            "helpMarkDown": "Test results files path. Wildcards can be used. For example, `**/TEST-*.xml` for all XML files whose name starts with TEST-.",
+            "helpMarkDown": "Test results files path. Wildcards can be used. For example, `**/test-*.xml` for all XML files whose name starts with test-. (case sensitive match)",
             "visibleRule": "publishJUnitResults = true"
         },
         {

--- a/Tasks/Grunt/task.loc.json
+++ b/Tasks/Grunt/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 0,
     "Minor": 5,
-    "Patch": 23
+    "Patch": 24
   },
   "demands": [
     "node.js"
@@ -91,7 +91,7 @@
       "name": "testResultsFiles",
       "type": "filePath",
       "label": "ms-resource:loc.input.label.testResultsFiles",
-      "defaultValue": "**/TEST-*.xml",
+      "defaultValue": "**/test-*.xml",
       "required": true,
       "groupName": "junitTestResults",
       "helpMarkDown": "ms-resource:loc.input.help.testResultsFiles",

--- a/Tests/L0/Grunt/_suite.ts
+++ b/Tests/L0/Grunt/_suite.ts
@@ -32,7 +32,7 @@ describe('Grunt Suite', function () {
 		var tr = new trm.TaskRunner('Grunt');
 		tr.setInput('gruntFile', 'gruntfile.js');
 		tr.setInput('publishJUnitResults', 'true');
-		tr.setInput('testResultsFiles', '**/build/test-results/TEST-*.xml');
+		tr.setInput('testResultsFiles', '**/build/test-results/test-*.xml');
 		tr.setInput('enableCodeCoverage', 'false');
 		if (os.type().match(/^Win/)) {
 			tr.setInput('cwd', 'c:/fake/wd');
@@ -61,7 +61,7 @@ describe('Grunt Suite', function () {
 		var tr = new trm.TaskRunner('Grunt');
 		tr.setInput('gruntFile', 'gruntfile.js');
 		tr.setInput('publishJUnitResults', 'true');
-		tr.setInput('testResultsFiles', '**/build/test-results/TEST-*.xml');
+		tr.setInput('testResultsFiles', '**/build/test-results/test-*.xml');
 		tr.setInput('enableCodeCoverage', 'false');
 		if (os.type().match(/^Win/)) {
 			tr.setInput('cwd', 'c:/fake/wd');
@@ -96,7 +96,7 @@ describe('Grunt Suite', function () {
 		var tr = new trm.TaskRunner('Grunt');
 		tr.setInput('gruntFile', 'gruntfile.js');
 		tr.setInput('publishJUnitResults', 'true');
-		tr.setInput('testResultsFiles', '**/build/test-results/TEST-*.xml');
+		tr.setInput('testResultsFiles', '**/build/test-results/test-*.xml');
 		tr.setInput('enableCodeCoverage', 'true');
 		tr.setInput('testFramework', 'Mocha');
 		tr.setInput('srcFiles', '**/build/src/*.js');
@@ -154,7 +154,7 @@ describe('Grunt Suite', function () {
 		var tr = new trm.TaskRunner('Grunt');
 		tr.setInput('gruntFile', 'gruntfile.js');
 		tr.setInput('publishJUnitResults', 'true');
-		tr.setInput('testResultsFiles', '**/build/test-results/TEST-*.xml');
+		tr.setInput('testResultsFiles', '**/build/test-results/test-*.xml');
 		tr.setInput('enableCodeCoverage', 'false');
 		if (os.type().match(/^Win/)) {
 			tr.setInput('cwd', 'c:/fake/wd');
@@ -209,7 +209,7 @@ describe('Grunt Suite', function () {
 		var tr = new trm.TaskRunner('Grunt');
 		tr.setInput('gruntFile', 'gruntfile.js');
 		tr.setInput('publishJUnitResults', 'true');
-		tr.setInput('testResultsFiles', '**/build/test-results/TEST-*.xml');
+		tr.setInput('testResultsFiles', '**/build/test-results/test-*.xml');
 		tr.setInput('enableCodeCoverage', 'true');
 		tr.setInput('testFramework', 'Mocha');
 		tr.setInput('srcFiles', '**/build/src/*.js');
@@ -243,7 +243,7 @@ describe('Grunt Suite', function () {
 		var tr = new trm.TaskRunner('Grunt');
 		tr.setInput('gruntFile', 'gruntfile.js');
 		tr.setInput('publishJUnitResults', 'true');
-		tr.setInput('testResultsFiles', '**/build/test-results/TEST-*.xml');
+		tr.setInput('testResultsFiles', '**/build/test-results/test-*.xml');
 		tr.setInput('enableCodeCoverage', 'false');
 		if (os.type().match(/^Win/)) {
 			tr.setInput('cwd', 'c:/fake/wd');
@@ -278,7 +278,7 @@ describe('Grunt Suite', function () {
 		var tr = new trm.TaskRunner('Grunt');
 		tr.setInput('gruntFile', 'gruntfile.js');
 		tr.setInput('publishJUnitResults', 'true');
-		tr.setInput('testResultsFiles', '**/build/test-results/TEST-*.xml');
+		tr.setInput('testResultsFiles', '**/build/test-results/test-*.xml');
 		tr.setInput('enableCodeCoverage', 'true');
 		tr.setInput('testFramework', 'Mocha');
 		tr.setInput('srcFiles', '**/build/src/*.js');
@@ -430,7 +430,7 @@ describe('Grunt Suite', function () {
 		var tr = new trm.TaskRunner('Grunt');
 		tr.setInput('gruntFile', 'gruntfile.js');
 		tr.setInput('publishJUnitResults', 'true');
-		tr.setInput('testResultsFiles', '**/build/test-results/TEST-*.xml');
+		tr.setInput('testResultsFiles', '**/build/test-results/test-*.xml');
 		tr.setInput('enableCodeCoverage', 'true');
 		tr.setInput('testFramework', 'Mocha');
 		tr.setInput('srcFiles', '**/build/src/*.js');
@@ -461,7 +461,7 @@ describe('Grunt Suite', function () {
 		var tr = new trm.TaskRunner('Grunt');
 		tr.setInput('gruntFile', 'gruntfile.js');
 		tr.setInput('publishJUnitResults', 'true');
-		tr.setInput('testResultsFiles', '**/build/test-results/TEST-*.xml');
+		tr.setInput('testResultsFiles', '**/build/test-results/test-*.xml');
 		tr.setInput('enableCodeCoverage', 'true');
 		tr.setInput('testFramework', 'Mocha');
 		tr.setInput('srcFiles', '**/build/src/*.js');


### PR DESCRIPTION
Most reports tend to use test-results.xml as its default file name.
Since file matching is case sensitive having an uppercased pattern by
default is going to increase the chance of a missed publication if default
values are used.
