### PR TITLE
Users/kavipriya/rtw fixes

### DIFF
--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 10
+        "Patch": 11
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 10
+    "Patch": 11
   },
   "demands": [
     "vstest"

--- a/Tests/L0/VsTest/vs2017.json
+++ b/Tests/L0/VsTest/vs2017.json
@@ -24,7 +24,7 @@
             "code": 0,
             "stdout": "vstest"
         },
-        "powershell -file /path/to/vs15Helper.ps1": {
+        "powershell -NonInteractive -ExecutionPolicy Unrestricted -file /path/to/vs15Helper.ps1": {
             "code": 0,
             "stdout": "<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\"><S>\\vs2017\\installation\\folder</S></Objs>"
         }

--- a/Tests/L0/VsTest/vstestGood.json
+++ b/Tests/L0/VsTest/vstestGood.json
@@ -74,7 +74,7 @@
             "code": 0,
             "stdout": "vstest"
         },
-        "powershell -file /path/to/vs15Helper.ps1": {
+        "powershell -NonInteractive -ExecutionPolicy Unrestricted -file /path/to/vs15Helper.ps1": {
             "code": 0,
             "stdout": "<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\"><S>\\vs2017\\installation\\folder</S></Objs>"
         }


### PR DESCRIPTION
Fixes for:
924814 VSTest 2x version throws error if on build agent powershell execution policy is not set to execute unsigned powershell script
924823 VSTest 2.x task by default should not search form dll within Test Results folder
