### PR TITLE
Allow ServiceFabricDeploy task to specify the Upgrade Action.

### DIFF
--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/de-de/resources.resjson
@@ -16,6 +16,7 @@
   "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the value specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",
   "loc.input.label.upgradeMode": "Upgrade Mode",
+  "loc.input.label.upgradeAction": "Upgrade Action",
   "loc.input.label.FailureAction": "FailureAction",
   "loc.input.label.UpgradeReplicaSetCheckTimeoutSec": "UpgradeReplicaSetCheckTimeoutSec",
   "loc.input.label.ReplicaQuorumTimeoutSec": "ReplicaQuorumTimeoutSec",

--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/en-US/resources.resjson
@@ -20,6 +20,7 @@
   "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the value specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",
   "loc.input.label.upgradeMode": "Upgrade Mode",
+  "loc.input.label.upgradeAction": "Upgrade Action",
   "loc.input.label.FailureAction": "FailureAction",
   "loc.input.label.UpgradeReplicaSetCheckTimeoutSec": "UpgradeReplicaSetCheckTimeoutSec",
   "loc.input.label.ReplicaQuorumTimeoutSec": "ReplicaQuorumTimeoutSec",

--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/es-es/resources.resjson
@@ -16,6 +16,7 @@
   "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the value specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",
   "loc.input.label.upgradeMode": "Upgrade Mode",
+  "loc.input.label.upgradeAction": "Upgrade Action",
   "loc.input.label.FailureAction": "FailureAction",
   "loc.input.label.UpgradeReplicaSetCheckTimeoutSec": "UpgradeReplicaSetCheckTimeoutSec",
   "loc.input.label.ReplicaQuorumTimeoutSec": "ReplicaQuorumTimeoutSec",

--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/fr-fr/resources.resjson
@@ -16,6 +16,7 @@
   "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the value specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",
   "loc.input.label.upgradeMode": "Upgrade Mode",
+  "loc.input.label.upgradeAction": "Upgrade Action",
   "loc.input.label.FailureAction": "FailureAction",
   "loc.input.label.UpgradeReplicaSetCheckTimeoutSec": "UpgradeReplicaSetCheckTimeoutSec",
   "loc.input.label.ReplicaQuorumTimeoutSec": "ReplicaQuorumTimeoutSec",

--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/it-IT/resources.resjson
@@ -16,6 +16,7 @@
   "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the value specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",
   "loc.input.label.upgradeMode": "Upgrade Mode",
+  "loc.input.label.upgradeAction": "Upgrade Action",
   "loc.input.label.FailureAction": "FailureAction",
   "loc.input.label.UpgradeReplicaSetCheckTimeoutSec": "UpgradeReplicaSetCheckTimeoutSec",
   "loc.input.label.ReplicaQuorumTimeoutSec": "ReplicaQuorumTimeoutSec",

--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/ja-jp/resources.resjson
@@ -16,6 +16,7 @@
   "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the value specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",
   "loc.input.label.upgradeMode": "Upgrade Mode",
+  "loc.input.label.upgradeAction": "Upgrade Action",
   "loc.input.label.FailureAction": "FailureAction",
   "loc.input.label.UpgradeReplicaSetCheckTimeoutSec": "UpgradeReplicaSetCheckTimeoutSec",
   "loc.input.label.ReplicaQuorumTimeoutSec": "ReplicaQuorumTimeoutSec",

--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/ko-KR/resources.resjson
@@ -16,6 +16,7 @@
   "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the value specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",
   "loc.input.label.upgradeMode": "Upgrade Mode",
+  "loc.input.label.upgradeAction": "Upgrade Action",
   "loc.input.label.FailureAction": "FailureAction",
   "loc.input.label.UpgradeReplicaSetCheckTimeoutSec": "UpgradeReplicaSetCheckTimeoutSec",
   "loc.input.label.ReplicaQuorumTimeoutSec": "ReplicaQuorumTimeoutSec",

--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/ru-RU/resources.resjson
@@ -16,6 +16,7 @@
   "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the value specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",
   "loc.input.label.upgradeMode": "Upgrade Mode",
+  "loc.input.label.upgradeAction": "Upgrade Action",
   "loc.input.label.FailureAction": "FailureAction",
   "loc.input.label.UpgradeReplicaSetCheckTimeoutSec": "UpgradeReplicaSetCheckTimeoutSec",
   "loc.input.label.ReplicaQuorumTimeoutSec": "ReplicaQuorumTimeoutSec",

