### PR TITLE
Removing mocha from devdependencies (#3348)

### DIFF
--- a/Tasks/AzureNLBManagement/package.json
+++ b/Tasks/AzureNLBManagement/package.json
@@ -12,8 +12,5 @@
     "q": "1.4.1",
     "vso-node-api": "6.0.1-preview",
     "vsts-task-lib": "0.9.20"
-  },
-  "devDependencies": {
-    "mocha": "3.2.0"
   }
 }

--- a/Tasks/AzureRmWebAppDeployment/package.json
+++ b/Tasks/AzureRmWebAppDeployment/package.json
@@ -18,8 +18,5 @@
   "homepage": "https://github.com/Microsoft/vsts-tasks#readme",
   "dependencies": {
     "q": "1.4.1"
-  },
-  "devDependencies": {
-    "mocha": "^3.1.0"
   }
 }

--- a/Tasks/Common/azurerest-common/package.json
+++ b/Tasks/Common/azurerest-common/package.json
@@ -17,8 +17,5 @@
     "vso-node-api": "6.0.1-preview",
     "vsts-task-lib": "1.1.0",
     "xml2js": "0.4.13"
-  },
-  "devDependencies": {
-    "mocha": "^3.1.2"
   }
 }

--- a/Tasks/Common/webdeployment-common/package.json
+++ b/Tasks/Common/webdeployment-common/package.json
@@ -21,8 +21,5 @@
     "vsts-task-lib": "1.1.0",
     "winreg": "1.2.2",
     "xml2js": "0.4.13"
-  },
-  "devDependencies": {
-    "mocha": "^3.1.2"
   }
 }

--- a/Tasks/IISWebAppDeploymentOnMachineGroup/package.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroup/package.json
@@ -18,8 +18,5 @@
   "homepage": "https://github.com/Microsoft/vsts-tasks#readme",
   "dependencies": {
     "q": "1.4.1"
-  },
-   "devDependencies": {
-    "mocha": "^3.1.2"
   }
 }


### PR DESCRIPTION
* Removing mocha from devdependencies

* Removed devdependencies section

Verified running test
1. On existing repo after doing git clean -fdx
2. On fresh clone repo
3. Queued Task CI against this branch and it is green.