### PR TITLE
Add copy and register timeout parameters

### DIFF
--- a/Tasks/ServiceFabricDeploy/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
+++ b/Tasks/ServiceFabricDeploy/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
@@ -35,6 +35,12 @@ function Publish-UpgradedServiceFabricApplication
     .PARAMETER SkipPackageValidation
     Switch signaling whether the package should be validated or not before deployment.
 
+    .PARAMETER CopyPackageTimeoutSec
+    Timeout in seconds for copying application package to image store.
+
+    .PARAMETER RegisterPackageTimeoutSec
+    Timeout in seconds for registering application package.
+
     .EXAMPLE
     Publish-UpgradeServiceFabricApplication -ApplicationPackagePath 'pkg\Debug' -ApplicationParameterFilePath 'AppParameters.Local.xml'
 
@@ -78,7 +84,15 @@ function Publish-UpgradedServiceFabricApplication
 
         [Parameter(ParameterSetName="ApplicationParameterFilePath")]
         [Parameter(ParameterSetName="ApplicationName")]
-        [Switch]$SkipPackageValidation
+        [Switch]$SkipPackageValidation,
+
+        [Parameter(ParameterSetName="ApplicationParameterFilePath")]
+        [Parameter(ParameterSetName="ApplicationName")]
+        [int]$CopyPackageTimeoutSec,
+
+        [Parameter(ParameterSetName="ApplicationParameterFilePath")]
+        [Parameter(ParameterSetName="ApplicationName")]
+        [int]$RegisterPackageTimeoutSec
     )
 
 
@@ -186,14 +200,43 @@ function Publish-UpgradedServiceFabricApplication
     
         $applicationPackagePathInImageStore = $names.ApplicationTypeName
         Write-Host (Get-VstsLocString -Key SFSDK_CopyingAppToImageStore)
-        Copy-ServiceFabricApplicationPackage -ApplicationPackagePath $AppPkgPathToUse -ImageStoreConnectionString $imageStoreConnectionString -ApplicationPackagePathInImageStore $applicationPackagePathInImageStore
+
+        $copyParameters = @{
+            'ApplicationPackagePath' = $AppPkgPathToUse
+            'ImageStoreConnectionString' = $imageStoreConnectionString
+            'ApplicationPackagePathInImageStore' = $applicationPackagePathInImageStore
+        }
+
+        if ($CopyPackageTimeoutSec)
+        {
+            $InstalledSdkVersion = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Service Fabric SDK" -Name FabricSDKVersion).FabricSDKVersion
+            if ([version]$InstalledSdkVersion -gt [version]"2.3")
+            {
+                $copyParameters['TimeOutSec'] = $CopyPackageTimeoutSec
+            }
+            else
+            {
+                Write-Warning (Get-VstsLocString -Key CopyPackageTimeoutSecWarning $InstalledSdkVersion)
+            }
+        }
+
+        Copy-ServiceFabricApplicationPackage @copyParameters
         if(!$?)
         {
             throw (Get-VstsLocString -Key SFSDK_CopyingAppToImageStoreFailed)
         }
-    
+        
+        $registerParameters = @{
+            'ApplicationPathInImageStore' = $applicationPackagePathInImageStore
+        }
+        
+        if ($RegisterPackageTimeoutSec)
+        {
+            $registerParameters['TimeOutSec'] = $RegisterPackageTimeoutSec
+        }
+
         Write-Host (Get-VstsLocString -Key SFSDK_RegisterAppType)
-        Register-ServiceFabricApplicationType -ApplicationPathInImageStore $applicationPackagePathInImageStore
+        Register-ServiceFabricApplicationType @registerParameters
         if(!$?)
         {
             throw Write-Host (Get-VstsLocString -Key SFSDK_RegisterAppTypeFailed)
@@ -273,7 +316,7 @@ function Publish-UpgradedServiceFabricApplication
         }
         elseif($upgradeStatus.UpgradeState -eq "RollingBackCompleted")
         {
-            Write-Host (Get-VstsLocString -Key SFSDK_UpgradeRolledBack)
+            Write-Error (Get-VstsLocString -Key SFSDK_UpgradeRolledBack)
         }
     }
 }

