### PR TITLE
Ignore stderr errors when running vstest

### DIFF
--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -496,7 +496,7 @@ function executeVstest(testResultsDirectory: string, parallelRunSettingsFile: st
     tl.mkdirP(testResultsDirectory);
     tl.cd(workingDirectory);
     var ignoreTestFailures = ignoreVstestFailure && ignoreVstestFailure.toLowerCase() === "true";
-    vstest.exec(<tr.IExecOptions>{ failOnStdErr: !ignoreTestFailures })
+    vstest.exec()
         .then(function(code) {
             cleanUp(parallelRunSettingsFile);
             defer.resolve(code);


### PR DESCRIPTION
`vstest.console.exe` writes to stderr when there are inconclusive or ignored tests which causes this task to fail, even if all tests are successful and `vstest.console.exe` returns code 0. We should not fail the test run if errors are written to stderr. `vstest.console.exe` returns non-zero based codes when there are test failures, but returns zero when there are inconclusive or ignored tests, which is correct.

By removing this line, we are now relying on `vstest.console.exe`'s return codes and ignoring what is written to the console.

To test this, make two test assemblies:

Assembly1.dll
```csharp
[TestClass]
public class UnitTests
{
	[TestMethod]
	public void SuccessfulTest()
	{
		Assert.IsTrue(true);
	}
		
	[TestMethod]
	public void FailedTest()
	{
		Assert.Fail();
	}
		
	[TestMethod]
	[Ignore]
	public void IgnoredTest()
	{
		Assert.Fail();
	}

	[TestMethod]
	public void InconclusiveTest()
	{
		Assert.Inconclusive();
	}
}
```

Assembly2.dll
```csharp
[TestClass]
public class UnitTests
{
	[TestMethod]
	public void SuccessfulTest()
	{
		Assert.IsTrue(true);
	}
		
	[TestMethod]
	[Ignore]
	public void IgnoredTest()
	{
		Assert.Fail();
	}

	[TestMethod]
	public void InconclusiveTest()
	{
		Assert.Inconclusive();
	}
}
```

When running with `Assembly1.dll`, the task should fail. When running with `Assembly2.dll`, the task should succeed.

https://github.com/Microsoft/vsts-tasks/issues/3473