### PR TITLE
changes for failure criteria

### DIFF
--- a/Tasks/QuickPerfTest/CltTasksUtility.ps1
+++ b/Tasks/QuickPerfTest/CltTasksUtility.ps1
@@ -1,9 +1,9 @@
 function InvokeRestMethod($headers, $contentType, $uri , $method= "Get", $body)
 {
-  $ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($uri)
-  $result = Invoke-RestMethod -ContentType "application/json" -UserAgent $global:userAgent -TimeoutSec $global:RestTimeout -Uri $uri -Method $method -Headers $headers -Body $body
-  $ServicePoint.CloseConnectionGroup("")
-  return $result
+	$ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($uri)
+	$result = Invoke-RestMethod -ContentType "application/json" -UserAgent $global:userAgent -TimeoutSec $global:RestTimeout -Uri $uri -Method $method -Headers $headers -Body $body
+	$ServicePoint.CloseConnectionGroup("")
+	return $result
 }
 
 function ComposeTestDropJson($name, $duration, $homepage, $vu, $geoLocation)
@@ -28,32 +28,32 @@ function ComposeTestDropJson($name, $duration, $homepage, $vu, $geoLocation)
 	}
 "@
 
-    return $tdjson
+	return $tdjson
 }
 
 function CreateTestDrop($headers, $dropJson, $CltAccountUrl)
 {
-    $uri = [String]::Format("{0}/_apis/clt/testdrops?api-version=1.0", $CltAccountUrl)
-    $drop = InvokeRestMethod -contentType "application/json" -uri $uri -method Post -headers $headers -body $dropJson
+	$uri = [String]::Format("{0}/_apis/clt/testdrops?api-version=1.0", $CltAccountUrl)
+	$drop = InvokeRestMethod -contentType "application/json" -uri $uri -method Post -headers $headers -body $dropJson
 
-    return $drop
+	return $drop
 }
 
 function GetTestDrop($headers, $drop, $CltAccountUrl)
 {
-    $uri = [String]::Format("{0}/_apis/clt/testdrops/{1}?api-version=1.0", $CltAccountUrl, $drop.id)
-    $testdrop = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+	$uri = [String]::Format("{0}/_apis/clt/testdrops/{1}?api-version=1.0", $CltAccountUrl, $drop.id)
+	$testdrop = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
 
-    return $testdrop
+	return $testdrop
 }
 
 function UploadTestDrop($testdrop)
 {
-    $uri = New-Object System.Uri($testdrop.accessData.dropContainerUrl)
-    $sas = New-Object Microsoft.WindowsAzure.Storage.Auth.StorageCredentials($testdrop.accessData.sasKey)
-    $container = New-Object Microsoft.WindowsAzure.Storage.Blob.CloudBlobContainer($uri, $sas)
+	$uri = New-Object System.Uri($testdrop.accessData.dropContainerUrl)
+	$sas = New-Object Microsoft.WindowsAzure.Storage.Auth.StorageCredentials($testdrop.accessData.sasKey)
+	$container = New-Object Microsoft.WindowsAzure.Storage.Blob.CloudBlobContainer($uri, $sas)
 
-    return $container
+	return $container
 }
 
 #function GetTestRuns($headers, $CltAccountUrl)
@@ -66,59 +66,59 @@ function UploadTestDrop($testdrop)
 
 function GetTestRunUri($testRunId, $headers, $CltAccountUrl)
 {
- $uri = [String]::Format("{0}/_apis/clt/testruns/{1}?api-version=1.0", $CltAccountUrl,$testRunId)
- $run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
- 
- return $run.WebResultUrl
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}?api-version=1.0", $CltAccountUrl,$testRunId)
+	$run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+
+	return $run.WebResultUrl
 }
 
 function RunInProgress($run)
 {
-    return $run.state -eq "queued" -or $run.state -eq "inProgress"
+	return $run.state -eq "queued" -or $run.state -eq "inProgress"
 }
 
 function MonitorTestRun($headers, $run, $CltAccountUrl)
 {
-    $uri = [String]::Format("{0}/_apis/clt/testruns/{1}?api-version=1.0", $CltAccountUrl, $run.id)
-    $prevState = $run.state
-    $prevSubState = $run.subState
-    Write-Output ("Load test '{0}' is in state '{1}|{2}'." -f  $run.name, $run.state, $run.subState)
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}?api-version=1.0", $CltAccountUrl, $run.id)
+	$prevState = $run.state
+	$prevSubState = $run.subState
+	Write-Output ("Load test '{0}' is in state '{1}|{2}'." -f  $run.name, $run.state, $run.subState)
 
-    do
-    {
-        Start-Sleep -s 15
-        $run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
-        if ($prevState -ne $run.state -or $prevSubState -ne $run.subState)
-        {
-            $prevState = $run.state
-            $prevSubState = $run.subState
-            Write-Output ("Load test '{0}' is in state '{1}|{2}'." -f  $run.name, $run.state, $run.subState)
-        }
-    }
-    while (RunInProgress $run)
+	do
+	{
+		Start-Sleep -s 15
+		$run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+		if ($prevState -ne $run.state -or $prevSubState -ne $run.subState)
+		{
+			$prevState = $run.state
+			$prevSubState = $run.subState
+			Write-Output ("Load test '{0}' is in state '{1}|{2}'." -f  $run.name, $run.state, $run.subState)
+		}
+	}
+	while (RunInProgress $run)
 
-    $run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
-    Write-Output "------------------------------------"
-    $uri = [String]::Format("{0}/_apis/clt/testruns/{1}/messages?api-version=1.0", $CltAccountUrl, $run.id)
-    $messages = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+	$run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+	Write-Output "------------------------------------"
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}/messages?api-version=1.0", $CltAccountUrl, $run.id)
+	$messages = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
 
-    if ($messages)
-    {
-        $timeSorted = $messages.value | Sort-Object loggedDate
-        foreach ($message in $timeSorted)
-        {
-            switch ($message.messageType)
-            {
-                "info"      { Write-Host -NoNewline ("[Message]{0}" -f $message.message) }
-                "output"    { Write-Host -NoNewline ("[Output]{0}" -f $message.message) }
-                "warning"   { Write-Warning $message.message }
-                "error"     { Write-Error $message.message }
-                "critical"  { Write-Error $message.message }
-            }
-        }
-    }
+	if ($messages)
+	{
+		$timeSorted = $messages.value | Sort-Object loggedDate
+		foreach ($message in $timeSorted)
+		{
+			switch ($message.messageType)
+			{
+				"info"      { Write-Host -NoNewline ("[Message]{0}" -f $message.message) }
+				"output"    { Write-Host -NoNewline ("[Output]{0}" -f $message.message) }
+				"warning"   { Write-Warning $message.message }
+				"error"     { Write-Error $message.message }
+				"critical"  { Write-Error $message.message }
+			}
+		}
+	}
 
-    Write-Output "------------------------------------"
+	Write-Output "------------------------------------"
 }
 
 function ComposeTestRunJson($name, $tdid, $machineType)
@@ -134,44 +134,44 @@ function ComposeTestRunJson($name, $tdid, $machineType)
 	}
 "@
 
-    return $trjson
+	return $trjson
 }
 
 function QueueTestRun($headers, $runJson, $CltAccountUrl)
 {
-    $uri = [String]::Format("{0}/_apis/clt/testruns?api-version=1.0", $CltAccountUrl)
-    $run = InvokeRestMethod -contentType "application/json" -uri $uri -method Post -headers $headers -body $runJson
+	$uri = [String]::Format("{0}/_apis/clt/testruns?api-version=1.0", $CltAccountUrl)
+	$run = InvokeRestMethod -contentType "application/json" -uri $uri -method Post -headers $headers -body $runJson
 
 	$start = @"
 	{
-	  "state": "queued"
+	"state": "queued"
 	}
 "@
 
-    $uri = [String]::Format("{0}/_apis/clt/testruns/{1}?api-version=1.0", $CltAccountUrl, $run.id)
-    InvokeRestMethod -contentType "application/json" -uri $uri -method Patch -headers $headers -body $start
-    $run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}?api-version=1.0", $CltAccountUrl, $run.id)
+	InvokeRestMethod -contentType "application/json" -uri $uri -method Patch -headers $headers -body $start
+	$run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
 
-    return $run
+	return $run
 }
 
 function ComposeAccountUrl($connectedServiceUrl, $headers)
 {
 	#Load all dependent files for execution
-    . $PSScriptRoot/VssConnectionHelper.ps1
+	. $PSScriptRoot/VssConnectionHelper.ps1
 	$connectedServiceUrl = $connectedServiceUrl.TrimEnd('/')
 	Write-Host "Getting Clt Endpoint:"
 	$elsUrl = Get-CltEndpoint $connectedServiceUrl $headers
 
-    return $elsUrl
+	return $elsUrl
 }
 
 function ValidateInputs($websiteUrl, $tfsCollectionUrl, $connectedServiceName)
 {
-    if (![System.Uri]::IsWellFormedUriString($websiteUrl, [System.UriKind]::Absolute))
-    {
-        throw "Website Url is not well formed."
-    }
+	if (![System.Uri]::IsWellFormedUriString($websiteUrl, [System.UriKind]::Absolute))
+	{
+		throw "Website Url is not well formed."
+	}
 	
 	if([string]::IsNullOrWhiteSpace($connectedServiceName) -and $tfsCollectionUrl -notlike "*VISUALSTUDIO.COM*" -and $tfsCollectionUrl -notlike "*TFSALLIN.NET*")
 	{
@@ -188,4 +188,11 @@ function UploadSummaryMdReport($summaryMdPath)
 		Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=Load test results;]$summaryMdPath"
 	}
 }
+
+function isNumericValue ($str) {
+	$numericValue = 0
+	$isNum = [System.Int32]::TryParse($str, [ref]$numericValue)
+	return $isNum
+}
+
 

--- a/Tasks/QuickPerfTest/CltTasksUtility.ps1
+++ b/Tasks/QuickPerfTest/CltTasksUtility.ps1
@@ -189,7 +189,7 @@ function UploadSummaryMdReport($summaryMdPath)
 	}
 }
 
-function isNumericValue ($str) {
+function IsNumericValue ($str) {
 	$numericValue = 0
 	$isNum = [System.Int32]::TryParse($str, [ref]$numericValue)
 	return $isNum

--- a/Tasks/QuickPerfTest/CltThresholdValidationHelper.ps1
+++ b/Tasks/QuickPerfTest/CltThresholdValidationHelper.ps1
@@ -16,7 +16,7 @@ function ValidateAvgResponseTimeThresholdInput($avgResponseTimeThreshold)
 		return $null
 	}
 
-	if(((isNumericValue $avgResponseTimeThreshold) -ne $true) -or [System.Int32]$avgResponseTimeThreshold -lt 0)
+	if(((IsNumericValue $avgResponseTimeThreshold) -ne $true) -or [System.Int32]$avgResponseTimeThreshold -lt 0)
 	{
 		throw "Avg. Response Time threshold should be a positive numeric value.Please specify a valid threshold value and try again "
 	}
@@ -28,11 +28,7 @@ function ValidateAvgResponseTimeThreshold($cltAccountUrl,$headers,$testRunId,$av
 	$resultsSummary = GetResultsSummary  $cltAccountUrl  $headers $testRunId
 	if($resultsSummary -and $resultsSummary.overallRequestSummary -and $resultsSummary.overallRequestSummary.averageResponseTime)
 	{
-		if($resultsSummary.overallRequestSummary.averageResponseTime -gt ($avgResponseTimeThreshold/1000))
-		{
-			return $false
-		}
-		return $true
+		return ($resultsSummary.overallRequestSummary.averageResponseTime -lt ($avgResponseTimeThreshold/1000))
 	}
 	else
 	{

--- a/Tasks/QuickPerfTest/CltThresholdValidationHelper.ps1
+++ b/Tasks/QuickPerfTest/CltThresholdValidationHelper.ps1
@@ -1,0 +1,41 @@
+function GetResultsSummary($cltAccountUrl,$headers,$testRunId)
+{
+	$getResultsSummaryUri = [string]::Format("{0}/_apis/clt/testRuns/{1}/ResultSummary", $cltAccountUrl, $testRunId)
+	$resultsSummary = InvokeRestMethod -Uri $getResultsSummaryUri -contentType "application/json" -headers $headers -Method Get 
+	if($resultsSummary -eq $null)
+	{
+		throw "Unable to fetch the result summary for the run"
+	}
+	return $resultsSummary
+}
+
+function ValidateAvgResponseTimeThresholdInput($avgResponseTimeThreshold)
+{
+	if ($avgResponseTimeThreshold -eq 0)
+	{
+		return $null
+	}
+
+	if(((isNumericValue $avgResponseTimeThreshold) -ne $true) -or [System.Int32]$avgResponseTimeThreshold -lt 0)
+	{
+		throw "Avg. Response Time threshold should be a positive numeric value.Please specify a valid threshold value and try again "
+	}
+	return $avgResponseTimeThreshold
+}
+
+function ValidateAvgResponseTimeThreshold($cltAccountUrl,$headers,$testRunId,$avgResponseTimeThreshold)
+{
+	$resultsSummary = GetResultsSummary  $cltAccountUrl  $headers $testRunId
+	if($resultsSummary -and $resultsSummary.overallRequestSummary -and $resultsSummary.overallRequestSummary.averageResponseTime)
+	{
+		if($resultsSummary.overallRequestSummary.averageResponseTime -gt ($avgResponseTimeThreshold/1000))
+		{
+			return $false
+		}
+		return $true
+	}
+	else
+	{
+		throw "Unable to fetch the result summary for the run"
+	}
+}

--- a/Tasks/QuickPerfTest/Invoke-QuickPerfTest.ps1
+++ b/Tasks/QuickPerfTest/Invoke-QuickPerfTest.ps1
@@ -157,7 +157,7 @@ if ($drop.dropType -eq "InPlaceDrop")
 	$summary = ('[Test Run: {0}]({1}) using {2}.<br/>' -f  $run.runNumber, $webResultsUrl ,$run.name)
 	$summary = ('<span class="bowtie-icon {3}" />   {4}<br/>[Test Run: {0}]({1}) using {2}.<br/>' -f  $run.runNumber, $webResultsUri , $run.name, $thresholdImage, $thresholdMessage)
 
-	('<p>{0}</p>' -f $summary) >>  $summaryFile
+	('<p>{0}</p>' -f $summary) | Out-File  $summaryFile -Encoding ascii -Append
 	UploadSummaryMdReport $summaryFile
 }
 else

--- a/Tasks/QuickPerfTest/Invoke-QuickPerfTest.ps1
+++ b/Tasks/QuickPerfTest/Invoke-QuickPerfTest.ps1
@@ -1,53 +1,55 @@
 [CmdletBinding(DefaultParameterSetName = 'None')]
 param
 (
-    [String]
-    $env:SYSTEM_DEFINITIONID,
-    [String]
-    $env:BUILD_BUILDID,
+[String]
+$env:SYSTEM_DEFINITIONID,
+[String]
+$env:BUILD_BUILDID,
 
-    [String] [Parameter(Mandatory = $false)]
-    $connectedServiceName,
+[String] [Parameter(Mandatory = $false)]
+$connectedServiceName,
 
-    [String] [Parameter(Mandatory = $true)]
-    $websiteUrl,
-    [String] [Parameter(Mandatory = $true)]
-    $testName,
-    [String] [Parameter(Mandatory = $true)]
-    $vuLoad,
-    [String] [Parameter(Mandatory = $true)]
-    $runDuration,
-    [String] [Parameter(Mandatory = $true)]
-    $geoLocation,
-    [String] [Parameter(Mandatory = $true)]
-    $machineType
+[String] [Parameter(Mandatory = $true)]
+$websiteUrl,
+[String] [Parameter(Mandatory = $true)]
+$testName,
+[String] [Parameter(Mandatory = $true)]
+$vuLoad,
+[String] [Parameter(Mandatory = $true)]
+$runDuration,
+[String] [Parameter(Mandatory = $true)]
+$geoLocation,
+[String] [Parameter(Mandatory = $true)]
+$machineType,
+[String] [Parameter(Mandatory = $false)]
+$avgResponseTimeThreshold
 )
 
 function InitializeRestHeaders()
 {
-    $restHeaders = New-Object -TypeName "System.Collections.Generic.Dictionary[[String], [String]]"
+	$restHeaders = New-Object -TypeName "System.Collections.Generic.Dictionary[[String], [String]]"
 	if([string]::IsNullOrWhiteSpace($connectedServiceName))
 	{
-		$patToken = Get-AccessToken $connectedServiceDetails
+		$patToken = GetAccessToken $connectedServiceDetails
 		ValidatePatToken $patToken
 		$restHeaders.Add("Authorization", [String]::Concat("Bearer ", $patToken))
-       
-    }
+		
+	}
 	else
 	{
-	   $Username = $connectedServiceDetails.Authorization.Parameters.Username
-	   Write-Verbose "Username = $Username" -Verbose
-	   $Password = $connectedServiceDetails.Authorization.Parameters.Password
-	   $alternateCreds = [String]::Concat($Username, ":", $Password)
-       $basicAuth = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($alternateCreds))
-       $restHeaders.Add("Authorization", [String]::Concat("Basic ", $basicAuth))
+		$Username = $connectedServiceDetails.Authorization.Parameters.Username
+		Write-Verbose "Username = $Username" -Verbose
+		$Password = $connectedServiceDetails.Authorization.Parameters.Password
+		$alternateCreds = [String]::Concat($Username, ":", $Password)
+		$basicAuth = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($alternateCreds))
+		$restHeaders.Add("Authorization", [String]::Concat("Basic ", $basicAuth))
 	}
