### PR TITLE
Bumping up VsTest Tasks version

### DIFF
--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 83
+        "Patch": 84
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 83
+    "Patch": 84
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Description: VsTest task was modified to remove Test Impact related changes from version 1 of the task. Due to some merge error, the task version did not get incremented. This PR is for bumping the task version of VsTest task.