### PR TITLE
No longer use Build.SourcesDirectory var in Gradle and Maven

### DIFF
--- a/Tasks/Gradle/CodeAnalysis/Common/CodeAnalysisOrchestrator.ts
+++ b/Tasks/Gradle/CodeAnalysis/Common/CodeAnalysisOrchestrator.ts
@@ -64,7 +64,7 @@ export class CodeAnalysisOrchestrator {
     }
 
     private checkBuildContext(): boolean {
-        let requiredVariables: string[] = ['build.sourcesDirectory', 'build.artifactStagingDirectory', 'build.buildNumber'];
+        let requiredVariables: string[] = ['System.DefaultWorkingDirectory', 'build.artifactStagingDirectory', 'build.buildNumber'];
 
         for (let requiredVariable of requiredVariables) {
             if (!tl.getVariable(requiredVariable)) {

--- a/Tasks/Gradle/CodeAnalysis/gradlesonar.ts
+++ b/Tasks/Gradle/CodeAnalysis/gradlesonar.ts
@@ -48,7 +48,7 @@ export function processSonarQubeIntegration(): Q.Promise<void> {
     }
 
       // the output folder may not be directly in the build root, for example if the entire project is in a top-level dir
-    let reportTaskGlob: string = path.join(tl.getVariable('build.sourcesDirectory'), '**', 'build', 'sonar', 'report-task.txt');
+    let reportTaskGlob: string = path.join(tl.getVariable('System.DefaultWorkingDirectory'), '**', 'build', 'sonar', 'report-task.txt');
 
     return sqCommon.processSonarQubeIntegration(reportTaskGlob);
 }

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -15,8 +15,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 112,
-        "Patch": 1
+        "Minor": 113,
+        "Patch": 0
     },
     "demands": [
         "java"

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -15,8 +15,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 112,
-    "Patch": 1
+    "Minor": 113,
+    "Patch": 0
   },
   "demands": [
     "java"

--- a/Tasks/Maven/CodeAnalysis/Common/CodeAnalysisOrchestrator.ts
+++ b/Tasks/Maven/CodeAnalysis/Common/CodeAnalysisOrchestrator.ts
@@ -77,7 +77,7 @@ export class CodeAnalysisOrchestrator {
     }
 
     private checkBuildContext(): boolean {
-        let requiredVariables: string[] = ['build.sourcesDirectory', 'build.artifactStagingDirectory', 'build.buildNumber'];
+        let requiredVariables: string[] = ['System.DefaultWorkingDirectory', 'build.artifactStagingDirectory', 'build.buildNumber'];
 
         for (var requiredVariable of requiredVariables) {
             if (!tl.getVariable(requiredVariable)) {

--- a/Tasks/Maven/CodeAnalysis/mavensonar.ts
+++ b/Tasks/Maven/CodeAnalysis/mavensonar.ts
@@ -40,7 +40,7 @@ export function processSonarQubeIntegration(): Q.Promise<void> {
     }
 
     // the output folder may not be directly in the build root, for example if the entire project is in a top-lvel dir
-    var reportTaskGlob: string = path.join(tl.getVariable('build.sourcesDirectory'), '**', 'target', 'sonar', 'report-task.txt');
+    var reportTaskGlob: string = path.join(tl.getVariable('System.DefaultWorkingDirectory'), '**', 'target', 'sonar', 'report-task.txt');
    
     return sqCommon.processSonarQubeIntegration(reportTaskGlob);
 }

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -19,8 +19,8 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 0,
-        "Patch": 78
+        "Minor": 113,
+        "Patch": 0
     },
     "minimumAgentVersion": "1.89.0",
     "instanceNameFormat": "Maven $(mavenPOMFile)",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -19,8 +19,8 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 0,
-    "Patch": 78
+    "Minor": 113,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.89.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
Instead, use `System.DefaultWorkingDirectory` which works in both Build and Release definitions.