-    return $restHeaders
+	return $restHeaders
 }
 
-function Get-AccessToken($vssEndPoint) 
+function GetAccessToken($vssEndPoint) 
 {
-    return $vssEndpoint.Authorization.Parameters.AccessToken
+	return $vssEndpoint.Authorization.Parameters.AccessToken
 }
 
 function ValidatePatToken($token)
@@ -58,10 +60,11 @@ function ValidatePatToken($token)
 	}
 }
 
-  # Load all dependent files for execution
-  . $PSScriptRoot/CltTasksUtility.ps1
-  . $PSScriptRoot/VssConnectionHelper.ps1
-  
+# Load all dependent files for execution
+. $PSScriptRoot/CltTasksUtility.ps1
+. $PSScriptRoot/VssConnectionHelper.ps1
+. $PSScriptRoot/CltThresholdValidationHelper
+
 $userAgent = "QuickPerfTestBuildTask"
 $global:RestTimeout = 60
 
@@ -85,13 +88,18 @@ Write-Output "Run source identifier = build/$env:SYSTEM_DEFINITIONID/$env:BUILD_
 #Validate Input
 ValidateInputs $websiteUrl $env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI $connectedServiceName
 
+#Process Threshold Rules
+Write-Output "Initializing threshold rule for avg. response time with value(ms) : $avgResponseTimeThreshold "
+$avgResponseTimeThreshold = ValidateAvgResponseTimeThresholdInput $avgResponseTimeThreshold
+
+#Initialize Connected Service Details
 if([string]::IsNullOrWhiteSpace($connectedServiceName))
 {
 	$connectedServiceDetails = Get-ServiceEndpoint -Context $distributedTaskContext -Name SystemVssConnection
 }
 else
 {
-    $connectedServiceDetails = Get-ServiceEndpoint -Context $distributedTaskContext -Name $connectedServiceName
+	$connectedServiceDetails = Get-ServiceEndpoint -Context $distributedTaskContext -Name $connectedServiceName
 }
 
 $VSOAccountUrl = $connectedServiceDetails.Url.AbsoluteUri
@@ -109,30 +117,54 @@ $drop = CreateTestDrop $headers $dropjson $CltAccountUrl
 
 if ($drop.dropType -eq "InPlaceDrop")
 {
-    $runJson = ComposeTestRunJson $testName $drop.id $MachineType
-    $run = QueueTestRun $headers $runJson $CltAccountUrl
-    MonitorTestRun $headers $run $CltAccountUrl
-    $webResultsUrl = GetTestRunUri $run.id $headers $CltAccountUrl
+	$runJson = ComposeTestRunJson $testName $drop.id $MachineType
+	$run = QueueTestRun $headers $runJson $CltAccountUrl
+	MonitorTestRun $headers $run $CltAccountUrl
+	$webResultsUrl = GetTestRunUri $run.id $headers $CltAccountUrl
 	
-    Write-Output ("Run-id for this load test is {0} and its name is '{1}'." -f  $run.runNumber, $run.name)
-    Write-Output ("To view run details navigate to {0}" -f $webResultsUrl)
-    Write-Output "To view detailed results navigate to Load Test | Load Test Manager in Visual Studio IDE, and open this run."
+	Write-Output ("Run-id for this load test is {0} and its name is '{1}'." -f  $run.runNumber, $run.name)
+	Write-Output ("To view run details navigate to {0}" -f $webResultsUrl)
+	Write-Output "To view detailed results navigate to Load Test | Load Test Manager in Visual Studio IDE, and open this run."
 
-    $resultsMDFolder = New-Item -ItemType Directory -Force -Path "$env:Temp\LoadTestResultSummary"	
-    $resultFilePattern = ("QuickPerfTestResults_{0}_{1}_*.md" -f $env:AGENT_ID, $env:SYSTEM_DEFINITIONID)
-    $excludeFilePattern = ("QuickPerfTestResults_{0}_{1}_{2}_*.md" -f $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID)   
-    Remove-Item $resultsMDFolder\$resultFilePattern -Exclude $excludeFilePattern -Force	
-    $summaryFile =  ("{0}\QuickPerfTestResults_{1}_{2}_{3}_{4}.md" -f $resultsMDFolder, $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID, $run.id)	
-    $summary = ('[Test Run: {0}]({1}) using {2}.<br/>' -f  $run.runNumber, $webResultsUrl ,$run.name)
+	$resultsMDFolder = New-Item -ItemType Directory -Force -Path "$env:Temp\LoadTestResultSummary"	
+	$resultFilePattern = ("QuickPerfTestResults_{0}_{1}_*.md" -f $env:AGENT_ID, $env:SYSTEM_DEFINITIONID)
+	$excludeFilePattern = ("QuickPerfTestResults_{0}_{1}_{2}_*.md" -f $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID)
+	
+	if($avgResponseTimeThreshold)
+	{
+		$avgResponseTimeThresholdValidationResult = ValidateAvgResponseTimeThreshold $CltAccountUrl $headers $run.id $avgResponseTimeThreshold 
+		if($avgResponseTimeThresholdValidationResult -eq $false)
+		{
+			Write-Output "The Avg.Response Time for the run is greater than the threshold value of $avgResponseTimeThreshold specified for the run "
+			Write-Output "To view detailed results navigate to Load Test | Load Test Manager in Visual Studio IDE, and open this run."
+			Write-Error "Load test task is marked as failed, as there were threshold violations for the Avg. Response Time"
+		}
+	}
+
+	Remove-Item $resultsMDFolder\$resultFilePattern -Exclude $excludeFilePattern -Force	
+	$summaryFile =  ("{0}\QuickPerfTestResults_{1}_{2}_{3}_{4}.md" -f $resultsMDFolder, $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID, $run.id)	
+
+	if ($thresholdViolationsCount -gt 0)
+	{
+		$thresholdMessage=("{0} thresholds violated." -f $thresholdViolationsCount)
+		$thresholdImage="bowtie-status-error"
+	}
+	else
+	{
+		$thresholdMessage="No thresholds violated."
+		$thresholdImage="bowtie-status-success"
+	}
+	$summary = ('[Test Run: {0}]({1}) using {2}.<br/>' -f  $run.runNumber, $webResultsUrl ,$run.name)
+	$summary = ('<span class="bowtie-icon {3}" />   {4}<br/>[Test Run: {0}]({1}) using {2}.<br/>' -f  $run.runNumber, $webResultsUri , $run.name, $thresholdImage, $thresholdMessage)
 
 	('<p>{0}</p>' -f $summary) >>  $summaryFile
-    UploadSummaryMdReport $summaryFile
+	UploadSummaryMdReport $summaryFile
 }
 else
 {
-    Write-Error ("Failed to connect to the endpoint '{0}' for VSO account '{1}'" -f $EndpointName, $VSOAccountUrl)
+	Write-Error ("Failed to connect to the endpoint '{0}' for VSO account '{1}'" -f $EndpointName, $VSOAccountUrl)
 }
 
-	
+
 Write-Output "Quick Perf Test Script execution completed"
 

--- a/Tasks/QuickPerfTest/VssConnectionHelper.ps1
+++ b/Tasks/QuickPerfTest/VssConnectionHelper.ps1
@@ -1,13 +1,12 @@
 function Get-CltEndpoint($connectedServiceUrl, $headers)
 {
-    # Load all dependent files for execution
-    . $PSScriptRoot/CltTasksUtility.ps1
-    $vsoUrl = $connectedServiceUrl
-    Write-Host "Fetching the Clt endpoint for $vsoUrl"
-    $spsLocation = Get-SpsLocation $vsoUrl $headers
-    $cltLocation = Get-CltLocation $spsLocation $headers
-
-    return $cltLocation
+	# Load all dependent files for execution
+	. $PSScriptRoot/CltTasksUtility.ps1
+	$vsoUrl = $connectedServiceUrl
+	Write-Host "Fetching the Clt endpoint for $vsoUrl"
+	$spsLocation = Get-SpsLocation $vsoUrl $headers
+	$cltLocation = Get-CltLocation $spsLocation $headers
+	return $cltLocation
 
 }
 
@@ -15,27 +14,26 @@ function Get-SpsLocation($vsoUrl, $headers)
 {
 	Write-Host "Fetching the SPS endpoint for $vsoUrl"
 	$spsUniqueIdentifier = "951917AC-A960-4999-8464-E3F0AA25B381"
-    $spsLocation = Get-ServiceLocation $vsoUrl $headers $spsUniqueIdentifier
-    return $spsLocation
+	$spsLocation = Get-ServiceLocation $vsoUrl $headers $spsUniqueIdentifier
+	return $spsLocation
 }
 
 function Get-CltLocation($spsUrl, $headers)
 {
 	Write-Host "Fetching the CLT endpoint for $vsoUrl"
-    $cltUniqueIdentifier = "6C404D78-EF65-4E65-8B6A-DF19D6361EAE"
-    return Get-ServiceLocation $spsUrl $headers $cltUniqueIdentifier
+	$cltUniqueIdentifier = "6C404D78-EF65-4E65-8B6A-DF19D6361EAE"
+	return Get-ServiceLocation $spsUrl $headers $cltUniqueIdentifier
 }
 
 function Get-ServiceLocation($baseUrl, $headers, $serviceUniqueIdentifier)
 {
 	# Load all dependent files for execution
-  . $PSScriptRoot/CltTasksUtility.ps1
-    $locationCallUri = [string]::Format("{0}/_apis/servicedefinitions/LocationService2/{1}", $baseUrl, $serviceUniqueIdentifier)
-    $locationCallJsonResponse = InvokeRestMethod -Uri $locationCallUri -contentType "application/json" -headers $headers -Method Get
-    if($locationCallJsonResponse)
-    {
-     return $locationCallJsonResponse.locationMappings.location|Select -First 1
-    }
-
+	. $PSScriptRoot/CltTasksUtility.ps1
+	$locationCallUri = [string]::Format("{0}/_apis/servicedefinitions/LocationService2/{1}", $baseUrl, $serviceUniqueIdentifier)
+	$locationCallJsonResponse = InvokeRestMethod -Uri $locationCallUri -contentType "application/json" -headers $headers -Method Get
+	if($locationCallJsonResponse)
+	{
+		return $locationCallJsonResponse.locationMappings.location|Select -First 1
+	}
 	return $null
 }

--- a/Tasks/QuickPerfTest/task.json
+++ b/Tasks/QuickPerfTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 15
+        "Patch": 17
     },
     "demands": [
         "msbuild",
@@ -109,6 +109,13 @@
                 "0": "Automatically provisioned agents",
                 "2": "Self-provisioned agents"
             }