--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/en-US/resources.resjson
@@ -12,6 +12,10 @@
   "loc.input.help.publishProfilePath": "Path to the publish profile that defines the settings to use. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) and wildcards can be used in the path.",
   "loc.input.label.applicationParameterPath": "Application Parameters",
   "loc.input.help.applicationParameterPath": "Path to the application parameters file. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) and wildcards can be used in the path. If specified, this will override the value in the publish profile.",
+  "loc.input.label.copyPackageTimeoutSec": "CopyPackageTimeoutSec",
+  "loc.input.help.copyPackageTimeoutSec": "Timeout in seconds for copying application package to image store.",
+  "loc.input.label.registerPackageTimeoutSec": "RegisterPackageTimeoutSec",
+  "loc.input.help.registerPackageTimeoutSec": "Timeout in seconds for registering application package.",
   "loc.input.label.overridePublishProfileSettings": "Override All Publish Profile Upgrade Settings",
   "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the value specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",
@@ -20,7 +24,6 @@
   "loc.input.label.UpgradeReplicaSetCheckTimeoutSec": "UpgradeReplicaSetCheckTimeoutSec",
   "loc.input.label.ReplicaQuorumTimeoutSec": "ReplicaQuorumTimeoutSec",
   "loc.input.label.TimeoutSec": "TimeoutSec",
-  "loc.input.label.Force": "Force",
   "loc.input.label.ForceRestart": "ForceRestart",
   "loc.input.label.HealthCheckRetryTimeoutSec": "HealthCheckRetryTimeoutSec",
   "loc.input.label.HealthCheckWaitDurationSec": "HealthCheckWaitDurationSec",
@@ -77,5 +80,6 @@
   "loc.messages.SFSDK_UpgradeSuccess": "Upgrade completed successfully.",
   "loc.messages.SFSDK_UpgradeRolledBack": "Upgrade was rolled back.",
   "loc.messages.SFSDK_UnzipPackage": "Attempting to unzip '{0}' to location '{1}'.",
-  "loc.messages.SFSDK_UnexpectedError": "Unexpected Error. Error details: $_.Exception.Message"
+  "loc.messages.SFSDK_UnexpectedError": "Unexpected Error. Error details: $_.Exception.Message",
+  "loc.messages.CopyPackageTimeoutSecWarning": "The CopyPackageTimeoutSec parameter requires version '2.3' of the Service Fabric SDK, but the installed version is '{0}'. This parameter will be ignored."
 }

--- a/Tasks/ServiceFabricDeploy/task.json
+++ b/Tasks/ServiceFabricDeploy/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 1,
-        "Patch": 3
+        "Minor": 2,
+        "Patch": 0
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [

--- a/Tasks/ServiceFabricDeploy/task.json
+++ b/Tasks/ServiceFabricDeploy/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 2
+        "Patch": 3
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [
@@ -56,6 +56,22 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "Path to the application parameters file. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) and wildcards can be used in the path. If specified, this will override the value in the publish profile."
+        },
+        {
+            "name": "copyPackageTimeoutSec",
+            "type": "string",
+            "label": "CopyPackageTimeoutSec",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Timeout in seconds for copying application package to image store."
+        },
+        {
+            "name": "registerPackageTimeoutSec",
+            "type": "string",
+            "label": "RegisterPackageTimeoutSec",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Timeout in seconds for registering application package."
         },
         {
             "name": "overridePublishProfileSettings",
@@ -126,15 +142,6 @@
             "label": "TimeoutSec",
             "defaultValue": "",
             "required": false,
-            "groupname": "upgrade",
-            "visibleRule": "overridePublishProfileSettings = true && isUpgrade = true"
-        },
-        {
-            "name": "Force",
-            "type": "boolean",
-            "label": "Force",
-            "defaultValue": "true",
-            "required": true,
             "groupname": "upgrade",
             "visibleRule": "overridePublishProfileSettings = true && isUpgrade = true"
         },
@@ -281,6 +288,7 @@
         "SFSDK_UpgradeSuccess": "Upgrade completed successfully.",
         "SFSDK_UpgradeRolledBack": "Upgrade was rolled back.",
         "SFSDK_UnzipPackage": "Attempting to unzip '{0}' to location '{1}'.",
-        "SFSDK_UnexpectedError": "Unexpected Error. Error details: $_.Exception.Message"
+        "SFSDK_UnexpectedError": "Unexpected Error. Error details: $_.Exception.Message",
+        "CopyPackageTimeoutSecWarning": "The CopyPackageTimeoutSec parameter requires version '2.3' of the Service Fabric SDK, but the installed version is '{0}'. This parameter will be ignored."
     }
 }

