### PR TITLE
CocoaPods: support 2 optional arguments

### DIFF
--- a/Tasks/CocoaPods/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CocoaPods/Strings/resources.resjson/en-US/resources.resjson
@@ -3,9 +3,14 @@
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613745)",
   "loc.description": "CocoaPods is a dependency manager for Swift and Objective-C Cocoa projects. This task runs 'pod install'.",
   "loc.instanceNameFormat": "pod install",
+  "loc.group.displayName.advanced": "Advanced",
   "loc.input.label.cwd": "Working Directory",
   "loc.input.help.cwd": "Specify the working directory in which to execute this step. If left empty, the repository directory will be used.",
+  "loc.input.label.forceRepoUpdate": "Force Repo Update",
+  "loc.input.help.forceRepoUpdate": "Selecting this option will force running 'pod repo update' before install.",
+  "loc.input.label.projectDirectory": "Project Directory",
+  "loc.input.help.projectDirectory": "Optionally specify the path to the root of the project directory. If left empty, the project specified in the Podfile will be used. If no project is specified, then a search for an Xcode project will be made. If more than one Xcode project is found, an error will occur.",
   "loc.messages.PodReturnCode": "The 'pod' command exited with return code: %d",
   "loc.messages.PodFailed": "The 'pod' command failed with error: %s",
-  "loc.messages.CocoaPodsNotFound": "The 'pod' command was not found. Please install CocoaPods on the build machine (https://cocoapods.org/)."
+  "loc.messages.CocoaPodsNotFound": "The 'pod' command was not found. Please install CocoaPods on the agent machine (https://cocoapods.org/)."
 }

--- a/Tasks/CocoaPods/cocoapods.ts
+++ b/Tasks/CocoaPods/cocoapods.ts
@@ -2,6 +2,9 @@ import path = require('path');
 import tl = require('vsts-task-lib/task');
 import trm = require('vsts-task-lib/toolrunner');
 
+// The CocoaPods install command is documented here:
+// https://guides.cocoapods.org/terminal/commands.html#pod_install
+
 async function run() {
     try {
         // Set path to resource strings
@@ -20,13 +23,26 @@ async function run() {
             throw new Error(tl.loc('CocoaPodsNotFound'));
         }
 
-        // Run 'pod install'
+        // Prepare to run 'pod install'
         var pod: trm.ToolRunner = tl.tool(podPath);
         pod.arg('install');
 
+        // Force updating the pod repo before install?
+        if (tl.getBoolInput('forceRepoUpdate', true)) {
+            pod.arg('--repo-update');
+        }
+
+        // Explicitly specify a project directory?
+        var projectDirectory: string = tl.getPathInput('projectDirectory', false, true);
+        if (projectDirectory) {
+            pod.arg('--project-directory=' + projectDirectory);
+        }
+
+        // Execute
+        var returnCode: number = await pod.exec();
+        
         // Get the result code and set the task result accordingly
-        var code: number = await pod.exec();
-        tl.setResult(tl.TaskResult.Succeeded, tl.loc('PodReturnCode', code));
+        tl.setResult(tl.TaskResult.Succeeded, tl.loc('PodReturnCode', returnCode));
     }
     catch(err) {
         // Report failure

--- a/Tasks/CocoaPods/task.json
+++ b/Tasks/CocoaPods/task.json
@@ -15,9 +15,16 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 1,
-        "Patch": 20
+        "Minor": 112,
+        "Patch": 0
     },
+    "groups": [
+        {
+            "name": "advanced",
+            "displayName": "Advanced",
+            "isExpanded": true
+        }
+    ],
     "instanceNameFormat": "pod install",
     "inputs": [
         {
@@ -27,6 +34,24 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "Specify the working directory in which to execute this step. If left empty, the repository directory will be used."
+        },
+        {
+            "name": "forceRepoUpdate",
+            "type": "boolean",
+            "label": "Force Repo Update",
+            "defaultValue": false,
+            "required": true,
+            "helpMarkDown": "Selecting this option will force running 'pod repo update' before install.",
+            "groupName": "advanced"
+        },
+        {
+            "name": "projectDirectory",
+            "type": "filePath",
+            "label": "Project Directory",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Optionally specify the path to the root of the project directory. If left empty, the project specified in the Podfile will be used. If no project is specified, then a search for an Xcode project will be made. If more than one Xcode project is found, an error will occur.",
+            "groupName": "advanced"
         }
     ],
     "execution": {
@@ -38,6 +63,6 @@
     "messages": {
         "PodReturnCode": "The 'pod' command exited with return code: %d",
         "PodFailed": "The 'pod' command failed with error: %s",
-        "CocoaPodsNotFound": "The 'pod' command was not found. Please install CocoaPods on the build machine (https://cocoapods.org/)."
+        "CocoaPodsNotFound": "The 'pod' command was not found. Please install CocoaPods on the agent machine (https://cocoapods.org/)."
     }
 }

--- a/Tasks/CocoaPods/task.loc.json
+++ b/Tasks/CocoaPods/task.loc.json
@@ -15,9 +15,16 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 1,
-    "Patch": 20
+    "Minor": 112,
+    "Patch": 0
   },
+  "groups": [
+    {
+      "name": "advanced",
+      "displayName": "ms-resource:loc.group.displayName.advanced",
+      "isExpanded": true
+    }
+  ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [
     {
@@ -27,6 +34,24 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.cwd"
+    },
+    {
+      "name": "forceRepoUpdate",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.forceRepoUpdate",
+      "defaultValue": false,
+      "required": true,
+      "helpMarkDown": "ms-resource:loc.input.help.forceRepoUpdate",
+      "groupName": "advanced"
+    },
+    {
+      "name": "projectDirectory",
+      "type": "filePath",
+      "label": "ms-resource:loc.input.label.projectDirectory",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.projectDirectory",
+      "groupName": "advanced"
     }
   ],
   "execution": {


### PR DESCRIPTION
This allows for additional, optional parameters of the `pod install` command.
See https://guides.cocoapods.org/terminal/commands.html#pod_install.
#2903 