+        },
+		{
+            "name": "avgResponseTimeThreshold",
+            "type": "string",
+            "label": "Fail test if Avg.Response Time(ms) exceeds",
+            "helpMarkDown": "Load test run duration in seconds.",
+            "defaultValue": "0"
         }
     ],
     "instanceNameFormat": "Quick Web Performance Test $(testName)",

--- a/Tasks/RunJMeterLoadTest/CltTasksUtility.ps1
+++ b/Tasks/RunJMeterLoadTest/CltTasksUtility.ps1
@@ -1,0 +1,339 @@
+function InvokeRestMethod($headers, $contentType, $uri , $method= "Get", $body)
+{
+	$restTimeout = 60
+	$ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($uri)
+	$result = Invoke-RestMethod -ContentType "application/json" -UserAgent $global:userAgent -TimeoutSec $restTimeout -Uri $uri -Method $method -Headers $headers -Body $body
+	$ServicePoint.CloseConnectionGroup("")
+	return $result
+}
+
+function ComposeTestDropJson($name, $duration, $homepage, $vu, $geoLocation)
+{
+	$tdjson = @"
+	{
+		"dropType": "InplaceDrop",
+		"loadTestDefinition":{
+			"loadTestName":"$name",
+			"runDuration":$duration,
+			"urls":["$homepage"],
+			"browserMixs":[
+				{"browserName":"Internet Explorer 11.0","browserPercentage":60.0},
+				{"browserName":"Chrome 2","browserPercentage":40.0}
+			],
+			"loadPatternName":"Constant",
+			"maxVusers":$vu,
+			"loadGenerationGeoLocations":[
+				{"Location":"$geoLocation","Percentage":100}
+			]
+		}
+	}
+"@
+
+	return $tdjson
+}
+
+function CreateTestDrop($headers, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testdrops?{1}", $CltAccountUrl, $global:apiVersion)
+	$drop = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers -method Post -body "{ ""dropType"": ""TestServiceBlobDrop"" }"
+	return $drop
+}
+
+function GetTestDrop($headers, $drop, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testdrops/{1}?{2}", $CltAccountUrl, $drop.id, $global:apiVersion)
+	$testdrop = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+
+	return $testdrop
+}
+
+function UploadTestDrop($testdrop, $src)
+{   
+	$dest = $testdrop.accessData.dropContainerUrl
+	$sas = $testdrop.accessData.sasKey
+
+	$azcopy = Get-ToolPath -Name "AzCopy\AzCopy.exe"
+	Write-Verbose "Calling AzCopy = $azcopy" -Verbose
+
+	$azlog = ("{0}\..\azlog" -f $src)
+	$args = ("/Source:`"{0}`" /Dest:{1} /DestSAS:{2} /S /Z:`"{3}`"" -f $src, $dest, $sas, $azlog)
+	Write-Verbose "AzCopy Args = $args" -Verbose
+
+	Invoke-Tool -Path $azcopy -Arguments $args
+}
+
+
+function GetTestRun($headers, $runId, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}?{2}", $CltAccountUrl, $runId, $global:apiVersion)
+	$run = Get $headers $uri
+	return $run
+}
+
+function GetTestRunUri($testRunId, $headers, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}?{2}", $CltAccountUrl, $testRunId, $global:apiVersion)
+	$run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+
+	return $run.WebResultUrl
+}
+
+function RunInProgress($run)
+{
+	return $run.state -eq "queued" -or $run.state -eq "inProgress"
+}
+
+function MonitorTestRun($headers, $run, $CltAccountUrl, $monitorThresholds)
+{
+	$runId = $run.id
+	if ($runId)
+	{
+		$abortRun = $false
+		do
+		{
+			Start-Sleep -s 15
+			$run = GetTestRun $headers $runId $CltAccountUrl
+			$abortRun = CheckTestErrors $headers $run $CltAccountUrl $monitorThresholds
+			if ($abortRun)
+			{
+				StopTestRun $headers $run $CltAccountUrl
+			}
+		}
+		while (RunInProgress $run)
+	}
+	return $abortRun
+}
+
+function QueueTestRun($headers, $runJson, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testruns?{1}", $CltAccountUrl, $global:apiVersion)
+	$run = InvokeRestMethod -contentType "application/json" -uri $uri -method Post -headers $headers -body $runJson
+
+	$start = @"
+	{
+	"state": "queued"
+	}
+"@
+
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}?{2}", $CltAccountUrl, $run.id, $global:apiVersion)
+	InvokeRestMethod -contentType "application/json" -uri $uri -method Patch -headers $headers -body $start
+	$run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+
+	return $run
+}
+
+function ComposeAccountUrl($connectedServiceUrl, $headers)
+{
+	#Load all dependent files for execution
+	. $PSScriptRoot/VssConnectionHelper.ps1
+	$connectedServiceUrl = $connectedServiceUrl.TrimEnd('/')
+	Write-Host "Getting Clt Endpoint:"
+	$elsUrl = Get-CltEndpoint $connectedServiceUrl $headers
+
+	return $elsUrl
+}
+
+function UploadSummaryMdReport($summaryMdPath)
+{
+	Write-Verbose "Summary Markdown Path = $summaryMdPath"
+
+	if (($env:SYSTEM_HOSTTYPE -eq "build") -and (Test-Path($summaryMdPath)))
+	{	
+		Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=Load test results;]$summaryMdPath"
+	}
+}
+
+function isNumericValue ($str) {
+	$numericValue = 0
+	$isNum = [System.Int32]::TryParse($str, [ref]$numericValue)
+	return $isNum
+}
+
+function ValidateFiles($inputName, $fileName)
+{
+	$file = Get-ChildItem -Path $TestDrop -recurse | where {$_.Name -eq $fileName} | Select -First 1
+	if ($file)
+	{
+		# Check for fileName
+		$global:ScopedTestDrop = $file.Directory.FullName
+		Write-Host -NoNewline ("Selected {0} is '{1}' under '{2}'"  -f $inputName, $file.FullName, $global:ScopedTestDrop)
+	}
+	else
+	{
+		ErrorMessage "No $inputName is present in the test drop."
+	}
+}
+
+function ValidateInputs($tfsCollectionUrl, $connectedServiceName, $testDrop, $loadtest)
+{
+	if (-Not (Test-Path $testDrop))
+	{
+		ErrorMessage "The path for the load test files does not exist. Please provide a valid path."
+	}
+
+	ValidateFiles "load test file" $loadTest
+}
+
+function Get($headers, $uri)
+{
+	try
+	{
+		$result = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+		return $result
+	}
+	catch
+	{
+		Write-Host -NoNewline $_.Exception.Message
+	}
+}
+
+function WriteTaskMessages($message)
+{
+	Write-Host ("{0}" -f $message ) -NoNewline
+}
+
+function MonitorAcquireResource($headers, $run, $CltAccountUrl)
+{
+	$runId = $run.id
+	if ($runId)
+	{
+		$elapsed = [System.Diagnostics.Stopwatch]::StartNew()
+		do
+		{
+			Start-Sleep -s 5
+			$run = GetTestRun $headers $runId $CltAccountUrl
+		}
+		while ($run.state -eq "queued")
+		if ($run.state -eq "inProgress")
+		{
+			WriteTaskMessages ("Acquiring test resources took {0}. Starting test execution." -f $($elapsed.Elapsed.ToString()))
+		}
+	}
+}
+
+function ErrorMessage($message)
+{
+	Write-Error $message
+	exit $LastExitCode
+}
+
+function StopTestRun($headers, $run, $CltAccountUrl)
+{
+	$stop = @"
+	{
+	"state": "aborted"
+	}
+"@
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}?{2}", $CltAccountUrl, $run.id, $global:apiVersion)
+	InvokeRestMethod -contentType "application/json" -uri $uri -method Patch -headers $headers -body $stop
+	$run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+	return $run
+
+}
+
+function ComposeTestRunJson($name, $tdid, $agentCount, $runDuration, $machineType)
+{
+	$processPlatform = "x86"
+	$setupScript=""
+	$cleanupScript=""
+
+	$trjson = @"
+	{
+		"name":"$name",
+		"runType":"jMeterLoadTest",
+		"description":"Apache Jmeter test queued from build",
+		"testSettings":{"cleanupCommand":"$cleanupScript", "hostProcessPlatform":"$processPlatform", "setupCommand":"$setupScript"},
+		"runSpecificDetails":{"coreCount":"$agentCount", "duration":"$runDuration", "samplingInterval":15},
+		"superSedeRunSettings":{"loadGeneratorMachinesType":"$machineType"},
+		"testDrop":{"id":"$tdid"},
+		"runSourceIdentifier":"build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
+	}
+"@
+	return $trjson
+}
+
+function ShowMessages($headers, $run, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}/messages?{2}", $CltAccountUrl, $run.id, $global:apiVersion)
+	$messages = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+	if ($messages)
+	{
+		$sMessages = $messages.value | Sort-Object loggedDate
+		foreach ($message in $sMessages)
+		{
+			switch ($message.messageType)
+			{
+				"info"     { Write-Host -NoNewline ("[Message]{0}" -f $message.message) }
+				"output"   { Write-Host -NoNewline ("[Message]{0}" -f $message.message) }
+				"warning"  { Write-Warning $message.message }
+				"error"    { Write-Error $message.message }
+				"critical" { Write-Error $message.message }
+			}
+		}
+	}
+}
+
+function GetTestErrors($headers, $run, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}/errors?detailed=true&{2}", $CltAccountUrl, $run.id, $global:apiVersion)
+	$testerrors = Get $headers $uri
+	return $testerrors
+}
+
+function PrintErrorSummary($headers, $run, $CltAccountUrl, $monitorThresholds)
+{
+	$thresholdViolationsCount = 0
+	$errors = GetTestErrors $headers $run $CltAccountUrl
+	if ($errors -and $errors.count -gt 0 -and  $errors.types.count -gt 0)
+	{
+		foreach ($type in $errors.types)
+		{
+			foreach ($subType in $type.subTypes)
+			{
+				foreach ($errorDetail in $subType.errorDetailList)
+				{
+					if ($type.typeName -eq "ThresholdMessage")
+					{
+						Write-Warning ( "[{0}] {1} occurrences of {2} " -f $type.typeName, $errorDetail.occurrences, $errorDetail.messageText)
+						$thresholdViolationsCount += $errorDetail.occurrences
+					}
+					else
+					{
+						Write-Warning ( "[{0}] {1} occurrences of ['{2}','{3}','{4}'] : {5} " -f $type.typeName, $errorDetail.occurrences, $errorDetail.scenarioName, $errorDetail.testCaseName,
+						$subType.subTypeName, $errorDetail.messageText)
+					}
+				}
+				if ($type.typeName -eq "ThresholdMessage" -and $subType.subTypeName -eq "Critical" -and $monitorThresholds -and $subType.occurrences -gt $ThresholdLimit)
+				{
+					Write-Error ( "Your loadtest has crossed the permissible {0} threshold violations with {1} violations" -f $ThresholdLimit, $subType.occurrences )
+				}
+			}
+		}		
+	}
+	return $thresholdViolationsCount
+}
+
+
+function CheckTestErrors($headers, $run, $CltAccountUrl, $MonitorThresholds)
+{
+	$thresholdExceeded = $false
+	if ($MonitorThresholds)
+	{
+		$uri = [String]::Format("{0}/_apis/clt/testruns/{1}/errors?type=ThresholdMessage&detailed=True&{2}", $CltAccountUrl, $run.id, $global:apiVersion)
+		$errors = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+
+		if ($errors -and $errors.count -gt 0 -and  $errors.types.count -gt 0)
+		{
+			foreach ($subType in $errors.types.subTypes)
+			{
+				if ($subType.subTypeName -eq 'Critical' -and $subType.occurrences -gt $ThresholdLimit)
+				{
+					$thresholdExceeded = $true
+					return $true;
+				}
+			}
+		}
+	}
+	return $false;
+}
+

