### PR TITLE
Support to ignore test failure in vstest task

### DIFF
--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -397,7 +397,8 @@ function executeVstest(testResultsDirectory: string, parallelRunSettingsFile: st
     tl.rmRF(testResultsDirectory, true);
     tl.mkdirP(testResultsDirectory);
     tl.cd(workingDirectory);
-    vstest.exec(<tr.IExecOptions>{ failOnStdErr: true })
+    var writeOnStdErr = (ignoreVstestFailure && ignoreVstestFailure.toLowerCase() === "true") ? false : true;
+    vstest.exec(<tr.IExecOptions>{ failOnStdErr: writeOnStdErr })
         .then(function(code) {
             cleanUp(parallelRunSettingsFile);
             defer.resolve(code);

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -397,16 +397,16 @@ function executeVstest(testResultsDirectory: string, parallelRunSettingsFile: st
     tl.rmRF(testResultsDirectory, true);
     tl.mkdirP(testResultsDirectory);
     tl.cd(workingDirectory);
-    var writeOnStdErr = (ignoreVstestFailure && ignoreVstestFailure.toLowerCase() === "true") ? false : true;
-    vstest.exec(<tr.IExecOptions>{ failOnStdErr: writeOnStdErr })
+    var ignoreTestFailures = ignoreVstestFailure && ignoreVstestFailure.toLowerCase() === "true";
+    vstest.exec(<tr.IExecOptions>{ failOnStdErr: !ignoreTestFailures })
         .then(function(code) {
             cleanUp(parallelRunSettingsFile);
             defer.resolve(code);
         })
         .fail(function(err) {
-			cleanUp(parallelRunSettingsFile);
+		    cleanUp(parallelRunSettingsFile);
             tl.warning(tl.loc('VstestFailed'));
-			if (ignoreVstestFailure && ignoreVstestFailure.toLowerCase() === "true") {
+			if (ignoreTestFailures) {
 				tl.warning(err);
 				defer.resolve(0);
 			}

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -49,6 +49,7 @@ try {
     var useNewCollectorFlag = tl.getVariable('tia.useNewCollector');
     var isPrFlow = tl.getVariable('tia.isPrFlow');
     var vsTestVersionForTIA: number[] = null;
+	var ignoreVstestFailure: string = tl.getVariable("vstest.ignorefailure");
 
     var useNewCollector = false;
     if (useNewCollectorFlag && useNewCollectorFlag.toUpperCase() === "TRUE") {
@@ -402,10 +403,16 @@ function executeVstest(testResultsDirectory: string, parallelRunSettingsFile: st
             defer.resolve(code);
         })
         .fail(function(err) {
-            cleanUp(parallelRunSettingsFile);
+			cleanUp(parallelRunSettingsFile);
             tl.warning(tl.loc('VstestFailed'));
-            tl.error(err);
-            defer.resolve(1);
+			if (ignoreVstestFailure && ignoreVstestFailure.toLowerCase() === "true") {
+				tl.warning(err);
+				defer.resolve(0);
+			}
+			else {
+				tl.error(err);
+				defer.resolve(1);
+			}
         });
     return defer.promise;
 }

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -49,7 +49,7 @@ try {
     var useNewCollectorFlag = tl.getVariable('tia.useNewCollector');
     var isPrFlow = tl.getVariable('tia.isPrFlow');
     var vsTestVersionForTIA: number[] = null;
-	var ignoreVstestFailure: string = tl.getVariable("vstest.ignorefailure");
+	var ignoreVstestFailure: string = tl.getVariable("vstest.ignoretestfailures");
 
     var useNewCollector = false;
     if (useNewCollectorFlag && useNewCollectorFlag.toUpperCase() === "TRUE") {

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -49,7 +49,7 @@ try {
     var useNewCollectorFlag = tl.getVariable('tia.useNewCollector');
     var isPrFlow = tl.getVariable('tia.isPrFlow');
     var vsTestVersionForTIA: number[] = null;
-	var ignoreVstestFailure: string = tl.getVariable("vstest.ignoretestfailures");
+    var ignoreVstestFailure: string = tl.getVariable("vstest.ignoretestfailures");
 
     var useNewCollector = false;
     if (useNewCollectorFlag && useNewCollectorFlag.toUpperCase() === "TRUE") {

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -239,7 +239,7 @@ describe('VsTest Suite', function () {
         tr.run()
             .then(() => {
                 assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length > 0, 'should have written to stderr.');
+                assert(tr.stderr.length > 0, 'should have written to stderr');
                 assert(tr.failed, 'task should have failed');
                 assert(tr.ran(vstestCmd), 'should have run vstest');
                 assert(tr.stdout.search(/##vso\[results.publish/) < 0, 'should not have published test results.');

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -239,8 +239,32 @@ describe('VsTest Suite', function () {
         tr.run()
             .then(() => {
                 assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length > 0, 'should have written to stderr');
+                assert(tr.stderr.length > 0, 'should have written to stderr.');
                 assert(tr.failed, 'task should have failed');
+                assert(tr.ran(vstestCmd), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish/) < 0, 'should not have published test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Vstest task when vstest is set to ignore test failures', (done) => {
+
+        let vstestCmd = [sysVstestLocation, '/source/dir/someFile2 /source/dir/someFile1', "/logger:trx"].join(" ");
+        setResponseFile('vstestSucceedsOnIgnoreFailure.json');
+
+        let tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testAssemblyVer2', '/source/dir/some/*pattern');
+        tr.setInput('vstestLocationMethod', 'version');
+        tr.setInput('vsTestVersion', '14.0');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should have not written to stderr. error: ' + tr.stderr);
+                assert(!tr.failed, 'task should not have failed');
                 assert(tr.ran(vstestCmd), 'should have run vstest');
                 assert(tr.stdout.search(/##vso\[results.publish/) < 0, 'should not have published test results.');
                 done();

--- a/Tests/L0/VsTest/vstestSucceedsOnIgnoreFailure.json
+++ b/Tests/L0/VsTest/vstestSucceedsOnIgnoreFailure.json
@@ -1,0 +1,33 @@
+{
+    "getVariable": {
+        "System.DefaultWorkingDirectory": "/source/dir",
+        "build.sourcesdirectory": "/source/dir",
+        "VS140COMNTools": "/vs/path",
+        "VSTest_14.0": "/vs/IDE/CommonExtensions/Microsoft/TestWindow",
+        "vstest.ignorefailure": "true"
+    },
+    "match": {
+        "**\\packages\\**\\*TestAdapter.dll": []
+    },
+    "findMatch": {
+        "/source/dir/some/*pattern": [
+            "/source/dir/someFile2",
+            "/source/dir/someFile1"
+        ],
+        "/source/dir/someFile1": [
+            "/source/dir/someFile1"
+        ]
+    },
+    "exec": {
+        "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile2 /source/dir/someFile1 /logger:trx": {
+            "code": 1,
+            "stdout": "running vstest"
+        }
+    },
+    "rmRF": {
+        "\\source\\dir\\TestResults": {
+            "success": true,
+            "message": "success"
+        }
+    }
+}

--- a/Tests/L0/VsTest/vstestSucceedsOnIgnoreFailure.json
+++ b/Tests/L0/VsTest/vstestSucceedsOnIgnoreFailure.json
@@ -4,7 +4,7 @@
         "build.sourcesdirectory": "/source/dir",
         "VS140COMNTools": "/vs/path",
         "VSTest_14.0": "/vs/IDE/CommonExtensions/Microsoft/TestWindow",
-        "vstest.ignorefailure": "true"
+        "vstest.ignoretestfailures": "true"
     },
     "match": {
         "**\\packages\\**\\*TestAdapter.dll": []


### PR DESCRIPTION
- Introduced checking for a variable to decide whether or not to fail on vstest execution failure.
- Added a json response file along with L0 test for js handler

Validation- Validated that on presence of the aforementioned variable, the task doesn't fail and moves on. And in absence, works as is.