### PR TITLE
ServiceFabricDeploy control OverwriteBehavior from task

### DIFF
--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/en-US/resources.resjson
@@ -19,6 +19,8 @@
   "loc.input.help.copyPackageTimeoutSec": "Timeout in seconds for copying application package to image store. If specified, this will override the value in the publish profile.",
   "loc.input.label.registerPackageTimeoutSec": "RegisterPackageTimeoutSec",
   "loc.input.help.registerPackageTimeoutSec": "Timeout in seconds for registering application package.",
+  "loc.input.label.overwriteBehavior": "Overwrite Behavior",
+  "loc.input.help.overwriteBehavior": "Overwrite Behavior if an application exists in the cluster with the same name, and upgrades have not been configured.",
   "loc.input.label.overridePublishProfileSettings": "Override All Publish Profile Upgrade Settings",
   "loc.input.help.overridePublishProfileSettings": "This will override all upgrade settings with either the values specified below or the default value if not specified.",
   "loc.input.label.isUpgrade": "Upgrade the Application",

--- a/Tasks/ServiceFabricDeploy/deploy.ps1
+++ b/Tasks/ServiceFabricDeploy/deploy.ps1
@@ -181,9 +181,9 @@ try {
         Publish-UpgradedServiceFabricApplication @publishParameters
     }
     else
-    {
+    {        
         $publishParameters['Action'] = "RegisterAndCreate"
-        $publishParameters['OverwriteBehavior'] = "SameAppTypeAndVersion"
+        $publishParameters['OverwriteBehavior'] = Get-VstsInput -Name overwriteBehavior
 
         Publish-NewServiceFabricApplication @publishParameters
     }

--- a/Tasks/ServiceFabricDeploy/task.json
+++ b/Tasks/ServiceFabricDeploy/task.json
@@ -90,6 +90,20 @@
             "helpMarkDown": "Timeout in seconds for registering application package."
         },
         {
+            "name": "overwriteBehavior",
+            "type": "pickList",
+            "label": "Overwrite Behavior",
+            "defaultValue": "SameAppTypeAndVersion",
+            "required": true,
+            "options": {
+                "Always": "Always",
+                "Never": "Never",
+                "SameAppTypeAndVersion": "SameAppTypeAndVersion"
+            },
+            "groupname": "advanced",
+            "helpMarkDown": "Overwrite Behavior if an application exists in the cluster with the same name, and upgrades have not been configured."
+        },        
+        {
             "name": "overridePublishProfileSettings",
             "type": "boolean",
             "label": "Override All Publish Profile Upgrade Settings",
@@ -106,7 +120,7 @@
             "required": false,
             "groupname": "upgrade",
             "visibleRule": "overridePublishProfileSettings = true"
-        },
+        },        
         {
             "name": "upgradeMode",
             "type": "pickList",

--- a/Tasks/ServiceFabricDeploy/task.loc.json
+++ b/Tasks/ServiceFabricDeploy/task.loc.json
@@ -90,6 +90,20 @@
       "helpMarkDown": "ms-resource:loc.input.help.registerPackageTimeoutSec"
     },
     {
+      "name": "overwriteBehavior",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.overwriteBehavior",
+      "defaultValue": "SameAppTypeAndVersion",
+      "required": true,
+      "options": {
+        "Always": "Always",
+        "Never": "Never",
+        "SameAppTypeAndVersion": "SameAppTypeAndVersion"
+      },
+      "groupname": "advanced",
+      "helpMarkDown": "ms-resource:loc.input.help.overwriteBehavior"
+    },
+    {
       "name": "overridePublishProfileSettings",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.overridePublishProfileSettings",

--- a/Tests/L0/ServiceFabricDeploy/AadDeploy.ps1
+++ b/Tests/L0/ServiceFabricDeploy/AadDeploy.ps1
@@ -21,6 +21,7 @@ Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
 Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
+Register-Mock Get-VstsInput { "SameAppTypeAndVersion" } -- -Name overwriteBehavior
 
 # Setup file resolution
 Register-Mock Find-VstsFiles { $publishProfilePath } -- -LegacyPattern $publishProfilePath

--- a/Tests/L0/ServiceFabricDeploy/CertDeploy.ps1
+++ b/Tests/L0/ServiceFabricDeploy/CertDeploy.ps1
@@ -15,6 +15,7 @@ Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
 Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
+Register-Mock Get-VstsInput { "SameAppTypeAndVersion" } -- -Name overwriteBehavior
 
 # Setup file resolution
 Register-Mock Find-VstsFiles { $publishProfilePath } -- -LegacyPattern $publishProfilePath

--- a/Tests/L0/ServiceFabricDeploy/NoAuthDeploy.ps1
+++ b/Tests/L0/ServiceFabricDeploy/NoAuthDeploy.ps1
@@ -14,6 +14,7 @@ Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
 Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
+Register-Mock Get-VstsInput { "SameAppTypeAndVersion" } -- -Name overwriteBehavior
 
 # Setup file resolution
 Register-Mock Find-VstsFiles { $publishProfilePath } -- -LegacyPattern $publishProfilePath


### PR DESCRIPTION
Simple implementation for [[Feature request] ServiceFabricDeploy control OverwriteBehavior from task #2984](https://github.com/Microsoft/vsts-tasks/issues/2984)

Added the parameter to new Advanced group, since it is not related to upgrades but new deployments. This parameter is helpfull to simply replace any given version of a SF application, which is usefull for fast deployments early in a release pipeline where a fresh install can be used for acceptance testing.