--- a/Tasks/ServiceFabricDeploy/task.loc.json
+++ b/Tasks/ServiceFabricDeploy/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 2
+    "Patch": 3
   },
   "minimumAgentVersion": "1.95.0",
   "groups": [
@@ -56,6 +56,22 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.applicationParameterPath"
+    },
+    {
+      "name": "copyPackageTimeoutSec",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.copyPackageTimeoutSec",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.copyPackageTimeoutSec"
+    },
+    {
+      "name": "registerPackageTimeoutSec",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.registerPackageTimeoutSec",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.registerPackageTimeoutSec"
     },
     {
       "name": "overridePublishProfileSettings",
@@ -126,15 +142,6 @@
       "label": "ms-resource:loc.input.label.TimeoutSec",
       "defaultValue": "",
       "required": false,
-      "groupname": "upgrade",
-      "visibleRule": "overridePublishProfileSettings = true && isUpgrade = true"
-    },
-    {
-      "name": "Force",
-      "type": "boolean",
-      "label": "ms-resource:loc.input.label.Force",
-      "defaultValue": "true",
-      "required": true,
       "groupname": "upgrade",
       "visibleRule": "overridePublishProfileSettings = true && isUpgrade = true"
     },
@@ -281,6 +288,7 @@
     "SFSDK_UpgradeSuccess": "ms-resource:loc.messages.SFSDK_UpgradeSuccess",
     "SFSDK_UpgradeRolledBack": "ms-resource:loc.messages.SFSDK_UpgradeRolledBack",
     "SFSDK_UnzipPackage": "ms-resource:loc.messages.SFSDK_UnzipPackage",
-    "SFSDK_UnexpectedError": "ms-resource:loc.messages.SFSDK_UnexpectedError"
+    "SFSDK_UnexpectedError": "ms-resource:loc.messages.SFSDK_UnexpectedError",
+    "CopyPackageTimeoutSecWarning": "ms-resource:loc.messages.CopyPackageTimeoutSecWarning"
   }
 }

--- a/Tasks/ServiceFabricDeploy/task.loc.json
+++ b/Tasks/ServiceFabricDeploy/task.loc.json
@@ -12,8 +12,8 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 1,
-    "Patch": 3
+    "Minor": 2,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.95.0",
   "groups": [

--- a/Tasks/ServiceFabricDeploy/utilities.ps1
+++ b/Tasks/ServiceFabricDeploy/utilities.ps1
@@ -231,8 +231,7 @@ function Get-VstsUpgradeParameters
         "UpgradeReplicaSetCheckTimeoutSec",
         "ReplicaQuorumTimeoutSec",
         "TimeoutSec",
-        "ForceRestart",
-        "Force"
+        "ForceRestart"
     )
 
     $upgradeMode = Get-VstsInput -Name upgradeMode -Require
@@ -274,6 +273,8 @@ function Get-VstsUpgradeParameters
             }
         }
     }
+
+    $parameters["Force"] = $true
 
     return $parameters
 }

