### PR TITLE
Try to fix issue #3196

### DIFF
--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -134,8 +134,8 @@ export async function getProvisioningProfileUUID(provProfilePath: string) {
 
     //find the provisioning profile UUID
     var provProfileDetails : string;
-    var getProvProfileDetailsCmd : ToolRunner = tl.tool(tl.which('security', true));
-    getProvProfileDetailsCmd.arg(['cms', '-D', '-i', provProfilePath]);
+    var getProvProfileDetailsCmd : ToolRunner = tl.tool(tl.which('openssl', true));
+    getProvProfileDetailsCmd.arg(['smime', '-inform', 'der', '-verify', '-noverify', '-in', provProfilePath]);
     getProvProfileDetailsCmd.on('stdout', function(data) {
         if(data) {
             if(provProfileDetails) {
@@ -197,8 +197,8 @@ export async function getProvisioningProfileType(provProfilePath: string) {
     try {
         //find the provisioning profile details
         var provProfileDetails:string;
-        var getProvProfileDetailsCmd:ToolRunner = tl.tool(tl.which('security', true));
-        getProvProfileDetailsCmd.arg(['cms', '-D', '-i', provProfilePath]);
+        var getProvProfileDetailsCmd : ToolRunner = tl.tool(tl.which('openssl', true));
+        getProvProfileDetailsCmd.arg(['smime', '-inform', 'der', '-verify', '-noverify', '-in', provProfilePath]);
         getProvProfileDetailsCmd.on('stdout', function (data) {
             if (data) {
                 if (provProfileDetails) {

--- a/Tasks/XamariniOS/Tests/L0SignWithFiles.ts
+++ b/Tasks/XamariniOS/Tests/L0SignWithFiles.ts
@@ -33,6 +33,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "xbuild": "/home/bin/xbuild",
         "nuget": "/home/bin/nuget",
         "security": "/usr/bin/security",
+        "openssl": "/usr/bin/openssl",
         "/usr/libexec/PlistBuddy": "/usr/libexec/PlistBuddy",
         "rm": "/bin/rm",
         "cp": "/bin/cp"
@@ -66,7 +67,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "1) 5229BFC905F473E52FAD51208174528106966930 \"iPhone Developer: XamariniOS Tester (HE432Y3E2Q)\"\n 1 valid identities found"
         },
-        "/usr/bin/security cms -D -i /user/build/testuuid.mobileprovision": {
+        "/usr/bin/openssl smime -inform der -verify -noverify -in /user/build/testuuid.mobileprovision": {
             "code": 0,
             "stdout": "prov profile details here"
         },
@@ -96,6 +97,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/home/bin/nuget": true,
         "src/project.sln": true,
         "/usr/bin/security": true,
+        "/usr/bin/openssl": true,
         "/usr/libexec/PlistBuddy": true,
         "/bin/rm": true,
         "/bin/cp": true

--- a/Tasks/Xcode/Tests/L0CreateIpaWithCodeSigning.ts
+++ b/Tasks/Xcode/Tests/L0CreateIpaWithCodeSigning.ts
@@ -41,6 +41,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "xcodebuild": "/home/bin/xcodebuild",
         "security": "/usr/bin/security",
+        "openssl": "/usr/bin/openssl",
         "/usr/libexec/PlistBuddy": "/usr/libexec/PlistBuddy",
         "rm": "/bin/rm",
         "cp": "/bin/cp"
@@ -48,6 +49,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "checkPath" : {
         "/home/bin/xcodebuild": true,
         "/usr/bin/security": true,
+        "/usr/bin/openssl": true,
         "/usr/libexec/PlistBuddy": true,
         "/bin/rm": true,
         "/bin/cp": true
@@ -124,7 +126,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "1) 5229BFC905F473E52FAD51208174528106966930 \"iPhone Developer: XcodeTask Tester (HE432Y3E2Q)\"\n 1 valid identities found"
         },
-        "/usr/bin/security cms -D -i /user/build/testuuid.mobileprovision": {
+        "/usr/bin/openssl smime -inform der -verify -noverify -in /user/build/testuuid.mobileprovision": {
             "code": 0,
             "stdout": "prov profile details here"
         },

--- a/Tasks/Xcode/Tests/L0ExportArchiveWithAuto.ts
+++ b/Tasks/Xcode/Tests/L0ExportArchiveWithAuto.ts
@@ -40,12 +40,14 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "xcodebuild": "/home/bin/xcodebuild",
         "security": "/usr/bin/security",
+        "openssl": "/usr/bin/openssl",
         "/usr/libexec/PlistBuddy": "/usr/libexec/PlistBuddy",
         "rm": "/bin/rm"
     },
     "checkPath" : {
         "/home/bin/xcodebuild": true,
         "/usr/bin/security": true,
+	"/usr/bin/openssl": true,
         "/usr/libexec/PlistBuddy": true,
         "/bin/rm": true,
     },
@@ -103,7 +105,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "plist add output here"
         },
-        "/usr/bin/security cms -D -i /user/build/testScheme.xcarchive/Products/testScheme.app/embedded.mobileprovision": {
+        "/usr/bin/openssl smime -inform der -verify -noverify -in /user/build/testScheme.xcarchive/Products/testScheme.app/embedded.mobileprovision": {
             "code": 0,
             "stdout": "prov profile details here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode8AutomaticSignWithDevTeam.ts
+++ b/Tasks/Xcode/Tests/L0Xcode8AutomaticSignWithDevTeam.ts
@@ -43,6 +43,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "xcodebuild": "/home/bin/xcodebuild",
         "security": "/usr/bin/security",
+        "openssl": "/usr/bin/openssl",
         "/usr/libexec/PlistBuddy": "/usr/libexec/PlistBuddy",
         "rm": "/bin/rm",
         "cp": "/bin/cp"
@@ -50,6 +51,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "checkPath" : {
         "/home/bin/xcodebuild": true,
         "/usr/bin/security": true,
+        "/usr/bin/openssl": true,
         "/usr/libexec/PlistBuddy": true,
         "/bin/rm": true,
         "/bin/cp": true
@@ -126,7 +128,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "1) 5229BFC905F473E52FAD51208174528106966930 \"iPhone Developer: XcodeTask Tester (HE432Y3E2Q)\"\n 1 valid identities found"
         },
-        "/usr/bin/security cms -D -i /user/build/testuuid.mobileprovision": {
+        "/usr/bin/openssl smime -inform der -verify -noverify -in /user/build/testuuid.mobileprovision": {
             "code": 0,
             "stdout": "prov profile details here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode8AutomaticSignWithFiles.ts
+++ b/Tasks/Xcode/Tests/L0Xcode8AutomaticSignWithFiles.ts
@@ -42,6 +42,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "xcodebuild": "/home/bin/xcodebuild",
         "security": "/usr/bin/security",
+        "openssl": "/usr/bin/openssl",
         "/usr/libexec/PlistBuddy": "/usr/libexec/PlistBuddy",
         "rm": "/bin/rm",
         "cp": "/bin/cp"
@@ -49,6 +50,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "checkPath" : {
         "/home/bin/xcodebuild": true,
         "/usr/bin/security": true,
+        "/usr/bin/openssl": true,
         "/usr/libexec/PlistBuddy": true,
         "/bin/rm": true,
         "/bin/cp": true
@@ -125,7 +127,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "1) 5229BFC905F473E52FAD51208174528106966930 \"iPhone Developer: XcodeTask Tester (HE432Y3E2Q)\"\n 1 valid identities found"
         },
-        "/usr/bin/security cms -D -i /user/build/testuuid.mobileprovision": {
+        "/usr/bin/openssl smime -inform der -verify -noverify -in /user/build/testuuid.mobileprovision": {
             "code": 0,
             "stdout": "prov profile details here"
         },

--- a/Tests/L0/Xcode/responseSigningFile.json
+++ b/Tests/L0/Xcode/responseSigningFile.json
@@ -63,7 +63,7 @@
       "code": 0,
       "stdout": "1) 5229BFC905F473E52FAD51208174528106966930 \"iPhone Developer: XcodeTask Tester (HE432Y3E2Q)\"\n 1 valid identities found"
     },
-    "/usr/bin/security cms -D -i /user/build/testuuid.mobileprovision": {
+    "/usr/bin/openssl smime -inform der -verify -noverify -in /user/build/testuuid.mobileprovision": {
       "code": 0,
       "stdout": "prov profile details here"
     },


### PR DESCRIPTION
The security command used to get UUID of provisioning profile
fails on macOS Sierra.
Instead, the command openssl can be used.