### PR TITLE
Support CompressPackage option in ServiceFabricDeploy task

### DIFF
--- a/Tasks/ServiceFabricDeploy/ServiceFabricSDK/Publish-NewServiceFabricApplication.ps1
+++ b/Tasks/ServiceFabricDeploy/ServiceFabricSDK/Publish-NewServiceFabricApplication.ps1
@@ -256,7 +256,7 @@
 
         if ($CopyPackageTimeoutSec)
         {
-            if ($InstalledSdkVersion -gt [version]"2.3")
+            if ($InstalledSdkVersion -ge [version]"2.3")
             {
                 $copyParameters['TimeOutSec'] = $CopyPackageTimeoutSec
             }
@@ -268,7 +268,7 @@
 
         if ($CompressPackage)
         {
-            if ($InstalledSdkVersion -gt [version]"2.5")
+            if ($InstalledSdkVersion -ge [version]"2.5")
             {
                 $copyParameters['CompressPackage'] = $CompressPackage
             }

--- a/Tasks/ServiceFabricDeploy/ServiceFabricSDK/Publish-NewServiceFabricApplication.ps1
+++ b/Tasks/ServiceFabricDeploy/ServiceFabricSDK/Publish-NewServiceFabricApplication.ps1
@@ -42,6 +42,9 @@
     .PARAMETER RegisterPackageTimeoutSec
     Timeout in seconds for registering application package.
 
+    .PARAMETER CompressPackage
+    Indicates whether the application package should be compressed before copying to the image store.
+
     .EXAMPLE
     Publish-NewServiceFabricApplication -ApplicationPackagePath 'pkg\Debug' -ApplicationParameterFilePath 'Local.xml'
 
@@ -91,7 +94,11 @@
 
         [Parameter(ParameterSetName="ApplicationParameterFilePath")]
         [Parameter(ParameterSetName="ApplicationName")]
-        [int]$RegisterPackageTimeoutSec
+        [int]$RegisterPackageTimeoutSec,
+
+        [Parameter(ParameterSetName="ApplicationParameterFilePath")]
+        [Parameter(ParameterSetName="ApplicationName")]
+        [Switch]$CompressPackage
     )
 
 
@@ -245,16 +252,29 @@
             'ApplicationPackagePathInImageStore' = $applicationPackagePathInImageStore
         }
 