--- a/Tests/L0/ServiceFabricDeploy/AadDeploy.ps1
+++ b/Tests/L0/ServiceFabricDeploy/AadDeploy.ps1
@@ -84,7 +84,7 @@ Register-Mock Get-ApplicationNameFromApplicationParameterFile { $appName } -- "$
 # Indicate that the application does not exist on cluster
 Register-Mock Get-ServiceFabricApplication { $null } -- -ApplicationName $appName
 
-$publishArgs = @("-ApplicationPackagePath", $applicationPackagePath, "-ApplicationParameterFilePath", "$PSScriptRoot\data\ApplicationParameters.xml", "-Action", "RegisterAndCreate", "-OverwriteBehavior", "SameAppTypeAndVersion", "-ErrorAction", "Stop")
+$publishArgs = @("-ApplicationParameterFilePath:", "$PSScriptRoot\data\ApplicationParameters.xml", "-ErrorAction:", "Stop", "-ApplicationPackagePath:", $applicationPackagePath, "-Action:", "RegisterAndCreate", "-OverwriteBehavior:", "SameAppTypeAndVersion")
 Register-Mock Publish-NewServiceFabricApplication -Arguments $publishArgs 
 
 # Act

--- a/Tests/L0/ServiceFabricDeploy/CertDeploy.ps1
+++ b/Tests/L0/ServiceFabricDeploy/CertDeploy.ps1
@@ -54,8 +54,7 @@ Register-Mock Get-ApplicationNameFromApplicationParameterFile { $appName } -- "$
 
 # Indicate that the application does not exist on cluster
 Register-Mock Get-ServiceFabricApplication { $null } -- -ApplicationName $appName
-
-$publishArgs = @("-ApplicationPackagePath", $applicationPackagePath, "-ApplicationParameterFilePath", "$PSScriptRoot\data\ApplicationParameters.xml", "-Action", "RegisterAndCreate", "-OverwriteBehavior", "SameAppTypeAndVersion", "-ErrorAction", "Stop")
+$publishArgs = @("-ApplicationParameterFilePath:", "$PSScriptRoot\data\ApplicationParameters.xml", "-ErrorAction:", "Stop", "-ApplicationPackagePath:", $applicationPackagePath, "-Action:", "RegisterAndCreate", "-OverwriteBehavior:", "SameAppTypeAndVersion")
 Register-Mock Publish-NewServiceFabricApplication -Arguments $publishArgs 
 
 try

--- a/Tests/L0/ServiceFabricDeploy/NoAuthDeploy.ps1
+++ b/Tests/L0/ServiceFabricDeploy/NoAuthDeploy.ps1
@@ -42,9 +42,8 @@ Register-Mock Get-ApplicationNameFromApplicationParameterFile { $appName } -- "$
 
 # Indicate that the application does not exist on cluster
 Register-Mock Get-ServiceFabricApplication { $null } -- -ApplicationName $appName
-
-$publishArgs = @("-ApplicationPackagePath", $applicationPackagePath, "-ApplicationParameterFilePath", "$PSScriptRoot\data\ApplicationParameters.xml", "-Action", "RegisterAndCreate", "-OverwriteBehavior", "SameAppTypeAndVersion", "-ErrorAction", "Stop")
-Register-Mock Publish-NewServiceFabricApplication -Arguments $publishArgs 
+$publishArgs = @("-ApplicationParameterFilePath:", "$PSScriptRoot\data\ApplicationParameters.xml", "-ErrorAction:", "Stop", "-ApplicationPackagePath:", $applicationPackagePath, "-Action:", "RegisterAndCreate", "-OverwriteBehavior:", "SameAppTypeAndVersion")
+Register-Mock Publish-NewServiceFabricApplication -Arguments $publishArgs
 
 # Act
 @( & $PSScriptRoot/../../../Tasks/ServiceFabricDeploy/deploy.ps1 )


### PR DESCRIPTION
The copy timeout parameter only exists in the Service Fabric SDK v2.3, so we will display a warning if we have to ignore it. The register timeout parameter does not have that problem.

Also fixed two minor bugs:
1. Report an error if the upgrade was rolled back
2. Always set the 'Force' parameter to true in upgrade settings because setting it to false would result in an error

Fix for #2894 