### PR TITLE
Fixes Jenkins job search responses which doesn't have downstreamProjects

### DIFF
--- a/Tasks/JenkinsQueueJob/job.ts
+++ b/Tasks/JenkinsQueueJob/job.ts
@@ -269,7 +269,7 @@ export class Job {
         thisJob.search.initialize().then(() => {
             if (thisJob.search.initialized) {
                 if (thisJob.queue.taskOptions.capturePipeline) {
-                    var downstreamProjects = thisJob.search.parsedTaskBody.downstreamProjects;
+                    var downstreamProjects = thisJob.search.parsedTaskBody.downstreamProjects || [];
                     downstreamProjects.forEach((project) => {
                         new Job(thisJob.queue, thisJob, project.url, null, -1, project.name); // will add a new child to the tree
                     });


### PR DESCRIPTION
Regarding: https://github.com/Microsoft/vsts-tasks/issues/3135

@DavidStaheli: you were right. The main problem exists in the [Jenkins TFS plugin](github.com/jenkinsci/tfs-plugin/). However, there is a small bug in the JenkinsQueueJob task as well. Therefore, it would be nice if you would review/merge this pull request.

In more details: the Job class currently assumes _thisJob.search.parsedTaskBody.downstreamProjects_ as being an array. However, in the case of a MultibranchPipeline Job, Jenkins does not return 'downstreamProjects' as a JSON key at all (i.e. undefined). Of course, _downstreamProjects.forEach()_ fails in this case. This fix / pull request will avoid this failure.