### PR TITLE
add multithread robocopy in PublishBuildArtifacts

### DIFF
--- a/Tasks/PublishBuildArtifacts/Invoke-Robocopy.ps1
+++ b/Tasks/PublishBuildArtifacts/Invoke-Robocopy.ps1
@@ -33,7 +33,7 @@ $writer = New-Object System.IO.StreamWriter($stdout, $utf8)
 # PowerShell 4, Write-Host and Out-Default do not consider the updated stream writer.
 
 # Print the ##command.
-[System.Console]::WriteLine("##[command]robocopy.exe /E /COPY:DA /NP /R:3 /MT:128`"$Source`" `"$Target`" *")
+[System.Console]::WriteLine("##[command]robocopy.exe /E /COPY:DA /NP /R:3 /MT:128 `"$Source`" `"$Target`" *")
 
 # The $OutputEncoding variable instructs PowerShell how to interpret the output
 # from the external command.

--- a/Tasks/PublishBuildArtifacts/Invoke-Robocopy.ps1
+++ b/Tasks/PublishBuildArtifacts/Invoke-Robocopy.ps1
@@ -33,7 +33,7 @@ $writer = New-Object System.IO.StreamWriter($stdout, $utf8)
 # PowerShell 4, Write-Host and Out-Default do not consider the updated stream writer.
 
 # Print the ##command.
-[System.Console]::WriteLine("##[command]robocopy.exe /E /COPY:DA /NP /R:3 `"$Source`" `"$Target`" *")
+[System.Console]::WriteLine("##[command]robocopy.exe /E /COPY:DA /NP /R:3 /MT:128`"$Source`" `"$Target`" *")
 
 # The $OutputEncoding variable instructs PowerShell how to interpret the output
 # from the external command.
@@ -52,7 +52,7 @@ $OutputEncoding = [System.Text.Encoding]::Default
 #
 # Note, the output from robocopy needs to be iterated over. Otherwise PowerShell.exe
 # will launch the external command in such a way that it inherits the streams.
-& robocopy.exe /E /COPY:DA /NP /R:3 $Source $Target * 2>&1 |
+& robocopy.exe /E /COPY:DA /NP /R:3 /MT:128 $Source $Target * 2>&1 |
     ForEach-Object {
         if ($_ -is [System.Management.Automation.ErrorRecord]) {
             [System.Console]::WriteLine($_.Exception.Message)


### PR DESCRIPTION
Publish Build Artifacts is too slow.
In VSO, our build often takes around 20 minutes in this step.
add /MT:128 to robocopy