### PR TITLE
Fixing runsettings for TIA

### DIFF
--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 4 
+        "Patch": 5 
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -629,8 +629,16 @@ function runVStest(testResultsDirectory: string, settingsFile: string, vsVersion
                                                             }).finally(function() {
                                                                 cleanFiles(responseFile, listFile);
                                                             });
+                                                    })
+                                                    .fail(function (err) {
+                                                        tl.error(err)
+                                                        defer.resolve(1);
                                                     });
                                             }
+                                        })
+                                        .fail(function (err) {
+                                            tl.error(err)
+                                            defer.resolve(1);
                                         });
                                 }
                             })
@@ -662,6 +670,10 @@ function runVStest(testResultsDirectory: string, settingsFile: string, vsVersion
                                     .fail(function(code) {
                                         defer.resolve(code);
                                     });
+                            })
+                            .fail(function (err) {
+                                tl.error(err)
+                                defer.resolve(1);
                             });
                     })
                     .fail(function(err) {

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -957,32 +957,16 @@ function pushImpactLevelAndRootPathIfNotFound(dataCollectorArray): void {
             if (!dataCollectorArray[i].Configuration) {
                 dataCollectorArray[i] = { Configuration: {} };
             }
-            if (dataCollectorArray[i].Configuration.TestImpact && !dataCollectorArray[i].Configuration.RootPath) {
-                if (context && context === "CD") {
-                    dataCollectorArray[i].Configuration = { RootPath: "" };
-                } else {
-                    dataCollectorArray[i].Configuration = { RootPath: sourcesDir };
-                }
-            } else if (!dataCollectorArray[i].Configuration.TestImpact && dataCollectorArray[i].Configuration.RootPath) {
-                if (getTIALevel() === 'file') {
-                    dataCollectorArray[i].Configuration = { ImpactLevel: getTIALevel(), LogFilePath: 'true' };
-                } else {
-                    dataCollectorArray[i].Configuration = { ImpactLevel: getTIALevel() };
-                }
-            } else if (dataCollectorArray[i].Configuration && !dataCollectorArray[i].Configuration.TestImpact && !dataCollectorArray[i].Configuration.RootPath) {
-                if (context && context === "CD") {
-                    if (getTIALevel() === 'file') {
-                        dataCollectorArray[i].Configuration = { ImpactLevel: getTIALevel(), LogFilePath: 'true', RootPath: "" };
-                    } else {
-                        dataCollectorArray[i].Configuration = { ImpactLevel: getTIALevel(), RootPath: "" };
-                    }
-                } else {
-                    if (getTIALevel() === 'file') {
-                        dataCollectorArray[i].Configuration = { ImpactLevel: getTIALevel(), LogFilePath: 'true', RootPath: sourcesDir };
-                    } else {
-                        dataCollectorArray[i].Configuration = { ImpactLevel: getTIALevel(), RootPath: sourcesDir };
-                    }
-                }
+
+            //Add TIA level, Rootpath and LogFilePath config nodes.
+            dataCollectorArray[i].Configuration[0].ImpactLevel = getTIALevel();
+            if (getTIALevel() === 'file') {
+                dataCollectorArray[i].Configuration[0].LogFilePath = 'true';
+            }
+            if (context && context === "CD") {
+                dataCollectorArray[i].Configuration[0].RootPath = "";
+            } else {
+                dataCollectorArray[i].Configuration[0].RootPath = sourcesDir;
             }
 
             //Adding the codebase attribute to TestImpact collector 


### PR DESCRIPTION
Bug 869007
We are eating up user provided testimpact datacollector config from runsettings. Fixing this.