### PR TITLE
Use valid results directory in Release Management

### DIFF
--- a/Tasks/JenkinsQueueJob/jenkinsqueuejobtask.ts
+++ b/Tasks/JenkinsQueueJob/jenkinsqueuejobtask.ts
@@ -75,7 +75,15 @@ export class TaskOptions {
         tl.debug('teamPluginUrl=' + this.teamPluginUrl);
 
         this.teamBuildPluginAvailable = false;
-        this.saveResultsTo = path.join(tl.getVariable('Build.StagingDirectory'), 'jenkinsResults');
+        // 'Build.StagingDirectory' is available during build.
+        // It is kept here (different than what is used during release) to maintain
+        // compatibility with other tasks relying on Jenkins results being placed in this folder.
+        var resultsDirectory: string = tl.getVariable('Build.StagingDirectory');
+        if (!resultsDirectory) {
+            // 'System.DefaultWorkingDirectory' is available during build and release
+            resultsDirectory = tl.getVariable('System.DefaultWorkingDirectory');
+        }
+        this.saveResultsTo = path.join(resultsDirectory, 'jenkinsResults');
 
         this.strictSSL = ("true" !== tl.getEndpointDataParameter(this.serverEndpoint, "acceptUntrustedCerts", true));
         tl.debug('strictSSL=' + this.strictSSL);

--- a/Tasks/JenkinsQueueJob/task.json
+++ b/Tasks/JenkinsQueueJob/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 5
+        "Patch": 6
     },
     "groups": [
         {

--- a/Tasks/JenkinsQueueJob/task.loc.json
+++ b/Tasks/JenkinsQueueJob/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 5
+    "Patch": 6
   },
   "groups": [
     {


### PR DESCRIPTION
This is just the first step in making the "Jenkins Queue Job" task work in RM.

In addition to this, the TFS Plugin for Jenkins crashes when build-only variables are not provided by RM.  As a next step, I will explore making the TFS Plugin for Jenkins not depend on build-only variables.