### PR TITLE
"Azure App Service Deployment: Classic" task has been deprecated

### DIFF
--- a/Tasks/AzureWebPowerShellDeployment/Readme.md
+++ b/Tasks/AzureWebPowerShellDeployment/Readme.md
@@ -1,3 +1,7 @@
 ## **Important Notice**
-The "Azure App Service Deployment: Classic" task has been **deprecated and will be removed soon**. To update Azure App Services using Web Deploy / Kudu REST APIs, please use the [**Azure App Service Deployment: ARM** task](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AzureRmWebAppDeployment).
+The "Azure App Service Deployment: Classic" task has been **deprecated and will be removed soon**. To update Azure App Services using Web Deploy / Kudu REST APIs, please use the [**Azure App Service Deployment: ARM** task](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AzureRmWebAppDeployment). 
+We reccommend you to migrate your Build or Release definitions to replace the deprecating task with the 'Azure App Service Deployment: ARM' task.
+
+
+
 

--- a/Tasks/AzureWebPowerShellDeployment/Readme.md
+++ b/Tasks/AzureWebPowerShellDeployment/Readme.md
@@ -1,0 +1,3 @@
+## **Important Notice**
+The "Azure App Service Deployment: Classic" task has been **deprecated and will be removed soon**. To update Azure App Services using Web Deploy / Kudu REST APIs, please use the [**Azure App Service Deployment: ARM** task](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AzureRmWebAppDeployment).
+

--- a/Tasks/AzureWebPowerShellDeployment/Readme.md
+++ b/Tasks/AzureWebPowerShellDeployment/Readme.md
@@ -1,6 +1,6 @@
 ## **Important Notice**
 The "Azure App Service Deployment: Classic" task has been **deprecated and will be removed soon**. To update Azure App Services using Web Deploy / Kudu REST APIs, please use the [**Azure App Service Deployment: ARM** task](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AzureRmWebAppDeployment). 
-We reccommend you to migrate your Build or Release definitions to replace the deprecating task with the 'Azure App Service Deployment: ARM' task.
+We recommend you to migrate your Build or Release definitions to replace the deprecating task with the 'Azure App Service Deployment: ARM' task.
 
 
 


### PR DESCRIPTION
"Azure App Service Deployment: Classic" task would soon be removed from the task catalog. Hence updating the readme to communicate the same.