### PR TITLE
Fix bug in NugetPublisher where it would throw an error if no nuget packages are found

### DIFF
--- a/Tasks/NuGetPublisher/nugetpublisher.ts
+++ b/Tasks/NuGetPublisher/nugetpublisher.ts
@@ -33,7 +33,8 @@ async function main(): Promise<void> {
         let searchPattern = tl.getPathInput("searchPattern", true, false);
         let filesList = nutil.resolveFilterSpec(
             searchPattern,
-            tl.getVariable("System.DefaultWorkingDirectory") || process.cwd());
+            tl.getVariable("System.DefaultWorkingDirectory") || process.cwd(),
+            true);
         filesList.forEach(packageFile => {
             if (!tl.stats(packageFile).isFile()) {
                 throw new Error(tl.loc("NotARegularFile", packageFile));


### PR DESCRIPTION
Fix bug in NugetPublisher where it would throw an error if no nuget packages are found.

The "Q & A" in https://www.visualstudio.com/en-us/docs/build/steps/package/nuget-publisher
claims that the task should succeed if no packages are found to be published.

We set the `allowEmptyMatch` argument in the [resolveFilterSpec](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/Common/nuget-task-common/Utility.ts ) function to `true`.