### PR TITLE
Fix cert import issue in ServiceFabricDeploy task

### DIFF
--- a/Tasks/ServiceFabricDeploy/task.json
+++ b/Tasks/ServiceFabricDeploy/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [

--- a/Tasks/ServiceFabricDeploy/task.loc.json
+++ b/Tasks/ServiceFabricDeploy/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 2,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "1.95.0",
   "groups": [

--- a/Tasks/ServiceFabricDeploy/utilities.ps1
+++ b/Tasks/ServiceFabricDeploy/utilities.ps1
@@ -185,12 +185,12 @@ function Add-Certificate
 
         if ($ConnectedServiceEndpoint.Auth.Parameters.CertificatePassword)
         {
-            $certificate.Import($bytes, $ConnectedServiceEndpoint.Auth.Parameters.CertificatePassword, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::DefaultKeySet)
+            $certPassword = $ConnectedServiceEndpoint.Auth.Parameters.CertificatePassword
         }
-        else
-        {
-            $certificate.Import($bytes)
-        }
+
+        # Explicitly set the key storage to use UserKeySet.  This will ensure the private key is stored in a folder location which the user has access to.
+        # If we don't explicitly set it to UserKeySet, it's possible the MachineKeySet will be used which the user doesn't have access to that folder location, resulting in an access denied error.
+        $certificate.Import($bytes, $certPassword, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::UserKeySet)
     }
     catch
     {


### PR DESCRIPTION
A customer was encountering an issue with the ServiceFabricDeploy task where an Access Denied error would occur when attempting to import their certificate used to connect to the cluster.

I determined that the certificate import logic was attempting to store the private key on the MachineKeys folder of the agent.  But the user being run as for the task does not have permission to that folder.

The fix is to explicitly set the key storage flags parameter to use UserKeySet which will store the private key in a user-scoped folder which the user will have permission to.  And I verified that the rest of the code which uses the certificate operates correctly when it is stored in this manner.