### PR TITLE
Fix to use old test selector tool

### DIFF
--- a/Tasks/VsTest/make.json
+++ b/Tasks/VsTest/make.json
@@ -2,7 +2,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://testselector.blob.core.windows.net/testselector/3614206/TestSelector.zip",
+                "url": "https://testselector.blob.core.windows.net/testselector/3606163/TestSelector.zip",
                 "dest": "./"
             }
         ]

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 12
+        "Patch": 13
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
In M112 branch we were taking latest master branch testselector tool. Latest doesn't work with old server and hence we were executing all tests always. fix is to use 112 testselector instead