### PR TITLE
Harden the way the task look for upstream causes

### DIFF
--- a/Tasks/JenkinsQueueJob/jobsearch.ts
+++ b/Tasks/JenkinsQueueJob/jobsearch.ts
@@ -264,7 +264,17 @@ export class JobSearch {
                      * So, for all jobs being tracked (within this code), one is consisdered the main job (which will be followed), and
                      * all others are considered joined and will not be tracked further.
                      */
-                    var causes : any = parsedBody.actions[0].causes;
+                    var findCauses = function(actions) { 
+                        for (var i in actions) {
+                            if (actions[i].causes) {
+                                return actions[i].causes; 
+                            }
+                        } 
+
+                        return null;
+                    };
+
+                    var causes : any = findCauses(parsedBody.actions);
                     thisSearch.foundCauses[thisSearch.nextSearchBuildNumber] = causes;
                     thisSearch.determineMainJob(thisSearch.nextSearchBuildNumber, function (mainJob: Job, secondaryJobs: Job[]) {
                         if (mainJob != null) {

--- a/Tasks/JenkinsQueueJob/task.json
+++ b/Tasks/JenkinsQueueJob/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 3
+        "Patch": 4
     },
     "groups": [
         {

--- a/Tasks/JenkinsQueueJob/task.loc.json
+++ b/Tasks/JenkinsQueueJob/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 3
+    "Patch": 4
   },
   "groups": [
     {


### PR DESCRIPTION
With multijob plugin, the first action is no longer the "causes".  We need to loop through the entire "actions" list to find the "causes".