### PR TITLE
Always upload PMD, CheckStyle and FindBugs reports even if build failed

### DIFF
--- a/Tasks/Gradle/gradletask.ts
+++ b/Tasks/Gradle/gradletask.ts
@@ -100,7 +100,7 @@ async function execBuild() {
     gb.exec()
         .then(function (code) {
             gradleResult = code;
-            return processCodeAnalysisResults();
+            return sqGradle.processSonarQubeIntegration();
         })
         .then(() => {
             tl.debug(`Gradle result: ${gradleResult}`);
@@ -114,6 +114,10 @@ async function execBuild() {
             return Q.resolve(err);
         })
         .then(function (resp) {
+            // We should always publish pmd/checkstyle/findbugs result
+            tl.debug('Processing code analysis results');
+            codeAnalysisOrchestrator.publishCodeAnalysisResults();
+
             // We should always publish test results and code coverage
             publishTestResults(publishJUnitResults, testResultsFiles);
             publishCodeCoverage(isCodeCoverageOpted);
@@ -138,14 +142,6 @@ function enableSonarQubeAnalysis() {
         gb = sqGradle.applySonarQubeCodeCoverageArguments(gb, isCodeCoverageOpted, ccTool, summaryFile);
     }
     gb = codeAnalysisOrchestrator.configureBuild(gb);
-}
-
-function processCodeAnalysisResults(): Q.Promise<void> {
-
-    tl.debug('Processing code analysis results');
-    codeAnalysisOrchestrator.publishCodeAnalysisResults();
-
-    return sqGradle.processSonarQubeIntegration();
 }
 
 // Configure the JVM associated with this run.

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -15,8 +15,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 0,
-        "Patch": 72
+        "Minor": 111,
+        "Patch": 0
     },
     "demands": [
         "java"

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -15,8 +15,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 0,
-    "Patch": 72
+    "Minor": 111,
+    "Patch": 0
   },
   "demands": [
     "java"


### PR DESCRIPTION
processCodeAnalysisResults() actually do two things:
1. Publish pmd/checkstyle/findbugs result
2. SonarQube integration.

The SonarQube integration could fail the build task, but publishing pmd/checkstyle/findbugs result shouldn't.  We should always publish any available results. 