### PR TITLE
Remove the (rc2) in the nuget 3.5 string

### DIFF
--- a/Tasks/NuGetInstaller/task.json
+++ b/Tasks/NuGetInstaller/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 27
+        "Patch": 28
     },
 	"runsOn": [
         "Agent",
@@ -94,7 +94,7 @@
             "groupName": "advanced",
             "options": {
                 "3.3.0": "3.3.0",
-                "3.5.0.1829": "3.5.0 - build 1938 (rc2)",
+                "3.5.0.1829": "3.5.0",
                 "custom": "Custom"
             }
         },

--- a/Tasks/NuGetInstaller/task.loc.json
+++ b/Tasks/NuGetInstaller/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 27
+    "Patch": 28
   },
   "runsOn": [
     "Agent",
@@ -94,7 +94,7 @@
       "groupName": "advanced",
       "options": {
         "3.3.0": "3.3.0",
-        "3.5.0.1829": "3.5.0 - build 1938 (rc2)",
+        "3.5.0.1829": "3.5.0",
         "custom": "Custom"
       }
     },

--- a/Tasks/NuGetPublisher/task.json
+++ b/Tasks/NuGetPublisher/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 28
+        "Patch": 29
     },
 	"runsOn": [
         "Agent",
@@ -98,7 +98,7 @@
             "groupName": "advanced",
             "options": {
                 "3.3.0": "3.3.0",
-                "3.5.0.1829": "3.5.0 - build 1829 (rc2)",
+                "3.5.0.1829": "3.5.0",
                 "custom": "Custom"
             }
         },

--- a/Tasks/NuGetPublisher/task.loc.json
+++ b/Tasks/NuGetPublisher/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 28
+    "Patch": 29
   },
   "runsOn": [
     "Agent",
@@ -98,7 +98,7 @@
       "groupName": "advanced",
       "options": {
         "3.3.0": "3.3.0",
-        "3.5.0.1829": "3.5.0 - build 1829 (rc2)",
+        "3.5.0.1829": "3.5.0",
         "custom": "Custom"
       }
     },


### PR DESCRIPTION
it was 3.5 rtm, we had to keep rc2 in there because nuget hadn't
make the rtm call yet.  Then we forgot to cleanup.