### PR TITLE
Fixed a Gradle script file not being copied to output correctly.

### DIFF
--- a/Tasks/Gradle/make.json
+++ b/Tasks/Gradle/make.json
@@ -17,7 +17,8 @@
                 "CodeAnalysis/checkstyle.gradle",
                 "CodeAnalysis/checkstyle.xml",
                 "CodeAnalysis/pmd.gradle",
-                "CodeAnalysis/sonar.gradle"
+                "CodeAnalysis/sonar.gradle",
+                "CodeAnalysis/findbugs.gradle"
             ],
             "dest": "CodeAnalysis/"
         }

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 71
+        "Patch": 72
     },
     "demands": [
         "java"

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 71
+    "Patch": 72
   },
   "demands": [
     "java"


### PR DESCRIPTION
Non-source files are no longer copied to the output directly automatically, and need to be specified in this make.json file.