+        $InstalledSdkVersion = [version](Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Service Fabric SDK" -Name FabricSDKVersion).FabricSDKVersion
+
         if ($CopyPackageTimeoutSec)
         {
-            $InstalledSdkVersion = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Service Fabric SDK" -Name FabricSDKVersion).FabricSDKVersion
-            if ([version]$InstalledSdkVersion -gt [version]"2.3")
+            if ($InstalledSdkVersion -gt [version]"2.3")
             {
                 $copyParameters['TimeOutSec'] = $CopyPackageTimeoutSec
             }
             else
             {
-                Write-Warning (Get-VstsLocString -Key CopyPackageTimeoutSecWarning $InstalledSdkVersion)
+                Write-Warning (Get-VstsLocString -Key SFSDK_CopyPackageTimeoutSecWarning $InstalledSdkVersion)
+            }
+        }
+
+        if ($CompressPackage)
+        {
+            if ($InstalledSdkVersion -gt [version]"2.5")
+            {
+                $copyParameters['CompressPackage'] = $CompressPackage
+            }
+            else
+            {
+                Write-Warning (Get-VstsLocString -Key SFSDK_CompressPackageWarning $InstalledSdkVersion)
             }
         }
 

--- a/Tasks/ServiceFabricDeploy/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
+++ b/Tasks/ServiceFabricDeploy/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
@@ -218,7 +218,7 @@ function Publish-UpgradedServiceFabricApplication
 
         if ($CopyPackageTimeoutSec)
         {
-            if ($InstalledSdkVersion -gt [version]"2.3")
+            if ($InstalledSdkVersion -ge [version]"2.3")
             {
                 $copyParameters['TimeOutSec'] = $CopyPackageTimeoutSec
             }
@@ -230,7 +230,7 @@ function Publish-UpgradedServiceFabricApplication
 
         if ($CompressPackage)
         {
-            if ($InstalledSdkVersion -gt [version]"2.5")
+            if ($InstalledSdkVersion -ge [version]"2.5")
             {
                 $copyParameters['CompressPackage'] = $CompressPackage
             }

--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/en-US/resources.resjson
@@ -3,6 +3,7 @@
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=820528)",
   "loc.description": "Deploy a Service Fabric application to a cluster.",
   "loc.instanceNameFormat": "Deploy Service Fabric Application",
+  "loc.group.displayName.advanced": "Advanced Settings",
   "loc.group.displayName.upgrade": "Upgrade Settings",
   "loc.input.label.applicationPackagePath": "Application Package",
   "loc.input.help.applicationPackagePath": "Path to the application package that is to be deployed. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) and wildcards can be used in the path.",
@@ -12,12 +13,14 @@
   "loc.input.help.publishProfilePath": "Path to the publish profile that defines the settings to use. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) and wildcards can be used in the path.",
   "loc.input.label.applicationParameterPath": "Application Parameters",
   "loc.input.help.applicationParameterPath": "Path to the application parameters file. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) and wildcards can be used in the path. If specified, this will override the value in the publish profile.",
+  "loc.input.label.compressPackage": "Compress Package",
+  "loc.input.help.compressPackage": "Indicates whether the application package should be compressed before copying to the image store. If enabled, this will override the value in the publish profile.",
   "loc.input.label.copyPackageTimeoutSec": "CopyPackageTimeoutSec",
-  "loc.input.help.copyPackageTimeoutSec": "Timeout in seconds for copying application package to image store.",
+  "loc.input.help.copyPackageTimeoutSec": "Timeout in seconds for copying application package to image store. If specified, this will override the value in the publish profile.",
   "loc.input.label.registerPackageTimeoutSec": "RegisterPackageTimeoutSec",
   "loc.input.help.registerPackageTimeoutSec": "Timeout in seconds for registering application package.",
   "loc.input.label.overridePublishProfileSettings": "Override All Publish Profile Upgrade Settings",
-  "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the value specified below or the default value if not specified.",
+  "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the values specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",
   "loc.input.label.upgradeMode": "Upgrade Mode",
   "loc.input.label.FailureAction": "FailureAction",
@@ -81,5 +84,6 @@
   "loc.messages.SFSDK_UpgradeRolledBack": "Upgrade was rolled back.",
   "loc.messages.SFSDK_UnzipPackage": "Attempting to unzip '{0}' to location '{1}'.",
   "loc.messages.SFSDK_UnexpectedError": "Unexpected Error. Error details: $_.Exception.Message",
-  "loc.messages.CopyPackageTimeoutSecWarning": "The CopyPackageTimeoutSec parameter requires version '2.3' of the Service Fabric SDK, but the installed version is '{0}'. This parameter will be ignored."
+  "loc.messages.SFSDK_CopyPackageTimeoutSecWarning": "The CopyPackageTimeoutSec parameter requires version '2.3' of the Service Fabric SDK, but the installed version is '{0}'. This parameter will be ignored.",
+  "loc.messages.SFSDK_CompressPackageWarning": "The CompressPackage parameter requires version '2.5' of the Service Fabric SDK, but the installed version is '{0}'. This parameter will be ignored."
 }

--- a/Tasks/ServiceFabricDeploy/deploy.ps1
+++ b/Tasks/ServiceFabricDeploy/deploy.ps1
@@ -140,14 +140,17 @@ try {
         'ErrorAction' = "Stop"
     }
 
-    if ($publishProfile.CopyPackageParameters.CompressPackage)
+    if ($publishProfile.CopyPackageParameters)
     {
-        $publishParameters['CompressPackage'] = [System.Boolean]::Parse($publishProfile.CopyPackageParameters.CompressPackage)
-    }
+        if ($publishProfile.CopyPackageParameters.CompressPackage)
+        {
+            $publishParameters['CompressPackage'] = [System.Boolean]::Parse($publishProfile.CopyPackageParameters.CompressPackage)
+        }
 
-    if ($publishProfile.CopyPackageParameters.CopyPackageTimeoutSec)
-    {
-        $publishParameters['CopyPackageTimeoutSec'] = $publishProfile.CopyPackageParameters.CopyPackageTimeoutSec
+        if ($publishProfile.CopyPackageParameters.CopyPackageTimeoutSec)
+        {
+            $publishParameters['CopyPackageTimeoutSec'] = $publishProfile.CopyPackageParameters.CopyPackageTimeoutSec
+        }
     }
 
     # compressPackage task input overrides the publish profile if it's enabled.
@@ -162,6 +165,7 @@ try {
         $publishParameters['CopyPackageTimeoutSec'] = $copyPackageTimeoutSec
     }
 
+    # registerPackageTimeoutSec task input overrides the publish profile if it's enabled
     if ($registerPackageTimeoutSec)
     {
         $publishParameters['RegisterPackageTimeoutSec'] = $registerPackageTimeoutSec

--- a/Tasks/ServiceFabricDeploy/deploy.ps1
+++ b/Tasks/ServiceFabricDeploy/deploy.ps1
@@ -27,6 +27,7 @@ try {
 
     $copyPackageTimeoutSec = Get-VstsInput -Name copyPackageTimeoutSec
     $registerPackageTimeoutSec = Get-VstsInput -Name registerPackageTimeoutSec
+    $compressPackage = [System.Boolean]::Parse((Get-VstsInput -Name compressPackage))
 
     $clusterConnectionParameters = @{}
     
@@ -133,49 +134,52 @@ try {
     $applicationName = Get-ApplicationNameFromApplicationParameterFile $applicationParameterFile
     $app = Get-ServiceFabricApplication -ApplicationName $applicationName
 
+    $publishParameters = @{
+        'ApplicationPackagePath' = $applicationPackagePath
+        'ApplicationParameterFilePath' = $applicationParameterFile
+        'ErrorAction' = "Stop"
+    }
+
+    if ($publishProfile.CopyPackageParameters.CompressPackage)
+    {
+        $publishParameters['CompressPackage'] = [System.Boolean]::Parse($publishProfile.CopyPackageParameters.CompressPackage)
+    }
+
+    if ($publishProfile.CopyPackageParameters.CopyPackageTimeoutSec)
+    {
+        $publishParameters['CopyPackageTimeoutSec'] = $publishProfile.CopyPackageParameters.CopyPackageTimeoutSec
+    }
+
+    # compressPackage task input overrides the publish profile if it's enabled.
+    if ($compressPackage)
+    {
+        $publishParameters['CompressPackage'] = $compressPackage
+    }
+
+    # copyPackageTimeoutSec task input overrides the publish profile if it's set.
+    if ($copyPackageTimeoutSec)
+    {
+        $publishParameters['CopyPackageTimeoutSec'] = $copyPackageTimeoutSec
+    }
+
+    if ($registerPackageTimeoutSec)
+    {
+        $publishParameters['RegisterPackageTimeoutSec'] = $registerPackageTimeoutSec
+    }
+
     # Do an upgrade if configured to do so and the app actually exists
     if ($isUpgrade -and $app)
     {
-        $publishParameters = @{
-            'ApplicationPackagePath' = $applicationPackagePath
-            'ApplicationParameterFilePath' = $applicationParameterFile
-            'Action' = "RegisterAndUpgrade"
-            'UpgradeParameters' = $upgradeParameters
-            'UnregisterUnusedVersions' = $true
-            'ErrorAction' = "Stop"
-        }
-
-        if ($copyPackageTimeoutSec)
-        {
-            $publishParameters['CopyPackageTimeoutSec'] = $copyPackageTimeoutSec
-        }
-
-        if ($registerPackageTimeoutSec)
-        {
-            $publishParameters['RegisterPackageTimeoutSec'] = $registerPackageTimeoutSec
-        }
+        $publishParameters['Action'] = "RegisterAndUpgrade"
+        $publishParameters['UpgradeParameters'] = $upgradeParameters
+        $publishParameters['UnregisterUnusedVersions'] = $true
 
         Publish-UpgradedServiceFabricApplication @publishParameters
     }
     else
     {
-        $publishParameters = @{
-            'ApplicationPackagePath' = $applicationPackagePath
-            'ApplicationParameterFilePath' = $applicationParameterFile
-            'Action' = "RegisterAndCreate"
-            'OverwriteBehavior' = "SameAppTypeAndVersion"
-            'ErrorAction' = "Stop"
-        }
-
-        if ($copyPackageTimeoutSec)
-        {
-            $publishParameters['CopyPackageTimeoutSec'] = $copyPackageTimeoutSec
-        }
-
-        if ($registerPackageTimeoutSec)
-        {
-            $publishParameters['RegisterPackageTimeoutSec'] = $registerPackageTimeoutSec
-        }
+        $publishParameters['Action'] = "RegisterAndCreate"
+        $publishParameters['OverwriteBehavior'] = "SameAppTypeAndVersion"
 
         Publish-NewServiceFabricApplication @publishParameters
     }

--- a/Tasks/ServiceFabricDeploy/task.json
+++ b/Tasks/ServiceFabricDeploy/task.json
@@ -12,11 +12,16 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 2,
-        "Patch": 1
+        "Minor": 3,
+        "Patch": 0
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [
+        {
+            "name": "advanced",
+            "displayName": "Advanced Settings",
+            "isExpanded": false
+        },
         {
             "name": "upgrade",
             "displayName": "Upgrade Settings",
@@ -58,12 +63,22 @@
             "helpMarkDown": "Path to the application parameters file. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) and wildcards can be used in the path. If specified, this will override the value in the publish profile."
         },
         {
+            "name": "compressPackage",
+            "type": "boolean",
+            "label": "Compress Package",
+            "defaultValue": "false",
+            "required": false,
+            "groupname": "advanced",
+            "helpMarkDown": "Indicates whether the application package should be compressed before copying to the image store. If enabled, this will override the value in the publish profile."
+        },
+        {
             "name": "copyPackageTimeoutSec",
             "type": "string",
             "label": "CopyPackageTimeoutSec",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Timeout in seconds for copying application package to image store."
+            "groupname": "advanced",
+            "helpMarkDown": "Timeout in seconds for copying application package to image store. If specified, this will override the value in the publish profile."
         },
         {
             "name": "registerPackageTimeoutSec",
@@ -71,6 +86,7 @@
             "label": "RegisterPackageTimeoutSec",
             "defaultValue": "",
             "required": false,
+            "groupname": "advanced",
             "helpMarkDown": "Timeout in seconds for registering application package."
         },
         {
@@ -80,7 +96,7 @@
             "defaultValue": "false",
             "required": false,
             "groupname": "upgrade",
-            "helpMarkDown": "This will override all upgrade settings with either the value specified below or the default value if not specified."
+            "helpMarkDown": "This will override all upgrade settings with either the values specified below or the default value if not specified."
         },
         {
             "name": "isUpgrade",
@@ -289,6 +305,7 @@
         "SFSDK_UpgradeRolledBack": "Upgrade was rolled back.",
         "SFSDK_UnzipPackage": "Attempting to unzip '{0}' to location '{1}'.",
         "SFSDK_UnexpectedError": "Unexpected Error. Error details: $_.Exception.Message",
-        "CopyPackageTimeoutSecWarning": "The CopyPackageTimeoutSec parameter requires version '2.3' of the Service Fabric SDK, but the installed version is '{0}'. This parameter will be ignored."
+        "SFSDK_CopyPackageTimeoutSecWarning": "The CopyPackageTimeoutSec parameter requires version '2.3' of the Service Fabric SDK, but the installed version is '{0}'. This parameter will be ignored.",
+        "SFSDK_CompressPackageWarning": "The CompressPackage parameter requires version '2.5' of the Service Fabric SDK, but the installed version is '{0}'. This parameter will be ignored."
     }
 }

--- a/Tasks/ServiceFabricDeploy/task.loc.json
+++ b/Tasks/ServiceFabricDeploy/task.loc.json
@@ -12,11 +12,16 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 2,
-    "Patch": 1
+    "Minor": 3,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.95.0",
   "groups": [
+    {
+      "name": "advanced",
+      "displayName": "ms-resource:loc.group.displayName.advanced",
+      "isExpanded": false
+    },
     {
       "name": "upgrade",
       "displayName": "ms-resource:loc.group.displayName.upgrade",
@@ -58,11 +63,21 @@
       "helpMarkDown": "ms-resource:loc.input.help.applicationParameterPath"
     },
     {
+      "name": "compressPackage",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.compressPackage",
+      "defaultValue": "false",
+      "required": false,
+      "groupname": "advanced",
+      "helpMarkDown": "ms-resource:loc.input.help.compressPackage"
+    },
+    {
       "name": "copyPackageTimeoutSec",
       "type": "string",
       "label": "ms-resource:loc.input.label.copyPackageTimeoutSec",
       "defaultValue": "",
       "required": false,
+      "groupname": "advanced",
       "helpMarkDown": "ms-resource:loc.input.help.copyPackageTimeoutSec"
     },
     {
@@ -71,6 +86,7 @@
       "label": "ms-resource:loc.input.label.registerPackageTimeoutSec",
       "defaultValue": "",
       "required": false,
+      "groupname": "advanced",
       "helpMarkDown": "ms-resource:loc.input.help.registerPackageTimeoutSec"
     },
     {
@@ -289,6 +305,7 @@
     "SFSDK_UpgradeRolledBack": "ms-resource:loc.messages.SFSDK_UpgradeRolledBack",
     "SFSDK_UnzipPackage": "ms-resource:loc.messages.SFSDK_UnzipPackage",
     "SFSDK_UnexpectedError": "ms-resource:loc.messages.SFSDK_UnexpectedError",
-    "CopyPackageTimeoutSecWarning": "ms-resource:loc.messages.CopyPackageTimeoutSecWarning"
+    "SFSDK_CopyPackageTimeoutSecWarning": "ms-resource:loc.messages.SFSDK_CopyPackageTimeoutSecWarning",
+    "SFSDK_CompressPackageWarning": "ms-resource:loc.messages.SFSDK_CompressPackageWarning"
   }
 }

--- a/Tasks/ServiceFabricDeploy/utilities.ps1
+++ b/Tasks/ServiceFabricDeploy/utilities.ps1
@@ -146,8 +146,8 @@ function Read-PublishProfile
     $publishProfileElement = $publishProfileXml.PublishProfile
     $publishProfile = @{}
 
-    $publishProfile.ClusterConnectionParameters = Read-XmlElementAsHashtable $publishProfileElement.Item("ClusterConnectionParameters")
     $publishProfile.UpgradeDeployment = Read-XmlElementAsHashtable $publishProfileElement.Item("UpgradeDeployment")
+    $publishProfile.CopyPackageParameters = Read-XmlElementAsHashtable $publishProfileElement.Item("CopyPackageParameters")
 
     if ($publishProfileElement.Item("UpgradeDeployment"))
     {

--- a/Tests/L0/ServiceFabricDeploy/AadDeploy.ps1
+++ b/Tests/L0/ServiceFabricDeploy/AadDeploy.ps1
@@ -20,6 +20,7 @@ $connectionEndpoint = ([System.Uri]$connectionEndpointFullUrl).Authority
 Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
+Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
 
 # Setup file resolution
 Register-Mock Find-VstsFiles { $publishProfilePath } -- -LegacyPattern $publishProfilePath
@@ -84,7 +85,7 @@ Register-Mock Get-ApplicationNameFromApplicationParameterFile { $appName } -- "$
 # Indicate that the application does not exist on cluster
 Register-Mock Get-ServiceFabricApplication { $null } -- -ApplicationName $appName
 
-$publishArgs = @("-ApplicationParameterFilePath:", "$PSScriptRoot\data\ApplicationParameters.xml", "-ErrorAction:", "Stop", "-ApplicationPackagePath:", $applicationPackagePath, "-Action:", "RegisterAndCreate", "-OverwriteBehavior:", "SameAppTypeAndVersion")
+$publishArgs = @("-ApplicationParameterFilePath:", "$PSScriptRoot\data\ApplicationParameters.xml", "-OverwriteBehavior:", "SameAppTypeAndVersion", "-ApplicationPackagePath:", $applicationPackagePath, "-ErrorAction:", "Stop", "-Action:", "RegisterAndCreate")
 Register-Mock Publish-NewServiceFabricApplication -Arguments $publishArgs 
 
 # Act

--- a/Tests/L0/ServiceFabricDeploy/CertDeploy.ps1
+++ b/Tests/L0/ServiceFabricDeploy/CertDeploy.ps1
@@ -14,6 +14,7 @@ $appName = "AppName"
 Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
+Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
 
 # Setup file resolution
 Register-Mock Find-VstsFiles { $publishProfilePath } -- -LegacyPattern $publishProfilePath
@@ -54,7 +55,7 @@ Register-Mock Get-ApplicationNameFromApplicationParameterFile { $appName } -- "$
 
 # Indicate that the application does not exist on cluster
 Register-Mock Get-ServiceFabricApplication { $null } -- -ApplicationName $appName
-$publishArgs = @("-ApplicationParameterFilePath:", "$PSScriptRoot\data\ApplicationParameters.xml", "-ErrorAction:", "Stop", "-ApplicationPackagePath:", $applicationPackagePath, "-Action:", "RegisterAndCreate", "-OverwriteBehavior:", "SameAppTypeAndVersion")
+$publishArgs = @("-ApplicationParameterFilePath:", "$PSScriptRoot\data\ApplicationParameters.xml",  "-OverwriteBehavior:", "SameAppTypeAndVersion", "-ApplicationPackagePath:", $applicationPackagePath, "-ErrorAction:", "Stop", "-Action:", "RegisterAndCreate")
 Register-Mock Publish-NewServiceFabricApplication -Arguments $publishArgs 
 
 try
@@ -70,7 +71,10 @@ finally
     try
     {
         $cert = $store.Certificates.Find($certFindType, $certFindValue, $false)[0]
-        $store.Remove($cert)    
+        if ($cert)
+        {
+            $store.Remove($cert)
+        }    
     }
     finally
     {

--- a/Tests/L0/ServiceFabricDeploy/NoAuthDeploy.ps1
+++ b/Tests/L0/ServiceFabricDeploy/NoAuthDeploy.ps1
@@ -13,6 +13,7 @@ $appName = "AppName"
 Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
+Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
 
 # Setup file resolution
 Register-Mock Find-VstsFiles { $publishProfilePath } -- -LegacyPattern $publishProfilePath
@@ -42,7 +43,7 @@ Register-Mock Get-ApplicationNameFromApplicationParameterFile { $appName } -- "$
 
 # Indicate that the application does not exist on cluster
 Register-Mock Get-ServiceFabricApplication { $null } -- -ApplicationName $appName
-$publishArgs = @("-ApplicationParameterFilePath:", "$PSScriptRoot\data\ApplicationParameters.xml", "-ErrorAction:", "Stop", "-ApplicationPackagePath:", $applicationPackagePath, "-Action:", "RegisterAndCreate", "-OverwriteBehavior:", "SameAppTypeAndVersion")
+$publishArgs = @("-ApplicationParameterFilePath:", "$PSScriptRoot\data\ApplicationParameters.xml", "-OverwriteBehavior:", "SameAppTypeAndVersion", "-ApplicationPackagePath:", $applicationPackagePath, "-ErrorAction:", "Stop", "-Action:", "RegisterAndCreate")
 Register-Mock Publish-NewServiceFabricApplication -Arguments $publishArgs
 
 # Act


### PR DESCRIPTION
A new feature in Service Fabric SDK adds a CompressPackage option parameter to the Copy-ServiceFabricApplicationPackage cmdlet.  When enabled, this parameter compresses the package prior to copying it to the image store to improve performance.  The SF SDK updated the Publish-NewServiceFabricApplication and Publish-UpgradedServiceFabricApplication scripts to include this new parameter as well.  We should allow users of the Service Fabric Deploy task to make use of this feature.

Two changes that are made to support this feature:
- Referenced publish profiles can have the CompressPackage option specified.  This setting is now passed along to the call to Service Fabric SDK's Publish-NewServiceFabricApplication and Publish-UpgradedServiceFabricApplication scripts.
- Uses have the option to specify the CompressPackage option as part of the task itself which, if it's enabled, will override the setting in the publish profile.