### PR TITLE
fixing npm install to do only production dependencies

### DIFF
--- a/make-util.js
+++ b/make-util.js
@@ -129,7 +129,7 @@ var buildNodeTask = function (taskPath, outDir) {
     var originalDir = pwd();
     cd(taskPath);
     if (test('-f', rp('package.json'))) {
-        run('npm install');
+        run('npm install --production');
     }
     run('tsc --outDir ' + outDir + ' --rootDir ' + taskPath);
     cd(originalDir);

--- a/make.js
+++ b/make.js
@@ -192,7 +192,7 @@ target.build = function() {
                     rm('-Rf', path.join(taskPath, 'node_modules', modName));
                     var originalDir = pwd();
                     cd(taskPath);
-                    run('npm install ' + modOutDir);
+                    run('npm install --production ' + modOutDir);
                     cd(originalDir);
                 }
                 // copy module resources to the task output dir


### PR DESCRIPTION
Fix for https://github.com/Microsoft/vsts-tasks/issues/3336