### PR TITLE
Porting to M109 - Support to ignore test failure in vstest task

### DIFF
--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 82
+        "Patch": 83
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 82
+    "Patch": 83
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -46,7 +46,7 @@ try {
     var useNewCollectorFlag = tl.getVariable('tia.useNewCollector');
     var isPrFlow = tl.getVariable('tia.isPrFlow');
     var vsTestVersionForTIA: number[] = null;
-     var ignoreVstestFailure: string = tl.getVariable("vstest.ignoretestfailures"); 
+    var ignoreVstestFailure: string = tl.getVariable("vstest.ignoretestfailures"); 
 
     var useNewCollector = false;
     if (useNewCollectorFlag && useNewCollectorFlag.toUpperCase() == "TRUE") {
@@ -128,7 +128,6 @@ function getVsTestVersion(): number[] {
     let wmicArgs = ["datafile", "where", "name='".concat(vstestLocationEscaped, "'"), "get", "Version", "/Value"];
     wmicTool.arg(wmicArgs);
     let output = wmicTool.execSync();
-
     let verSplitArray = output.stdout.split("=");
     if (verSplitArray.length != 2) {
         tl.warning(tl.loc("ErrorReadingVstestVersion"));
@@ -418,7 +417,7 @@ function executeVstest(testResultsDirectory: string, parallelRunSettingsFile: st
     tl.rmRF(testResultsDirectory, true);
     tl.mkdirP(testResultsDirectory);
     tl.cd(workingDirectory);
-    var ignoreTestFailures = ignoreVstestFailure && ignoreVstestFailure.toLowerCase() === "true"; 
+    var ignoreTestFailures = ignoreVstestFailure && ignoreVstestFailure.toLowerCase() === "true";
     vstest.exec({ failOnStdErr: !ignoreTestFailures })
         .then(function (code) {
             cleanUp(parallelRunSettingsFile);

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -128,6 +128,7 @@ function getVsTestVersion(): number[] {
     let wmicArgs = ["datafile", "where", "name='".concat(vstestLocationEscaped, "'"), "get", "Version", "/Value"];
     wmicTool.arg(wmicArgs);
     let output = wmicTool.execSync();
+    
     let verSplitArray = output.stdout.split("=");
     if (verSplitArray.length != 2) {
         tl.warning(tl.loc("ErrorReadingVstestVersion"));

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -46,6 +46,7 @@ try {
     var useNewCollectorFlag = tl.getVariable('tia.useNewCollector');
     var isPrFlow = tl.getVariable('tia.isPrFlow');
     var vsTestVersionForTIA: number[] = null;
+     var ignoreVstestFailure: string = tl.getVariable("vstest.ignoretestfailures"); 
 
     var useNewCollector = false;
     if (useNewCollectorFlag && useNewCollectorFlag.toUpperCase() == "TRUE") {
@@ -417,7 +418,8 @@ function executeVstest(testResultsDirectory: string, parallelRunSettingsFile: st
     tl.rmRF(testResultsDirectory, true);
     tl.mkdirP(testResultsDirectory);
     tl.cd(workingDirectory);
-    vstest.exec({ failOnStdErr: true })
+    var ignoreTestFailures = ignoreVstestFailure && ignoreVstestFailure.toLowerCase() === "true"; 
+    vstest.exec({ failOnStdErr: !ignoreTestFailures })
         .then(function (code) {
             cleanUp(parallelRunSettingsFile);
             defer.resolve(code);
@@ -425,8 +427,14 @@ function executeVstest(testResultsDirectory: string, parallelRunSettingsFile: st
         .fail(function (err) {
             cleanUp(parallelRunSettingsFile);
             tl.warning(tl.loc('VstestFailed'));
-            tl.error(err);
-            defer.resolve(1);
+            if (ignoreTestFailures) {
+                tl.warning(err);
+                defer.resolve(0);
+            }
+            else {
+                tl.error(err);
+                defer.resolve(1);
+            }
         });
     return defer.promise;
 }

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -308,7 +308,7 @@ describe('VsTest Suite', function () {
         let filePattern = getTestDllString(["testAssembly1.dll", "testAssembly2.dll"]);
         let vstestCmd = [sysVstestLocation, filePattern, "/logger:trx"].join(" ");
 
-        setResponseFile('vstestSucceedsOnIgnoreFailure.json');
+        setResponseFile('vstestSucceedsOnIgnoreFailure.json', vstestCmd, false);
         let tr = new trm.TaskRunner('VSTest');
         let assemblyPattern = path.join(__dirname, "data", "testDlls", "*.dll");
 

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -304,6 +304,32 @@ describe('VsTest Suite', function () {
             });
     })
 
+    it('Vstest task when vstest is set to ignore test failures', (done) => {
+        let filePattern = getTestDllString(["testAssembly1.dll", "testAssembly2.dll"]);
+        let vstestCmd = [sysVstestLocation, filePattern, "/logger:trx"].join(" ");
+
+        setResponseFile('vstestSucceedsOnIgnoreFailure.json');
+        let tr = new trm.TaskRunner('VSTest');
+        let assemblyPattern = path.join(__dirname, "data", "testDlls", "*.dll");
+
+        tr.setInput('testAssembly', assemblyPattern);
+        tr.setInput('vstestLocationMethod', 'version');
+        tr.setInput('vsTestVersion', '14.0');
+        
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should have not written to stderr. error: ' + tr.stderr);
+                assert(!tr.failed, 'task should not have failed');
+                assert(tr.ran(vstestCmd), 'should have run vstest');
+                assert(tr.stdout.search(/##vso\[results.publish/) < 0, 'should not have published test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
     it('Vstest task when vstest of specified version is not found', (done) => {
 
         let filePattern = getTestDllString(["testAssembly1.dll"]);

--- a/Tests/L0/VsTest/vstestSucceedsOnIgnoreFailure.json
+++ b/Tests/L0/VsTest/vstestSucceedsOnIgnoreFailure.json
@@ -1,0 +1,34 @@
+{
+    "getVariable": {
+        "System.DefaultWorkingDirectory": "/source/dir",
+        "build.sourcesdirectory": "/source/dir",
+        "VS140COMNTools": "/vs/path",
+        "VSTest_14.0": "/vs/IDE/CommonExtensions/Microsoft/TestWindow",
+        "vstest.ignoretestfailures": "true"
+    },
+    "find": {
+        "/source/dir": [
+            "someDir/someFile2",
+            "/someDir/someFile1"
+        ]
+    },
+    "match": {
+        "\\source\\dir\\some\\*pattern": [
+            "some/path/one",
+            "some/path/two"
+        ],
+        "**\\packages\\**\\*TestAdapter.dll": []
+    },
+    "exec": {
+        "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe some/path/one some/path/two /logger:trx": {
+            "code": 1,
+            "stdout": "running vstest"
+        }
+    },
+    "rmRF": {
+        "\\source\\dir\\TestResults": {
+            "success": true,
+            "message": "success"
+        }
+    }
+}


### PR DESCRIPTION
Porting similar changes from master to m109
Introduced checking for a variable to decide whether or not to fail on vstest execution failure.
Added a json response file along with L0 test for js handler

Validation- Validated that on presence of the aforementioned variable, the task doesn't fail and moves on. And in absence, works as is.