--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/zh-CN/resources.resjson
@@ -16,6 +16,7 @@
   "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the value specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",
   "loc.input.label.upgradeMode": "Upgrade Mode",
+  "loc.input.label.upgradeAction": "Upgrade Action",
   "loc.input.label.FailureAction": "FailureAction",
   "loc.input.label.UpgradeReplicaSetCheckTimeoutSec": "UpgradeReplicaSetCheckTimeoutSec",
   "loc.input.label.ReplicaQuorumTimeoutSec": "ReplicaQuorumTimeoutSec",

--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/zh-TW/resources.resjson
@@ -16,6 +16,7 @@
   "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the value specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",
   "loc.input.label.upgradeMode": "Upgrade Mode",
+  "loc.input.label.upgradeAction": "Upgrade Action",
   "loc.input.label.FailureAction": "FailureAction",
   "loc.input.label.UpgradeReplicaSetCheckTimeoutSec": "UpgradeReplicaSetCheckTimeoutSec",
   "loc.input.label.ReplicaQuorumTimeoutSec": "ReplicaQuorumTimeoutSec",

--- a/Tasks/ServiceFabricDeploy/deploy.ps1
+++ b/Tasks/ServiceFabricDeploy/deploy.ps1
@@ -110,6 +110,7 @@ try {
         throw (Get-VstsLocString -Key PublishProfileRequiredAppParams)
     }
 
+    $upgradeAction = "RegisterAndUpgrade"
     if ((Get-VstsInput -Name overridePublishProfileSettings) -eq "true")
     {
         Write-Host (Get-VstsLocString -Key OverrideUpgradeSettings)
@@ -117,6 +118,7 @@ try {
 
         if ($isUpgrade)
         {
+            $upgradeAction =  Get-VstsInput -Name upgradeAction -Require
             $upgradeParameters = Get-VstsUpgradeParameters
         }
     }
@@ -139,7 +141,7 @@ try {
         $publishParameters = @{
             'ApplicationPackagePath' = $applicationPackagePath
             'ApplicationParameterFilePath' = $applicationParameterFile
-            'Action' = "RegisterAndUpgrade"
+            'Action' = $upgradeAction
             'UpgradeParameters' = $upgradeParameters
             'UnregisterUnusedVersions' = $true
             'ErrorAction' = "Stop"

--- a/Tasks/ServiceFabricDeploy/task.json
+++ b/Tasks/ServiceFabricDeploy/task.json
@@ -106,6 +106,20 @@
             "visibleRule": "overridePublishProfileSettings = true && isUpgrade = true"
         },
         {
+            "name": "upgradeAction",
+            "type": "pickList",
+            "label": "Upgrade Action",
+            "defaultValue": "RegisterAndUpgrade",
+            "required": true,
+            "options": {
+                "RegisterAndUpgrade": "RegisterAndUpgrade",
+                "Upgrade": "Upgrade",
+                "Register": "Register"
+            },
+            "groupname": "upgrade",
+            "visibleRule": "overridePublishProfileSettings = true && isUpgrade = true"
+        },
+        {
             "name": "FailureAction",
             "type": "pickList",
             "label": "FailureAction",

--- a/Tasks/ServiceFabricDeploy/task.loc.json
+++ b/Tasks/ServiceFabricDeploy/task.loc.json
@@ -106,6 +106,20 @@
       "visibleRule": "overridePublishProfileSettings = true && isUpgrade = true"
     },
     {
+      "name": "upgradeAction",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.upgradeAction",
+      "defaultValue": "RegisterAndUpgrade",
+      "required": true,
+      "options": {
+        "RegisterAndUpgrade": "RegisterAndUpgrade",
+        "Upgrade": "Upgrade",
+        "Register": "Register"
+      },
+      "groupname": "upgrade",
+      "visibleRule": "overridePublishProfileSettings = true && isUpgrade = true"
+    },
+    {
       "name": "FailureAction",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.FailureAction",


### PR DESCRIPTION
To be able to specify if ServiceFabric should Register an
applicationType and Upgrade the actual application or only Upgrade (if
the applicationType has already been registered) you need to have the
ability to modify this behavior in the VSTS task as well.