--- a/Tasks/RunJMeterLoadTest/Start-ApacheJMeterTest.ps1
+++ b/Tasks/RunJMeterLoadTest/Start-ApacheJMeterTest.ps1
@@ -1,294 +1,82 @@
 [CmdletBinding(DefaultParameterSetName = 'None')]
 param
 (
-    [String]
-    $env:SYSTEM_DEFINITIONID,
-    [String]
-    $env:BUILD_BUILDID,
+[String]
+$env:SYSTEM_DEFINITIONID,
+[String]
+$env:BUILD_BUILDID,
 
-    [String] [Parameter(Mandatory = $true)]
-    $connectedServiceName,
+[String] [Parameter(Mandatory = $false)]
+$connectedServiceName,
 
-    [String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
-    $TestDrop,
-    [String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
-    $LoadTest,
+[String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
+$TestDrop,
+[String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
+$LoadTest,
 
-    [String] [Parameter(Mandatory = $true)]
-    $agentCount,
-    [String] [Parameter(Mandatory = $true)]
-    $runDuration,
-    [String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
-    $machineType
+[String] [Parameter(Mandatory = $true)]
+$agentCount,
+[String] [Parameter(Mandatory = $true)]
+$runDuration,
+[String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
+$machineType
 )
 
 $userAgent = "ApacheJmeterTestBuildTask"
-$apiVersion = "api-version=1.0"
-
 $global:RestTimeout = 60
-$global:ElsAccountUrl = "http://www.visualstudio.com"
-$global:TFSAccountUrl = "http://www.visualstudio.com"
-$global:ScopedTestDrop = $TestDrop
+$global:apiVersion = "api-version=1.0"
 
 function InitializeRestHeaders()
 {
-    $restHeaders = New-Object -TypeName "System.Collections.Generic.Dictionary[[String], [String]]"
-
-    $alternateCreds = [String]::Concat($Username, ":", $Password)
-    $basicAuth = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($alternateCreds))
-    $restHeaders.Add("Authorization", [String]::Concat("Basic ", $basicAuth))
-
-    return $restHeaders
+	$restHeaders = New-Object -TypeName "System.Collections.Generic.Dictionary[[String], [String]]"
+	if([string]::IsNullOrWhiteSpace($connectedServiceName))
+	{
+		$patToken = GetAccessToken $connectedServiceDetails
+		ValidatePatToken $patToken
+		$restHeaders.Add("Authorization", [String]::Concat("Bearer ", $patToken))
+		
+	}
+	else
+	{
+		$Username = $connectedServiceDetails.Authorization.Parameters.Username
+		Write-Verbose "Username = $Username" -Verbose
+		$Password = $connectedServiceDetails.Authorization.Parameters.Password
+		$alternateCreds = [String]::Concat($Username, ":", $Password)
+		$basicAuth = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($alternateCreds))
+		$restHeaders.Add("Authorization", [String]::Concat("Basic ", $basicAuth))
+	}
+	return $restHeaders
 }
 
-function InvokeRestMethod($headers, $contentType, $uri , $method= "Get", $body)
+function GetAccessToken($vssEndPoint) 
 {
-  $ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($uri)
-  $result = Invoke-RestMethod -ContentType "application/json" -UserAgent $userAgent -TimeoutSec $global:RestTimeout -Uri $uri -Method $method -Headers $headers -Body $body
-  $ServicePoint.CloseConnectionGroup("")
-  return $result
+	return $vssEndpoint.Authorization.Parameters.AccessToken
 }
 
-function CreateTestDrop($headers)
+function ValidatePatToken($token)
 {
-    $uri = [String]::Format("{0}/_apis/clt/testdrops?{1}", $global:ElsAccountUrl, $apiVersion)
-    $drop = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers -method Post -body "{ ""dropType"": ""TestServiceBlobDrop"" }"
-    return $drop
-}
-
-function Get($headers, $uri)
-{
-    try
-    {
-        $result = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
-        return $result
-    }
-    catch
-    {
-        Write-Host -NoNewline $_.Exception.Message
-    }
-}
-
-function GetTestDrop($drop, $headers)
-{
-    $uri = [String]::Format("{0}/_apis/clt/testdrops/{1}?{2}", $global:ElsAccountUrl, $drop.id, $apiVersion)
-    $testdrop = Get $headers $uri
-    return $testdrop
-}
-
-function GetTestRun($headers, $runId)
-{
-    $uri = [String]::Format("{0}/_apis/clt/testruns/{1}?{2}", $global:ElsAccountUrl, $runId, $apiVersion)
-    $run = Get $headers $uri
-    return $run
-}
-
-function GetTestErrors($headers, $run)
-{
-    $uri = [String]::Format("{0}/_apis/clt/testruns/{1}/errors?detailed=true&{2}", $global:ElsAccountUrl, $run.id, $apiVersion)
-    $testerrors = Get $headers $uri
-    return $testerrors
-}
-
-function QueueTestRun($headers, $runJson)
-{
-    $uri = [String]::Format("{0}/_apis/clt/testruns?{1}", $global:ElsAccountUrl, $apiVersion)
-    $run = InvokeRestMethod -contentType "application/json" -uri $uri -method Post -headers $headers -body $runJson
-
-$start = @"
-    {
-      "state": "queued"
-    }
-"@
-
-    $uri = [String]::Format("{0}/_apis/clt/testruns/{1}?{2}", $global:ElsAccountUrl, $run.id, $apiVersion)
-    InvokeRestMethod -contentType "application/json" -uri $uri -method Patch -headers $headers -body $start
-    $run = InvokeRestMethod -contentType "application/json" -userAgent $userAgent -uri $uri -headers $headers
-
-    return $run
-}
-
-function RunInProgress($run)
-{
-    return $run.state -ne "completed" -and $run.state -ne "error" -and $run.state -ne "aborted"
-}
-
-function PrintErrorSummary($headers, $run)
-{
-    $errors = GetTestErrors $headers $run
-    if ($errors -and $errors.count -gt 0 -and  $errors.types.count -gt 0)
-    {
-        foreach ($type in $errors.types)
-        {
-            foreach ($subType in $type.subTypes)
-            {
-                foreach ($errorDetail in $subType.errorDetailList)
-                {
-                    Write-Warning ( "[{0}] {1} occurrences of ['{2}','{3}','{4}'] : {5} " -f $type.typeName, $errorDetail.occurrences, $errorDetail.scenarioName, $errorDetail.testCaseName,
-                    $subType.subTypeName, $errorDetail.messageText)
-                }
-            }
-        }
-    }
-}
-
-function ShowMessages($headers, $run)
-{
-    $uri = [String]::Format("{0}/_apis/clt/testruns/{1}/messages?{2}", $global:ElsAccountUrl, $run.id, $apiVersion)
-    $messages = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
-    if ($messages)
-    {
-        $sMessages = $messages.value | Sort-Object loggedDate
-        foreach ($message in $sMessages)
-        {
-            switch ($message.messageType)
-            {
-                "info"     { Write-Host -NoNewline ("[Message]{0}" -f $message.message) }
-                "output"   { Write-Host -NoNewline ("[Message]{0}" -f $message.message) }
-                "warning"  { Write-Warning $message.message }
-                "error"    { Write-Error $message.message }
-                "critical" { Write-Error $message.message }
-            }
-        }
-    }
-}
-
-function UploadTestDrop($testdrop, $src)
-{
-    $dest = $testdrop.accessData.dropContainerUrl
-    $sas = $testdrop.accessData.sasKey
-
-    $azcopy = Get-ToolPath -Name "AzCopy\AzCopy.exe"
-    Write-Verbose "Calling AzCopy = $azcopy" -Verbose
-
-    $azlog = ("{0}\..\azlog" -f $src)
-    $args = ("/Source:`"{0}`" /Dest:{1} /DestSAS:{2} /S /Z:`"{3}`"" -f $src, $dest, $sas, $azlog)
-    Write-Verbose "AzCopy Args = $args" -Verbose
-
-    Invoke-Tool -Path $azcopy -Arguments $args
-}
-
-function ComposeTestRunJson($name, $tdid)
-{
-    $processPlatform = "x86"
-    $setupScript=""
-    $cleanupScript=""
-
-$trjson = @"
-    {
-        "name":"$name",
-        "runType":"jMeterLoadTest",
-        "description":"Apache Jmeter test queued from build",
-        "testSettings":{"cleanupCommand":"$cleanupScript", "hostProcessPlatform":"$processPlatform", "setupCommand":"$setupScript"},
-        "runSpecificDetails":{"coreCount":"$agentCount", "duration":"$runDuration", "samplingInterval":15},
-        "superSedeRunSettings":{"loadGeneratorMachinesType":"$MachineType"},
-        "testDrop":{"id":"$tdid"},
-        "runSourceIdentifier":"build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
-    }
-"@
-    return $trjson
+	if([string]::IsNullOrWhiteSpace($token))
+	{
+		throw "Unable to generate Personal Access Token for the user. Contact Project Collection Administrator"
+	}
 }
 
 function WriteTaskMessages($message)
 {
-    Write-Host ("{0}" -f $message ) -NoNewline
-}
-
-function MonitorTestRun($headers, $run)
-{
-    $runId = $run.id
-    if ($runId)
-    {
-        do
-        {
-            Start-Sleep -s 15
-            $run = GetTestRun $headers $runId
-        }
-        while (RunInProgress $run)
-    }
-}
-
-function MonitorAcquireResource($headers, $run)
-{
-    $runId = $run.id
-    if ($runId)
-    {
-        $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
-        do
-        {
-            Start-Sleep -s 5
-            $run = GetTestRun $headers $runId
-        }
-        while ($run.state -eq "queued")
-        if ($run.state -eq "inProgress")
-        {
-            WriteTaskMessages ("Acquiring test resources took {0}. Starting test execution." -f $($elapsed.Elapsed.ToString()))
-        }
-    }
-}
-
-function ComposeAccountUrl($vsoUrl)
-{
-    $elsUrl = $vsoUrl
-
-    if ($vsoUrl -notlike "*VSCLT.VISUALSTUDIO.COM*")
-    {
-        if ($vsoUrl -like "*VISUALSTUDIO.COM*")
-        {
-            $accountName = $vsoUrl.Split('//')[2].Split('.')[0]
-            $elsUrl = ("https://{0}.vsclt.visualstudio.com" -f $accountName)
-        }
-    }
-
-    return $elsUrl
-}
-
-function ErrorMessage($message)
-{
-    Write-Error $message
-    exit $LastExitCode
-}
-
-function ValidateFiles($inputName, $fileName)
-{
-    $file = Get-ChildItem -Path $TestDrop -recurse | where {$_.Name -eq $fileName} | Select -First 1
-    if ($file)
-    {
-        # Check for fileName
-        $global:ScopedTestDrop = $file.Directory.FullName
-        Write-Host -NoNewline ("Selected {0} is '{1}' under '{2}'"  -f $inputName, $file.FullName, $global:ScopedTestDrop)
-    }
-    else
-    {
-        ErrorMessage "No $inputName is present in the test drop."
-    }
-}
-
-function Validate()
-{
-    if (-Not (Test-Path $TestDrop))
-    {
-        ErrorMessage "The path for the load test files does not exist. Please provide a valid path."
-    }
-
-    ValidateFiles "load test file" $LoadTest
-}
-
-function UploadSummaryMdReport($summaryMdPath)
-{
-	Write-Verbose "Summary Markdown Path = $summaryMdPath"
-
-	if (($env:SYSTEM_HOSTTYPE -eq "build") -and (Test-Path($summaryMdPath)))
-	{	
-		Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=Load test results;]$summaryMdPath"
-	}
+	Write-Host ("{0}" -f $message ) -NoNewline
 }
 
 ############################################## PS Script execution starts here ##########################################
 WriteTaskMessages "Starting Load Test Script"
 
+# Load all dependent files for execution
+. $PSScriptRoot/CltTasksUtility.ps1
+. $PSScriptRoot/VssConnectionHelper.ps1
+
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Internal"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.DTA"
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.DevTestLabs"
 
 Write-Output "Test drop = $TestDrop"
 Write-Output "Load test = $LoadTest"
@@ -296,76 +84,81 @@ Write-Output "Load generator machine type = $machineType"
 Write-Output "Run source identifier = build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
 
 #Validate Input
-Validate
+ValidateInputs $env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI $connectedServiceName $testDrop $loadTest
 
-$connectedServiceDetails = Get-ServiceEndpoint -Context $distributedTaskContext -Name $connectedServiceName
-
-$Username = $connectedServiceDetails.Authorization.Parameters.Username
-Write-Verbose "Username = $userName" -Verbose
-$Password = $connectedServiceDetails.Authorization.Parameters.Password
-$global:ElsAccountUrl = ComposeAccountUrl($connectedServiceDetails.Url.AbsoluteUri).TrimEnd('/')
-$global:TFSAccountUrl = $env:System_TeamFoundationCollectionUri.TrimEnd('/')
-
-Write-Verbose "VSO account Url = $global:TFSAccountUrl" -Verbose
-Write-Verbose "CLT account Url = $global:ElsAccountUrl" -Verbose
-
-#Setting Headers and account Url accordingly
-$headers = InitializeRestHeaders
-
-#Upload the test drop
-$elapsed = [System.Diagnostics.Stopwatch]::StartNew()
-$drop = CreateTestDrop $headers
-
-if ($drop.dropType -eq "TestServiceBlobDrop")
+#Initialize Connected Service Details
+if([string]::IsNullOrWhiteSpace($connectedServiceName))
 {
-    $drop = GetTestDrop $drop $headers
-    UploadTestDrop $drop $global:ScopedTestDrop
-    WriteTaskMessages ("Uploading test files took {0}. Queuing the test run." -f $($elapsed.Elapsed.ToString()))
-
-    #Queue the test run
-    $runJson = ComposeTestRunJson $LoadTest $drop.id
-    $run = QueueTestRun $headers $runJson
-    MonitorAcquireResource $headers $run
-
-    #Monitor the test run
-    $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
-    MonitorTestRun $headers $run
-    WriteTaskMessages ( "Run execution took {0}. Collecting results." -f $($elapsed.Elapsed.ToString()))
-
-    #Print the error and messages
-    $run = GetTestRun $headers $run.id
-    ShowMessages $headers $run
-    PrintErrorSummary $headers $run
-
-    if ($run.state -ne "completed")
-    {
-        Write-Error "Load test has failed. Please check error messages to fix the problem."
-    }
-    else
-    {
-        WriteTaskMessages "The load test completed successfully."
-    }
-
-	$run = GetTestRun $headers $run.id
-	$webResultsUrl = $run.WebResultUrl
-    Write-Output ("Run-id for this load test is {0} and its name is '{1}'." -f  $run.runNumber, $run.name)
-    Write-Output ("To view run details navigate to {0}" -f $webResultsUrl)
-
-    $resultsMDFolder = New-Item -ItemType Directory -Force -Path "$env:Temp\LoadTestResultSummary"
-    $resultFilePattern = ("ApacheJMeterTestResults_{0}_{1}_*.md" -f $env:AGENT_ID, $env:SYSTEM_DEFINITIONID)
-    $excludeFilePattern = ("ApacheJMeterTestResults_{0}_{1}_{2}_*.md" -f $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID)
-    Remove-Item $resultsMDFolder\$resultFilePattern -Exclude $excludeFilePattern -Force
-    $summaryFile =  ("{0}\ApacheJMeterTestResults_{1}_{2}_{3}_{4}.md" -f $resultsMDFolder, $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID, $run.id)
-
-    $summary = ('[Test Run: {0}]({1}) using {2}.<br/>' -f  $run.runNumber, $webResultsUrl , $run.name)
-     	
-	('<p>{0}</p>' -f $summary) | Out-File  $summaryFile -Encoding ascii -Append
-    UploadSummaryMdReport $summaryFile
+	$connectedServiceDetails = Get-ServiceEndpoint -Context $distributedTaskContext -Name SystemVssConnection
 }
 else
 {
-    Write-Error ("Connection '{0}' failed for service '{1}'" -f $connectedServiceName, $connectedServiceDetails.Url.AbsoluteUri)
-    ("Connection '{0}' failed for service '{1}'" -f $connectedServiceName, $connectedServiceDetails.Url.AbsoluteUri) >> $summaryFile
+	$connectedServiceDetails = Get-ServiceEndpoint -Context $distributedTaskContext -Name $connectedServiceName
+}
+
+$VSOAccountUrl = $connectedServiceDetails.Url.AbsoluteUri
+Write-Output "VSO Account URL is : $VSOAccountUrl"
+$headers = InitializeRestHeaders
+$CltAccountUrl = ComposeAccountUrl $VSOAccountUrl $headers
+$TFSAccountUrl = $env:System_TeamFoundationCollectionUri.TrimEnd('/')
+
+Write-Output "TFS account Url = $TFSAccountUrl" -Verbose
+Write-Output "CLT account Url = $CltAccountUrl" -Verbose
+
+#Upload the test drop
+$elapsed = [System.Diagnostics.Stopwatch]::StartNew()
+$drop = CreateTestDrop $headers $CltAccountUrl
+
+if ($drop.dropType -eq "TestServiceBlobDrop")
+{
+	$drop = GetTestDrop $headers $drop $CltAccountUrl
+	UploadTestDrop $drop $global:ScopedTestDrop
+	WriteTaskMessages ("Uploading test files took {0}. Queuing the test run." -f $($elapsed.Elapsed.ToString()))
+
+	#Queue the test run
+	$runJson = ComposeTestRunJson $LoadTest $drop.id $agentCount $runDuration $machineType
+	$run = QueueTestRun $headers $runJson $CltAccountUrl
+	MonitorAcquireResource $headers $run $CltAccountUrl
+
+	#Monitor the test run
+	$elapsed = [System.Diagnostics.Stopwatch]::StartNew()
+	MonitorTestRun $headers $run $CltAccountUrl
+	WriteTaskMessages ( "Run execution took {0}. Collecting results." -f $($elapsed.Elapsed.ToString()))
+
+	#Print the error and messages
+	$run = GetTestRun $headers $run.id $CltAccountUrl
+	ShowMessages $headers $run $CltAccountUrl
+	PrintErrorSummary $headers $run $CltAccountUrl
+
+	if ($run.state -ne "completed")
+	{
+		Write-Error "Load test has failed. Please check error messages to fix the problem."
+	}
+	else
+	{
+		WriteTaskMessages "The load test completed successfully."
+	}
+
+	$run = GetTestRun $headers $run.id $CltAccountUrl
+	$webResultsUrl = $run.WebResultUrl
+	Write-Output ("Run-id for this load test is {0} and its name is '{1}'." -f  $run.runNumber, $run.name)
+	Write-Output ("To view run details navigate to {0}" -f $webResultsUrl)
+
+	$resultsMDFolder = New-Item -ItemType Directory -Force -Path "$env:Temp\LoadTestResultSummary"
+	$resultFilePattern = ("ApacheJMeterTestResults_{0}_{1}_*.md" -f $env:AGENT_ID, $env:SYSTEM_DEFINITIONID)
+	$excludeFilePattern = ("ApacheJMeterTestResults_{0}_{1}_{2}_*.md" -f $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID)
+	Remove-Item $resultsMDFolder\$resultFilePattern -Exclude $excludeFilePattern -Force
+	$summaryFile =  ("{0}\ApacheJMeterTestResults_{1}_{2}_{3}_{4}.md" -f $resultsMDFolder, $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID, $run.id)
+
+	$summary = ('[Test Run: {0}]({1}) using {2}.<br/>' -f  $run.runNumber, $webResultsUrl , $run.name)
+	
+	('<p>{0}</p>' -f $summary) | Out-File  $summaryFile -Encoding ascii -Append
+	UploadSummaryMdReport $summaryFile
+}
+else
+{
+	Write-Error ("Connection '{0}' failed for service '{1}'" -f $connectedServiceName, $connectedServiceDetails.Url.AbsoluteUri)
+	("Connection '{0}' failed for service '{1}'" -f $connectedServiceName, $connectedServiceDetails.Url.AbsoluteUri) >> $summaryFile
 }
 
 WriteTaskMessages "JMeter Test Script execution completed"

--- a/Tasks/RunJMeterLoadTest/VssConnectionHelper.ps1
+++ b/Tasks/RunJMeterLoadTest/VssConnectionHelper.ps1
@@ -1,0 +1,39 @@
+function Get-CltEndpoint($connectedServiceUrl, $headers)
+{
+	# Load all dependent files for execution
+	. $PSScriptRoot/CltTasksUtility.ps1
+	$vsoUrl = $connectedServiceUrl
+	Write-Host "Fetching the Clt endpoint for $vsoUrl"
+	$spsLocation = Get-SpsLocation $vsoUrl $headers
+	$cltLocation = Get-CltLocation $spsLocation $headers
+	return $cltLocation
+
+}
+
+function Get-SpsLocation($vsoUrl, $headers)
+{
+	Write-Host "Fetching the SPS endpoint for $vsoUrl"
+	$spsUniqueIdentifier = "951917AC-A960-4999-8464-E3F0AA25B381"
+	$spsLocation = Get-ServiceLocation $vsoUrl $headers $spsUniqueIdentifier
+	return $spsLocation
+}
+
+function Get-CltLocation($spsUrl, $headers)
+{
+	Write-Host "Fetching the CLT endpoint for $vsoUrl"
+	$cltUniqueIdentifier = "6C404D78-EF65-4E65-8B6A-DF19D6361EAE"
+	return Get-ServiceLocation $spsUrl $headers $cltUniqueIdentifier
+}
+
+function Get-ServiceLocation($baseUrl, $headers, $serviceUniqueIdentifier)
+{
+	# Load all dependent files for execution
+	. $PSScriptRoot/CltTasksUtility.ps1
+	$locationCallUri = [string]::Format("{0}/_apis/servicedefinitions/LocationService2/{1}", $baseUrl, $serviceUniqueIdentifier)
+	$locationCallJsonResponse = InvokeRestMethod -Uri $locationCallUri -contentType "application/json" -headers $headers -Method Get
+	if($locationCallJsonResponse)
+	{
+		return $locationCallJsonResponse.locationMappings.location|Select -First 1
+	}
+	return $null
+}

--- a/Tasks/RunJMeterLoadTest/task.json
+++ b/Tasks/RunJMeterLoadTest/task.json
@@ -1,97 +1,96 @@
 {
-    "id": "F20661EB-E0F7-4AFD-9A86-9FE9D1A93382",
-    "name": "ApacheJMeterLoadTest",
-    "friendlyName": "Cloud-based Apache JMeter Load Test",
-    "description": "Runs the Apache JMeter load test in cloud",
-    "helpMarkDown": "This task can be used to trigger an Apache JMeter load test in cloud using Visual Studio Team Services. [Learn more](https://go.microsoft.com/fwlink/?LinkId=784929).",
-    "category": "Test",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
-    "author": "Microsoft Corporation",
-    "version": {
-        "Major": 1,
-        "Minor": 0,
-        "Patch": 9
+  "id": "F20661EB-E0F7-4AFD-9A86-9FE9D1A93382",
+  "name": "ApacheJMeterLoadTest",
+  "friendlyName": "Cloud-based Apache JMeter Load Test",
+  "description": "Runs the Apache JMeter load test in cloud",
+  "helpMarkDown": "This task can be used to trigger an Apache JMeter load test in cloud using Visual Studio Team Services. [Learn more](https://go.microsoft.com/fwlink/?LinkId=784929).",
+  "category": "Test",
+  "visibility": [
+    "Build",
+    "Release"
+  ],
+  "author": "Microsoft Corporation",
+  "version": {
+    "Major": 1,
+    "Minor": 0,
+    "Patch": 10
+  },
+  "demands": [
+    "azureps"
+  ],
+  "minimumAgentVersion": "1.83.0",
+  "inputs": [
+    {
+      "name": "connectedServiceName",
+      "type": "connectedService:Generic",
+      "label": "VS Team Services Connection",
+      "defaultValue": "",
+      "helpMarkDown": "Select a previously registered service connection to talk to the cloud-based load test service. Choose 'Manage' to register a new connection."
     },
-    "demands": [
-        "azureps"
-    ],
-    "minimumAgentVersion": "1.83.0",
-    "inputs": [
-        {
-            "name": "connectedServiceName",
-            "type": "connectedService:Generic",
-            "label": "VS Team Service Endpoint",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Select a service endpoint to connect to the Cloud-based Load Test service. Choose 'Manage' to register a new endpoint."
-        },
-        {
-            "name": "TestDrop",
-            "type": "filePath",
-            "label": "Apache JMeter test files folder",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Relative path from repo root where the load test files are available."
-        },
-        {
-            "name": "LoadTest",
-            "type": "string",
-            "label": "Apache JMeter file",
-            "defaultValue": "jmeter.jmx",
-            "required": true,
-            "helpMarkDown": "The Apache JMeter test filename to be used under the load test folder specified above."
-        },
-        {
-            "name": "agentCount",
-            "type": "pickList",
-            "label": "Agent Count",
-            "required": true,
-            "helpMarkDown": "Number of test agents (dual-core) used in the run.",
-            "defaultValue": "1",
-            "options": {
-                "1": "1",
-                "2": "2",
-                "3": "3",
-                "4": "4",
-                "5": "5"
-            }
-        },
-        {
-            "name": "runDuration",
-            "type": "pickList",
-            "label": "Run Duration (sec)",
-            "required": true,
-            "helpMarkDown": "Load test run duration in seconds.",
-            "defaultValue": "60",
-            "options": {
-                "60": "60",
-                "120": "120",
-                "180": "180",
-                "240": "240",
-                "300": "300"
-            }
-        },
-        {
-            "name": "machineType",
-            "type": "radio",
-            "label": "Run load test using",
-            "required": true,
-            "defaultValue": "0",
-            "options": {
-                "0": "Automatically provisioned agents",
-                "2": "Self-provisioned agents"
-            }
-        }
-    ],
-    "instanceNameFormat": "Apache JMeter Test $(LoadTest)",
-    "execution": {
-        "PowerShell": {
-            "target": "$(currentDirectory)\\Start-ApacheJMeterTest.ps1",
-            "argumentFormat": "",
-            "workingDirectory": "$(currentDirectory)"
-        }
+    {
+      "name": "TestDrop",
+      "type": "filePath",
+      "label": "Apache JMeter test files folder",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Relative path from repo root where the load test files are available."
+    },
+    {
+      "name": "LoadTest",
+      "type": "string",
+      "label": "Apache JMeter file",
+      "defaultValue": "jmeter.jmx",
+      "required": true,
+      "helpMarkDown": "The Apache JMeter test filename to be used under the load test folder specified above."
+    },
+    {
+      "name": "agentCount",
+      "type": "pickList",
+      "label": "Agent Count",
+      "required": true,
+      "helpMarkDown": "Number of test agents (dual-core) used in the run.",
+      "defaultValue": "1",
+      "options": {
+        "1":"1",
+        "2":"2",
+        "3":"3",
+        "4":"4",
+        "5":"5"
+      }
+    },
+    {
+      "name": "runDuration",
+      "type": "pickList",
+      "label": "Run Duration (sec)",
+      "required": true,
+      "helpMarkDown": "Load test run duration in seconds.",
+      "defaultValue": "60",
+      "options": {
+        "60":"60",
+        "120":"120",
+        "180":"180",
+        "240":"240",
+        "300":"300"
+      }
+    },
+    {
+      "name": "machineType",
+      "type": "radio",
+      "label": "Run load test using",
+      "required": true,
+      "defaultValue": "0",
+      "options": {
+        "0": "Automatically provisioned agents",
+		"2": "Self-provisioned agents"
+      }
     }
+  ],
+  "instanceNameFormat": "Apache JMeter Test $(LoadTest)",
+  "execution": {
+    "PowerShell": {
+      "target": "$(currentDirectory)\\Start-ApacheJMeterTest.ps1",
+      "argumentFormat": "",
+      "workingDirectory": "$(currentDirectory)"
+    }
+  }
 }

--- a/Tasks/RunLoadTest/CltTasksUtility.ps1
+++ b/Tasks/RunLoadTest/CltTasksUtility.ps1
@@ -1,0 +1,356 @@
+function InvokeRestMethod($headers, $contentType, $uri , $method= "Get", $body)
+{
+	$restTimeout = 60
+	$ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($uri)
+	$result = Invoke-RestMethod -ContentType "application/json" -UserAgent $global:userAgent -TimeoutSec $restTimeout -Uri $uri -Method $method -Headers $headers -Body $body
+	$ServicePoint.CloseConnectionGroup("")
+	return $result
+}
+
+function ComposeTestDropJson($name, $duration, $homepage, $vu, $geoLocation)
+{
+	$tdjson = @"
+	{
+		"dropType": "InplaceDrop",
+		"loadTestDefinition":{
+			"loadTestName":"$name",
+			"runDuration":$duration,
+			"urls":["$homepage"],
+			"browserMixs":[
+				{"browserName":"Internet Explorer 11.0","browserPercentage":60.0},
+				{"browserName":"Chrome 2","browserPercentage":40.0}
+			],
+			"loadPatternName":"Constant",
+			"maxVusers":$vu,
+			"loadGenerationGeoLocations":[
+				{"Location":"$geoLocation","Percentage":100}
+			]
+		}
+	}
+"@
+
+	return $tdjson
+}
+
+function CreateTestDrop($headers, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testdrops?{1}", $CltAccountUrl, $global:apiVersion)
+	$drop = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers -method Post -body "{ ""dropType"": ""TestServiceBlobDrop"" }"
+	return $drop
+}
+
+function GetTestDrop($headers, $drop, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testdrops/{1}?api-version=1.0", $CltAccountUrl, $drop.id)
+	$testdrop = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+
+	return $testdrop
+}
+
+function UploadTestDrop($testdrop, $src)
+{   
+	$dest = $testdrop.accessData.dropContainerUrl
+	$sas = $testdrop.accessData.sasKey
+
+	$azcopy = Get-ToolPath -Name "AzCopy\AzCopy.exe"
+	Write-Verbose "Calling AzCopy = $azcopy" -Verbose
+
+	$azlog = ("{0}\..\azlog" -f $src)
+	$args = ("/Source:`"{0}`" /Dest:{1} /DestSAS:{2} /S /Z:`"{3}`"" -f $src, $dest, $sas, $azlog)
+	Write-Verbose "AzCopy Args = $args" -Verbose
+
+	Invoke-Tool -Path $azcopy -Arguments $args
+}
+
+
+function GetTestRun($headers, $runId, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}?{2}", $CltAccountUrl, $runId, $global:apiVersion)
+	$run = Get $headers $uri
+	return $run
+}
+
+function GetTestRunUri($testRunId, $headers, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}?api-version=1.0", $CltAccountUrl,$testRunId)
+	$run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+
+	return $run.WebResultUrl
+}
+
+function RunInProgress($run)
+{
+	return $run.state -eq "queued" -or $run.state -eq "inProgress"
+}
+
+function MonitorTestRun($headers, $run, $CltAccountUrl, $monitorThresholds)
+{
+	$runId = $run.id
+	if ($runId)
+	{
+		$abortRun = $false
+		do
+		{
+			Start-Sleep -s 15
+			$run = GetTestRun $headers $runId $CltAccountUrl
+			$abortRun = CheckTestErrors $headers $run $CltAccountUrl $monitorThresholds
+			if ($abortRun)
+			{
+				StopTestRun $headers $run $CltAccountUrl
+			}
+		}
+		while (RunInProgress $run)
+	}
+	return $abortRun
+}
+
+function QueueTestRun($headers, $runJson, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testruns?api-version=1.0", $CltAccountUrl)
+	$run = InvokeRestMethod -contentType "application/json" -uri $uri -method Post -headers $headers -body $runJson
+
+	$start = @"
+	{
+	"state": "queued"
+	}
+"@
+
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}?api-version=1.0", $CltAccountUrl, $run.id)
+	InvokeRestMethod -contentType "application/json" -uri $uri -method Patch -headers $headers -body $start
+	$run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+
+	return $run
+}
+
+function ComposeAccountUrl($connectedServiceUrl, $headers)
+{
+	#Load all dependent files for execution
+	. $PSScriptRoot/VssConnectionHelper.ps1
+	$connectedServiceUrl = $connectedServiceUrl.TrimEnd('/')
+	Write-Host "Getting Clt Endpoint:"
+	$elsUrl = Get-CltEndpoint $connectedServiceUrl $headers
+
+	return $elsUrl
+}
+
+function UploadSummaryMdReport($summaryMdPath)
+{
+	Write-Verbose "Summary Markdown Path = $summaryMdPath"
+
+	if (($env:SYSTEM_HOSTTYPE -eq "build") -and (Test-Path($summaryMdPath)))
+	{	
+		Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=Load test results;]$summaryMdPath"
+	}
+}
+
+function isNumericValue ($str) {
+	$numericValue = 0
+	$isNum = [System.Int32]::TryParse($str, [ref]$numericValue)
+	return $isNum
+}
+
+function ValidateFiles($inputName, $fileName)
+{
+	$file = Get-ChildItem -Path $TestDrop -recurse | where {$_.Name -eq $fileName} | Select -First 1
+	if ($file)
+	{
+		# Check for fileName
+		$global:ScopedTestDrop = $file.Directory.FullName
+		Write-Host -NoNewline ("Selected {0} is '{1}' under '{2}'"  -f $inputName, $file.FullName, $global:ScopedTestDrop)
+	}
+	else
+	{
+		ErrorMessage "No $inputName is present in the test drop."
+	}
+}
+
+function ValidateInputs($tfsCollectionUrl, $connectedServiceName, $testSettings, $testDrop, $loadtest)
+{
+	if (-Not (Test-Path $testSettings))
+	{
+		ErrorMessage "The path for the test settings file does not exist. Please provide a valid path."
+	}
+
+	if (-Not (Test-Path $testDrop))
+	{
+		ErrorMessage "The path for the load test files does not exist. Please provide a valid path."
+	}
+
+	ValidateFiles "load test file" $loadTest
+}
+
+function Get($headers, $uri)
+{
+	try
+	{
+		$result = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+		return $result
+	}
+	catch
+	{
+		Write-Host -NoNewline $_.Exception.Message
+	}
+}
+
+function WriteTaskMessages($message)
+{
+	Write-Host ("{0}" -f $message ) -NoNewline
+}
+
+function MonitorAcquireResource($headers, $run, $CltAccountUrl)
+{
+	$runId = $run.id
+	if ($runId)
+	{
+		$elapsed = [System.Diagnostics.Stopwatch]::StartNew()
+		do
+		{
+			Start-Sleep -s 5
+			$run = GetTestRun $headers $runId $CltAccountUrl
+		}
+		while ($run.state -eq "queued")
+		if ($run.state -eq "inProgress")
+		{
+			WriteTaskMessages ("Acquiring test resources took {0}. Starting test execution." -f $($elapsed.Elapsed.ToString()))
+		}
+	}
+}
+
+function ErrorMessage($message)
+{
+	Write-Error $message
+	exit $LastExitCode
+}
+
+function StopTestRun($headers, $run, $CltAccountUrl)
+{
+	$stop = @"
+	{
+	"state": "aborted"
+	}
+"@
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}?{2}", $CltAccountUrl, $run.id, $global:apiVersion)
+	InvokeRestMethod -contentType "application/json" -uri $uri -method Patch -headers $headers -body $stop
+	$run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+	return $run
+
+}
+
+function ComposeTestRunJson($name, $tdid, $machineType)
+{
+	$processPlatform = "x86"
+	$setupScript=""
+	$cleanupScript=""
+
+	[xml]$tsxml = Get-Content $TestSettings
+	if ($tsxml.TestSettings.Scripts.setupScript)
+	{
+		$setupScript = [System.IO.Path]::GetFileName($tsxml.TestSettings.Scripts.setupScript)
+	}
+	if ($tsxml.TestSettings.Scripts.cleanupScript)
+	{
+		$cleanupScript = [System.IO.Path]::GetFileName($tsxml.TestSettings.Scripts.cleanupScript)
+	}
+	if ($tsxml.TestSettings.Execution.hostProcessPlatform)
+	{
+		$processPlatform = $tsxml.TestSettings.Execution.hostProcessPlatform
+	}
+
+	$trjson = @"
+	{
+		"name":"$name",
+		"description":"Load Test queued from build",
+		"testSettings":{"cleanupCommand":"$cleanupScript", "hostProcessPlatform":"$processPlatform", "setupCommand":"$setupScript"},
+		"superSedeRunSettings":{"loadGeneratorMachinesType":"$machineType"},
+		"testDrop":{"id":"$tdid"},
+		"runSourceIdentifier":"build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
+	}
+"@
+	return $trjson
+}
+
+function ShowMessages($headers, $run, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}/messages?{2}", $CltAccountUrl, $run.id, $global:apiVersion)
+	$messages = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+	if ($messages)
+	{
+		$sMessages = $messages.value | Sort-Object loggedDate
+		foreach ($message in $sMessages)
+		{
+			switch ($message.messageType)
+			{
+				"info"     { Write-Host -NoNewline ("[Message]{0}" -f $message.message) }
+				"output"   { Write-Host -NoNewline ("[Message]{0}" -f $message.message) }
+				"warning"  { Write-Warning $message.message }
+				"error"    { Write-Error $message.message }
+				"critical" { Write-Error $message.message }
+			}
+		}
+	}
+}
+
+function GetTestErrors($headers, $run, $CltAccountUrl)
+{
+	$uri = [String]::Format("{0}/_apis/clt/testruns/{1}/errors?detailed=true&{2}", $CltAccountUrl, $run.id, $global:apiVersion)
+	$testerrors = Get $headers $uri
+	return $testerrors
+}
+
+function PrintErrorSummary($headers, $run, $CltAccountUrl, $monitorThresholds)
+{
+	$thresholdViolationsCount = 0
+	$errors = GetTestErrors $headers $run $CltAccountUrl
+	if ($errors -and $errors.count -gt 0 -and  $errors.types.count -gt 0)
+	{
+		foreach ($type in $errors.types)
+		{
+			foreach ($subType in $type.subTypes)
+			{
+				foreach ($errorDetail in $subType.errorDetailList)
+				{
+					if ($type.typeName -eq "ThresholdMessage")
+					{
+						Write-Warning ( "[{0}] {1} occurrences of {2} " -f $type.typeName, $errorDetail.occurrences, $errorDetail.messageText)
+						$thresholdViolationsCount += $errorDetail.occurrences
+					}
+					else
+					{
+						Write-Warning ( "[{0}] {1} occurrences of ['{2}','{3}','{4}'] : {5} " -f $type.typeName, $errorDetail.occurrences, $errorDetail.scenarioName, $errorDetail.testCaseName,
+						$subType.subTypeName, $errorDetail.messageText)
+					}
+				}
+				if ($type.typeName -eq "ThresholdMessage" -and $subType.subTypeName -eq "Critical" -and $monitorThresholds -and $subType.occurrences -gt $ThresholdLimit)
+				{
+					Write-Error ( "Your loadtest has crossed the permissible {0} threshold violations with {1} violations" -f $ThresholdLimit, $subType.occurrences )
+				}
+			}
+		}		
+	}
+	return $thresholdViolationsCount
+}
+
+
+function CheckTestErrors($headers, $run, $CltAccountUrl, $MonitorThresholds)
+{
+	$thresholdExceeded = $false
+	if ($MonitorThresholds)
+	{
+		$uri = [String]::Format("{0}/_apis/clt/testruns/{1}/errors?type=ThresholdMessage&detailed=True&{2}", $CltAccountUrl, $run.id, $global:apiVersion)
+		$errors = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
+
+		if ($errors -and $errors.count -gt 0 -and  $errors.types.count -gt 0)
+		{
+			foreach ($subType in $errors.types.subTypes)
+			{
+				if ($subType.subTypeName -eq 'Critical' -and $subType.occurrences -gt $ThresholdLimit)
+				{
+					$thresholdExceeded = $true
+					return $true;
+				}
+			}
+		}
+	}
+	return $false;
+}
+

--- a/Tasks/RunLoadTest/Start-CloudLoadTest.ps1
+++ b/Tasks/RunLoadTest/Start-CloudLoadTest.ps1
@@ -1,480 +1,196 @@
 [CmdletBinding(DefaultParameterSetName = 'None')]
 param
 (
-    [String]
-    $env:SYSTEM_DEFINITIONID,
-    [String]
-    $env:BUILD_BUILDID,
+[String]
+$env:SYSTEM_DEFINITIONID,
+[String]
+$env:BUILD_BUILDID,
 
-    [String] [Parameter(Mandatory = $true)]
-    $connectedServiceName,
+[String] [Parameter(Mandatory = $false)]
+$connectedServiceName,
 
-    [String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
-    $TestSettings,
-    [String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
-    $TestDrop,
-    [String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
-    $LoadTest,
-    [String]
-    $ThresholdLimit,
-    [String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
-    $MachineType
+[String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
+$TestSettings,
+[String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
+$TestDrop,
+[String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
+$LoadTest,
+[String]
+$ThresholdLimit,
+[String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
+$MachineType
 )
 
-$userAgent = "CloudLoadTestBuildTask"
-$apiVersion = "api-version=1.0"
-
-$global:ThresholdExceeded = $false
-$global:RestTimeout = 60
-$global:MonitorThresholds = $false
-$global:ElsAccountUrl = "http://www.visualstudio.com"
-$global:TFSAccountUrl = "http://www.visualstudio.com"
+$global:userAgent = "CloudLoadTestBuildTask"
+$global:apiVersion = "api-version=1.0"
 $global:ScopedTestDrop = $TestDrop
-$global:ThresholdsViolationCount = 0
+$ThresholdExceeded = $false
+$MonitorThresholds = $false
 
 function InitializeRestHeaders()
 {
-    $restHeaders = New-Object -TypeName "System.Collections.Generic.Dictionary[[String], [String]]"
-
-    $alternateCreds = [String]::Concat($Username, ":", $Password)
-    $basicAuth = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($alternateCreds))
-    $restHeaders.Add("Authorization", [String]::Concat("Basic ", $basicAuth))
-
-    return $restHeaders
+	$restHeaders = New-Object -TypeName "System.Collections.Generic.Dictionary[[String], [String]]"
+	if([string]::IsNullOrWhiteSpace($connectedServiceName))
+	{
+		$patToken = Get-AccessToken $connectedServiceDetails
+		ValidatePatToken $patToken
+		$restHeaders.Add("Authorization", [String]::Concat("Bearer ", $patToken))
+		
+	}
+	else
+	{
+		$Username = $connectedServiceDetails.Authorization.Parameters.Username
+		Write-Verbose "Username = $Username" -Verbose
+		$Password = $connectedServiceDetails.Authorization.Parameters.Password
+		$alternateCreds = [String]::Concat($Username, ":", $Password)
+		$basicAuth = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($alternateCreds))
+		$restHeaders.Add("Authorization", [String]::Concat("Basic ", $basicAuth))
+	}
+	return $restHeaders
 }
 
-function InvokeRestMethod($headers, $contentType, $uri , $method= "Get", $body)
+function Get-AccessToken($vssEndPoint) 
 {
-  $ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($uri)
-  $result = Invoke-RestMethod -ContentType "application/json" -UserAgent $userAgent -TimeoutSec $global:RestTimeout -Uri $uri -Method $method -Headers $headers -Body $body
-  $ServicePoint.CloseConnectionGroup("")
-  return $result
+	return $vssEndpoint.Authorization.Parameters.AccessToken
 }
 
-function CreateTestDrop($headers)
+function ValidatePatToken($token)
 {
-    $uri = [String]::Format("{0}/_apis/clt/testdrops?{1}", $global:ElsAccountUrl, $apiVersion)
-    $drop = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers -method Post -body "{ ""dropType"": ""TestServiceBlobDrop"" }"
-    return $drop
-}
-
-function Get($headers, $uri)
-{
-    try
-    {
-        $result = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
-        return $result
-    }
-    catch
-    {
-        Write-Host -NoNewline $_.Exception.Message
-    }
-}
-
-function GetTestDrop($drop, $headers)
-{
-    $uri = [String]::Format("{0}/_apis/clt/testdrops/{1}?{2}", $global:ElsAccountUrl, $drop.id, $apiVersion)
-    $testdrop = Get $headers $uri
-    return $testdrop
-}
-
-function GetTestRun($headers, $runId)
-{
-    $uri = [String]::Format("{0}/_apis/clt/testruns/{1}?{2}", $global:ElsAccountUrl, $runId, $apiVersion)
-    $run = Get $headers $uri
-    return $run
-}
-
-function GetTestErrors($headers, $run)
-{
-    $uri = [String]::Format("{0}/_apis/clt/testruns/{1}/errors?detailed=true&{2}", $global:ElsAccountUrl, $run.id, $apiVersion)
-    $testerrors = Get $headers $uri
-    return $testerrors
-}
-
-function QueueTestRun($headers, $runJson)
-{
-    $uri = [String]::Format("{0}/_apis/clt/testruns?{1}", $global:ElsAccountUrl, $apiVersion)
-    $run = InvokeRestMethod -contentType "application/json" -uri $uri -method Post -headers $headers -body $runJson
-
-$start = @"
-    {
-      "state": "queued"
-    }
-"@
-
-    $uri = [String]::Format("{0}/_apis/clt/testruns/{1}?{2}", $global:ElsAccountUrl, $run.id, $apiVersion)
-    InvokeRestMethod -contentType "application/json" -uri $uri -method Patch -headers $headers -body $start
-    $run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
-
-    return $run
-}
-
-function StopTestRun($headers, $run)
-{
-$stop = @"
-    {
-      "state": "aborted"
-    }
-"@
-    $uri = [String]::Format("{0}/_apis/clt/testruns/{1}?{2}", $global:ElsAccountUrl, $run.id, $apiVersion)
-    InvokeRestMethod -contentType "application/json" -uri $uri -method Patch -headers $headers -body $stop
-    $run = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
-    return $run
-
-}
-
-function RunInProgress($run)
-{
-    return $run.state -ne "completed" -and $run.state -ne "error" -and $run.state -ne "aborted"
-}
-
-function PrintErrorSummary($headers, $run)
-{
-    $errors = GetTestErrors $headers $run
-    if ($errors -and $errors.count -gt 0 -and  $errors.types.count -gt 0)
-    {
-        foreach ($type in $errors.types)
-        {
-            foreach ($subType in $type.subTypes)
-            {
-                foreach ($errorDetail in $subType.errorDetailList)
-                {
-                    if ($type.typeName -eq "ThresholdMessage")
-                    {
-                        Write-Warning ( "[{0}] {1} occurrences of {2} " -f $type.typeName, $errorDetail.occurrences, $errorDetail.messageText)
-                        $global:ThresholdsViolationCount += $errorDetail.occurrences
-                    }
-                    else
-                    {
-                        Write-Warning ( "[{0}] {1} occurrences of ['{2}','{3}','{4}'] : {5} " -f $type.typeName, $errorDetail.occurrences, $errorDetail.scenarioName, $errorDetail.testCaseName,
-                        $subType.subTypeName, $errorDetail.messageText)
-                    }
-                }
-                if ($type.typeName -eq "ThresholdMessage" -and $subType.subTypeName -eq "Critical" -and $global:MonitorThresholds -and $subType.occurrences -gt $ThresholdLimit)
-                {
-                    Write-Error ( "Your loadtest has crossed the permissible {0} threshold violations with {1} violations" -f $ThresholdLimit, $subType.occurrences )
-                }
-            }
-        }
-    }
-}
-
-function CheckTestErrors($headers, $run)
-{
-    if ($global:MonitorThresholds)
-    {
-        $uri = [String]::Format("{0}/_apis/clt/testruns/{1}/errors?type=ThresholdMessage&detailed=True&{2}", $global:ElsAccountUrl, $run.id, $apiVersion)
-        $errors = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
-
-        if ($errors -and $errors.count -gt 0 -and  $errors.types.count -gt 0)
-        {
-            foreach ($subType in $errors.types.subTypes)
-            {
-                if ($subType.subTypeName -eq 'Critical' -and $subType.occurrences -gt $ThresholdLimit)
-                {
-                    $global:ThresholdExceeded = $true
-                    return $true;
-                }
-            }
-        }
-    }
-    return $false;
-}
-
-function ShowMessages($headers, $run)
-{
-    $uri = [String]::Format("{0}/_apis/clt/testruns/{1}/messages?{2}", $global:ElsAccountUrl, $run.id, $apiVersion)
-    $messages = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
-    if ($messages)
-    {
-        $sMessages = $messages.value | Sort-Object loggedDate
-        foreach ($message in $sMessages)
-        {
-            switch ($message.messageType)
-            {
-                "info"     { Write-Host -NoNewline ("[Message]{0}" -f $message.message) }
-                "output"   { Write-Host -NoNewline ("[Message]{0}" -f $message.message) }
-                "warning"  { Write-Warning $message.message }
-                "error"    { Write-Error $message.message }
-                "critical" { Write-Error $message.message }
-            }
-        }
-    }
-}
-
-function UploadTestDrop($testdrop, $src)
-{   
-    $dest = $testdrop.accessData.dropContainerUrl
-    $sas = $testdrop.accessData.sasKey
-
-    $azcopy = Get-ToolPath -Name "AzCopy\AzCopy.exe"
-    Write-Verbose "Calling AzCopy = $azcopy" -Verbose
-
-    $azlog = ("{0}\..\azlog" -f $src)
-    $args = ("/Source:`"{0}`" /Dest:{1} /DestSAS:{2} /S /Z:`"{3}`"" -f $src, $dest, $sas, $azlog)
-    Write-Verbose "AzCopy Args = $args" -Verbose
-
-    Invoke-Tool -Path $azcopy -Arguments $args
-}
-
-function ComposeTestRunJson($name, $tdid)
-{
-    $processPlatform = "x86"
-    $setupScript=""
-    $cleanupScript=""
-
-    [xml]$tsxml = Get-Content $TestSettings
-    if ($tsxml.TestSettings.Scripts.setupScript)
-    {
-        $setupScript = [System.IO.Path]::GetFileName($tsxml.TestSettings.Scripts.setupScript)
-    }
-    if ($tsxml.TestSettings.Scripts.cleanupScript)
-    {
-        $cleanupScript = [System.IO.Path]::GetFileName($tsxml.TestSettings.Scripts.cleanupScript)
-    }
-    if ($tsxml.TestSettings.Execution.hostProcessPlatform)
-    {
-        $processPlatform = $tsxml.TestSettings.Execution.hostProcessPlatform
-    }
-
-$trjson = @"
-    {
-        "name":"$name",
-        "description":"Load Test queued from build",
-        "testSettings":{"cleanupCommand":"$cleanupScript", "hostProcessPlatform":"$processPlatform", "setupCommand":"$setupScript"},
-        "superSedeRunSettings":{"loadGeneratorMachinesType":"$MachineType"},
-        "testDrop":{"id":"$tdid"},
-        "runSourceIdentifier":"build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
-    }
-"@
-    return $trjson
-}
-
-function WriteTaskMessages($message)
-{
-    Write-Host ("{0}" -f $message ) -NoNewline
-}
-
-function MonitorTestRun($headers, $run)
-{
-    $runId = $run.id
-    if ($runId)
-    {
-        $abortRun = $false
-        do
-        {
-            Start-Sleep -s 15
-            $run = GetTestRun $headers $runId
-            $abortRun = CheckTestErrors $headers $run
-            if ($abortRun)
-            {
-                StopTestRun $headers $run
-            }
-        }
-        while (RunInProgress $run)
-    }
-}
-
-function MonitorAcquireResource($headers, $run)
-{
-    $runId = $run.id
-    if ($runId)
-    {
-        $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
-        do
-        {
-            Start-Sleep -s 5
-            $run = GetTestRun $headers $runId
-        }
-        while ($run.state -eq "queued")
-        if ($run.state -eq "inProgress")
-        {
-            WriteTaskMessages ("Acquiring test resources took {0}. Starting test execution." -f $($elapsed.Elapsed.ToString()))
-        }
-    }
-}
-
-function ComposeAccountUrl($vsoUrl)
-{
-    $elsUrl = $vsoUrl
-
-    if ($vsoUrl -notlike "*VSCLT.VISUALSTUDIO.COM*")
-    {
-        if ($vsoUrl -like "*VISUALSTUDIO.COM*")
-        {
-            $accountName = $vsoUrl.Split('//')[2].Split('.')[0]
-            $elsUrl = ("https://{0}.vsclt.visualstudio.com" -f $accountName)
-        }
-    }
-
-    return $elsUrl
-}
-
-function ErrorMessage($message)
-{
-    Write-Error $message
-    exit $LastExitCode
-}
-
-function ValidateFiles($inputName, $fileName)
-{
-    $file = Get-ChildItem -Path $TestDrop -recurse | where {$_.Name -eq $fileName} | Select -First 1
-    if ($file)
-    {
-        # Check for fileName
-        $global:ScopedTestDrop = $file.Directory.FullName
-        Write-Host -NoNewline ("Selected {0} is '{1}' under '{2}'"  -f $inputName, $file.FullName, $global:ScopedTestDrop)
-    }
-    else
-    {
-        ErrorMessage "No $inputName is present in the test drop."
-    }
-}
-
-function Validate()
-{
-    if (-Not (Test-Path $TestSettings))
-    {
-        ErrorMessage "The path for the test settings file does not exist. Please provide a valid path."
-    }
-
-    if (-Not (Test-Path $TestDrop))
-    {
-        ErrorMessage "The path for the load test files does not exist. Please provide a valid path."
-    }
-
-    ValidateFiles "load test file" $LoadTest
-}
-
-function UploadSummaryMdReport($summaryMdPath)
-{
-	Write-Verbose "Summary Markdown Path = $summaryMdPath"
-
-	if (($env:SYSTEM_HOSTTYPE -eq "build") -and (Test-Path($summaryMdPath)))
-	{	
-		Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=Load test results;]$summaryMdPath"
+	if([string]::IsNullOrWhiteSpace($token))
+	{
+		throw "Unable to generate Personal Access Token for the user. Contact Project Collection Administrator"
 	}
 }
+
+# Load all dependent files for execution
+. $PSScriptRoot/CltTasksUtility.ps1
+. $PSScriptRoot/VssConnectionHelper.ps1
 
 ############################################## PS Script execution starts here ##########################################
 WriteTaskMessages "Starting Load Test Script"
 
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Internal"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.DTA"
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.DevTestLabs"
 
-Write-Output "Test settings = $TestSettings"
-Write-Output "Test drop = $TestDrop"
-Write-Output "Load test = $LoadTest"
+Write-Output "Test settings = $testSettings"
+Write-Output "Test drop = $testDrop"
+Write-Output "Load test = $loadTest"
 Write-Output "Load generator machine type = $machineType"
 Write-Output "Run source identifier = build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
 
 #Validate Input
-Validate
+ValidateInputs $env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI $connectedServiceName $testSettings $testDrop $loadTest
 
 #Setting monitoring of Threshold rule appropriately
 if ($ThresholdLimit -and $ThresholdLimit -ge 0)
 {
-    $global:MonitorThresholds = $true
-    Write-Output "Threshold limit = $ThresholdLimit"
+	$MonitorThresholds = $true
+	Write-Output "Threshold limit = $ThresholdLimit"
 }
 
-$connectedServiceDetails = Get-ServiceEndpoint -Context $distributedTaskContext -Name $connectedServiceName
-
-$Username = $connectedServiceDetails.Authorization.Parameters.Username
-Write-Verbose "Username = $Username" -Verbose
-$Password = $connectedServiceDetails.Authorization.Parameters.Password
-$global:ElsAccountUrl = ComposeAccountUrl($connectedServiceDetails.Url.AbsoluteUri).TrimEnd('/')
-$global:TFSAccountUrl = $env:System_TeamFoundationCollectionUri.TrimEnd('/')
-
-Write-Verbose "VSO account Url = $global:TFSAccountUrl" -Verbose
-Write-Verbose "CLT account Url = $global:ElsAccountUrl" -Verbose
-
-#Setting Headers and account Url accordingly
-$headers = InitializeRestHeaders
-
-#Upload the test drop
-$elapsed = [System.Diagnostics.Stopwatch]::StartNew()
-$drop = CreateTestDrop $headers
-
-if ($drop.dropType -eq "TestServiceBlobDrop")
+#Initialize Connected Service Details
+if([string]::IsNullOrWhiteSpace($connectedServiceName))
 {
-    $drop = GetTestDrop $drop $headers
-    UploadTestDrop $drop $global:ScopedTestDrop
-    WriteTaskMessages ("Uploading test files took {0}. Queuing the test run." -f $($elapsed.Elapsed.ToString()))
-
-    #Queue the test run
-    $runJson = ComposeTestRunJson $LoadTest $drop.id
-
-    $run = QueueTestRun $headers $runJson
-    MonitorAcquireResource $headers $run
-
-    #Monitor the test run
-    $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
-    MonitorTestRun $headers $run
-    WriteTaskMessages ( "Run execution took {0}. Collecting results." -f $($elapsed.Elapsed.ToString()))
-
-    #Print the error and messages
-    $run = GetTestRun $headers $run.id
-    ShowMessages $headers $run
-    PrintErrorSummary $headers $run
-
-    if ($run.state -ne "completed")
-    {
-        Write-Error "Load test has failed. Please check error messages to fix the problem."
-    }
-    elseif ($global:ThresholdExceeded -eq $true)
-    {
-        Write-Error "Load test task is marked as failed, as the number of threshold errors has exceeded permissible limit."
-    }
-    else
-    {
-        WriteTaskMessages "The load test completed successfully."
-    }
-
-	$run = GetTestRun $headers $run.id
-	$webResultsUri = $run.WebResultUrl
-	
-    Write-Output ("Run-id for this load test is {0} and its name is '{1}'." -f  $run.runNumber, $run.name)	
-    Write-Output ("To view run details navigate to {0}" -f $webResultsUri)
-    Write-Output "To view detailed results navigate to Load Test | Load Test Manager in Visual Studio IDE, and open this run."
-
-    $resultsMDFolder = New-Item -ItemType Directory -Force -Path "$env:Temp\LoadTestResultSummary"
-    $resultFilePattern = ("CloudLoadTestResults_{0}_{1}_*.md" -f $env:AGENT_ID, $env:SYSTEM_DEFINITIONID)
-    $excludeFilePattern = ("CloudLoadTestResults_{0}_{1}_{2}_*.md" -f $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID)
-    Remove-Item $resultsMDFolder\$resultFilePattern -Exclude $excludeFilePattern -Force
-    $summaryFile =  ("{0}\CloudLoadTestResults_{1}_{2}_{3}_{4}.md" -f $resultsMDFolder, $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID, $run.id)
-	
-	if ($global:ThresholdExceeded -eq $true)
-	{
-        $thresholdMessage=("{0} thresholds violated." -f $global:ThresholdsViolationCount)
-        $thresholdImage="bowtie-status-error"
-	}
-	elseif ($global:ThresholdsViolationCount -gt 1)
-	{
-        $thresholdMessage=("{0} thresholds violated." -f $global:ThresholdsViolationCount)
-        $thresholdImage="bowtie-status-warning"
-	}
-	elseif ($global:ThresholdsViolationCount -eq 1)
-	{
-        $thresholdMessage=("{0} threshold violated." -f $global:ThresholdsViolationCount)
-        $thresholdImage="bowtie-status-warning"
-	}
-	else
-    {
-        $thresholdMessage="No thresholds violated."
-        $thresholdImage="bowtie-status-success"
-	}
-	
-	
-    $summary = ('<span class="bowtie-icon {3}" />   {4}<br/>[Test Run: {0}]({1}) using {2}.<br/>' -f  $run.runNumber, $webResultsUri , $run.name, $thresholdImage, $thresholdMessage)
-    
-	('<p>{0}</p>' -f $summary) | Out-File  $summaryFile -Encoding ascii -Append
-    UploadSummaryMdReport $summaryFile
+	$connectedServiceDetails = Get-ServiceEndpoint -Context $distributedTaskContext -Name SystemVssConnection
 }
 else
 {
-    Write-Error ("Connection '{0}' failed for service '{1}'" -f $connectedServiceName, $connectedServiceDetails.Url.AbsoluteUri)
+	$connectedServiceDetails = Get-ServiceEndpoint -Context $distributedTaskContext -Name $connectedServiceName
+}
+
+$VSOAccountUrl = $connectedServiceDetails.Url.AbsoluteUri
+Write-Output "VSO Account URL is : $VSOAccountUrl"
+$headers = InitializeRestHeaders
+$CltAccountUrl = ComposeAccountUrl $VSOAccountUrl $headers
+$TFSAccountUrl = $env:System_TeamFoundationCollectionUri.TrimEnd('/')
+
+Write-Output "TFS account Url = $TFSAccountUrl" -Verbose
+Write-Output "CLT account Url = $CltAccountUrl" -Verbose
+
+#Upload the test drop
+$elapsed = [System.Diagnostics.Stopwatch]::StartNew()
+$drop = CreateTestDrop $headers $CltAccountUrl
+
+if ($drop.dropType -eq "TestServiceBlobDrop")
+{
+	$drop = GetTestDrop $headers $drop $CltAccountUrl
+	Write-Output "Test Drop Source Location: $global:ScopedTestDrop"
+	UploadTestDrop $drop $global:ScopedTestDrop
+	WriteTaskMessages ("Uploading test files took {0}. Queuing the test run." -f $($elapsed.Elapsed.ToString()))
+
+	#Queue the test run
+	$runJson = ComposeTestRunJson $LoadTest $drop.id $MachineType
+
+	$run = QueueTestRun $headers $runJson $CltAccountUrl
+	MonitorAcquireResource $headers $run $CltAccountUrl
+
+	#Monitor the test run
+	$elapsed = [System.Diagnostics.Stopwatch]::StartNew()
+	$thresholdExceeded = MonitorTestRun $headers $run $CltAccountUrl $MonitorThresholds
+	WriteTaskMessages ( "Run execution took {0}. Collecting results." -f $($elapsed.Elapsed.ToString()))
+
+	#Print the error and messages
+	$run = GetTestRun $headers $run.id $CltAccountUrl
+	ShowMessages $headers $run $CltAccountUrl
+	$thresholdsViolatedCount = PrintErrorSummary $headers $run $CltAccountUrl $MonitorThresholds
+
+	if ($run.state -ne "completed")
+	{
+		Write-Error "Load test has failed. Please check error messages to fix the problem."
+	}
+	elseif ($thresholdExceeded -eq $true)
+	{
+		Write-Error "Load test task is marked as failed, as the number of threshold errors has exceeded permissible limit."
+	}
+	else
+	{
+		WriteTaskMessages "The load test completed successfully."
+	}
+
+	$run = GetTestRun $headers $run.id $CltAccountUrl
+	$webResultsUri = $run.WebResultUrl
+	
+	Write-Output ("Run-id for this load test is {0} and its name is '{1}'." -f  $run.runNumber, $run.name)	
+	Write-Output ("To view run details navigate to {0}" -f $webResultsUri)
+	Write-Output "To view detailed results navigate to Load Test | Load Test Manager in Visual Studio IDE, and open this run."
+
+	$resultsMDFolder = New-Item -ItemType Directory -Force -Path "$env:Temp\LoadTestResultSummary"
+	$resultFilePattern = ("CloudLoadTestResults_{0}_{1}_*.md" -f $env:AGENT_ID, $env:SYSTEM_DEFINITIONID)
+	$excludeFilePattern = ("CloudLoadTestResults_{0}_{1}_{2}_*.md" -f $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID)
+	Remove-Item $resultsMDFolder\$resultFilePattern -Exclude $excludeFilePattern -Force
+	$summaryFile =  ("{0}\CloudLoadTestResults_{1}_{2}_{3}_{4}.md" -f $resultsMDFolder, $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID, $run.id)
+	
+	if ($thresholdExceeded -eq $true)
+	{
+		$thresholdMessage=("{0} thresholds violated." -f $thresholdsViolatedCount)
+		$thresholdImage="bowtie-status-error"
+	}
+	elseif ($thresholdsViolatedCount -gt 1)
+	{
+		$thresholdMessage=("{0} thresholds violated." -f $thresholdsViolatedCount)
+		$thresholdImage="bowtie-status-warning"
+	}
+	elseif ($thresholdsViolatedCount -eq 1)
+	{
+		$thresholdMessage=("{0} threshold violated." -f $thresholdsViolatedCount)
+		$thresholdImage="bowtie-status-warning"
+	}
+	else
+	{
+		$thresholdMessage="No thresholds violated."
+		$thresholdImage="bowtie-status-success"
+	}
+	
+	
+	$summary = ('<span class="bowtie-icon {3}" />   {4}<br/>[Test Run: {0}]({1}) using {2}.<br/>' -f  $run.runNumber, $webResultsUri , $run.name, $thresholdImage, $thresholdMessage)
+	('<p>{0}</p>' -f $summary) | Out-File  $summaryFile -Encoding ascii -Append
+	UploadSummaryMdReport $summaryFile
+}
+else
+{
+	Write-Error ("Connection '{0}' failed for service '{1}'" -f $connectedServiceName, $connectedServiceDetails.Url.AbsoluteUri)
 }
 
 WriteTaskMessages "Load Test Script execution completed"

--- a/Tasks/RunLoadTest/VssConnectionHelper.ps1
+++ b/Tasks/RunLoadTest/VssConnectionHelper.ps1
@@ -1,0 +1,39 @@
+function Get-CltEndpoint($connectedServiceUrl, $headers)
+{
+	# Load all dependent files for execution
+	. $PSScriptRoot/CltTasksUtility.ps1
+	$vsoUrl = $connectedServiceUrl
+	Write-Host "Fetching the Clt endpoint for $vsoUrl"
+	$spsLocation = Get-SpsLocation $vsoUrl $headers
+	$cltLocation = Get-CltLocation $spsLocation $headers
+	return $cltLocation
+
+}
+
+function Get-SpsLocation($vsoUrl, $headers)
+{
+	Write-Host "Fetching the SPS endpoint for $vsoUrl"
+	$spsUniqueIdentifier = "951917AC-A960-4999-8464-E3F0AA25B381"
+	$spsLocation = Get-ServiceLocation $vsoUrl $headers $spsUniqueIdentifier
+	return $spsLocation
+}
+
+function Get-CltLocation($spsUrl, $headers)
+{
+	Write-Host "Fetching the CLT endpoint for $vsoUrl"
+	$cltUniqueIdentifier = "6C404D78-EF65-4E65-8B6A-DF19D6361EAE"
+	return Get-ServiceLocation $spsUrl $headers $cltUniqueIdentifier
+}
+
+function Get-ServiceLocation($baseUrl, $headers, $serviceUniqueIdentifier)
+{
+	# Load all dependent files for execution
+	. $PSScriptRoot/CltTasksUtility.ps1
+	$locationCallUri = [string]::Format("{0}/_apis/servicedefinitions/LocationService2/{1}", $baseUrl, $serviceUniqueIdentifier)
+	$locationCallJsonResponse = InvokeRestMethod -Uri $locationCallUri -contentType "application/json" -headers $headers -Method Get
+	if($locationCallJsonResponse)
+	{
+		return $locationCallJsonResponse.locationMappings.location|Select -First 1
+	}
+	return $null
+}

--- a/Tasks/RunLoadTest/task.json
+++ b/Tasks/RunLoadTest/task.json
@@ -1,83 +1,82 @@
 {
-    "id": "9E9DB38A-B40B-4C13-B7F0-31031C894C22",
-    "name": "CloudLoadTest",
-    "friendlyName": "Cloud-based Load Test",
-    "description": "Runs the load test in the cloud with Visual Studio Team Services",
-    "helpMarkDown": "This task triggers a cloud-based load test using Visual Studio Team Services. [Learn more](https://go.microsoft.com/fwlink/?linkid=546976).",
-    "category": "Test",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
-    "author": "Microsoft Corporation",
-    "version": {
-        "Major": 1,
-        "Minor": 0,
-        "Patch": 14
+  "id": "9E9DB38A-B40B-4C13-B7F0-31031C894C22",
+  "name": "CloudLoadTest",
+  "friendlyName": "Cloud-based Load Test",
+  "description": "Runs the load test in the cloud with Visual Studio Team Services",
+  "helpMarkDown": "This task triggers a cloud-based load test using Visual Studio Team Services. [Learn more](https://go.microsoft.com/fwlink/?linkid=546976).",
+  "category": "Test",
+  "visibility": [
+    "Build",
+    "Release"
+  ],
+  "author": "Microsoft Corporation",
+  "version": {
+    "Major": 1,
+    "Minor": 0,
+    "Patch": 16
+  },
+  "demands": [
+    "msbuild",
+    "azureps"
+  ],
+  "minimumAgentVersion": "1.83.0",
+  "inputs": [
+    {
+      "name": "connectedServiceName",
+      "type": "connectedService:Generic",
+      "label": "VS Team Services Connection",
+      "defaultValue": "",
+      "helpMarkDown": "Select a previously registered service connection to talk to the cloud-based load test service. Choose 'Manage' to register a new connection."
     },
-    "demands": [
-        "msbuild",
-        "azureps"
-    ],
-    "minimumAgentVersion": "1.83.0",
-    "inputs": [
-        {
-            "name": "connectedServiceName",
-            "type": "connectedService:Generic",
-            "label": "Registered connection",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Select a previously registered service connection to talk to the Cloud-based Load Test service. Choose 'Manage' to register a new connection."
-        },
-        {
-            "name": "TestSettings",
-            "type": "filePath",
-            "label": "Test settings file",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Relative path from repo root for the test settings file to use for the load test."
-        },
-        {
-            "name": "TestDrop",
-            "type": "filePath",
-            "label": "Load test files folder",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Relative path from repo root where the load test solution build output will be available."
-        },
-        {
-            "name": "LoadTest",
-            "type": "string",
-            "label": "Load test file",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "The load test filename to be used under the load test folder specified above."
-        },
-        {
-            "name": "ThresholdLimit",
-            "type": "string",
-            "label": "Number of permissible threshold violations",
-            "required": false,
-            "helpMarkDown": "Number of threshold violations above which the load test outcome is considered unsuccessful."
-        },
-        {
-            "name": "MachineType",
-            "type": "radio",
-            "label": "Run load test using",
-            "required": true,
-            "defaultValue": "0",
-            "options": {
-                "0": "Automatically provisioned agents",
-                "2": "Self-provisioned agents"
-            }
-        }
-    ],
-    "instanceNameFormat": "Cloud Load Test $(LoadTest)",
-    "execution": {
-        "PowerShell": {
-            "target": "$(currentDirectory)\\Start-CloudLoadTest.ps1",
-            "argumentFormat": "",
-            "workingDirectory": "$(currentDirectory)"
-        }
+    {
+      "name": "TestSettings",
+      "type": "filePath",
+      "label": "Test settings file",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Relative path from repo root for the test settings file to use for the load test."
+    },
+    {
+      "name": "TestDrop",
+      "type": "filePath",
+      "label": "Load test files folder",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Relative path from repo root where the load test solution build output will be available."
+    },
+    {
+      "name": "LoadTest",
+      "type": "string",
+      "label": "Load test file",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "The load test filename to be used under the load test folder specified above."
+    },
+    {
+      "name": "ThresholdLimit",
+      "type": "string",
+      "label": "Number of permissible threshold violations",
+      "required": false,
+      "helpMarkDown": "Number of threshold violations above which the load test outcome is considered unsuccessful."
+    },
+    {
+      "name": "MachineType",
+      "type": "radio",
+      "label": "Run load test using",
+      "required": true,
+      "defaultValue": "0",
+      "options": {
+        "0": "Automatically provisioned agents",
+		"2": "Self-provisioned agents"
+      }
     }
+  ],
+  "instanceNameFormat": "Cloud Load Test $(LoadTest)",
+  "execution": {
+    "PowerShell": {
+      "target": "$(currentDirectory)\\Start-CloudLoadTest.ps1",
+      "argumentFormat": "",
+      "workingDirectory": "$(currentDirectory)"
+    }
+  }
 }


### PR DESCRIPTION
- Fixed indentations in all CLT Build task PS scripts
- Changes to add failure criteria of Avg.Response time by fetching the avg response time from the Result Summary controller