### PR TITLE
Remove "Visual Studio" from Mobile Center task names

### DIFF
--- a/Tasks/VSMobileCenterTest/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VSMobileCenterTest/Strings/resources.resjson/en-US/resources.resjson
@@ -1,5 +1,5 @@
 {
-  "loc.friendlyName": "Visual Studio Mobile Center Test",
+  "loc.friendlyName": "Mobile Center Test",
   "loc.helpMarkDown": "Test mobile app packages with Visual Studio Mobile Center.",
   "loc.description": "Test mobile app packages with Visual Studio Mobile Center.",
   "loc.instanceNameFormat": "Test $(app) with Visual Studio Mobile Center",

--- a/Tasks/VSMobileCenterTest/task.json
+++ b/Tasks/VSMobileCenterTest/task.json
@@ -1,7 +1,7 @@
 {
     "id": "AD5CD22A-BE4E-48BB-ADCE-181A32432DA5",
     "name": "VSMobileCenterTest",
-    "friendlyName": "Visual Studio Mobile Center Test",
+    "friendlyName": "Mobile Center Test",
     "description": "Test mobile app packages with Visual Studio Mobile Center.",
     "helpMarkDown": "Test mobile app packages with Visual Studio Mobile Center.",
     "category": "Test",
@@ -11,8 +11,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 112,
-        "Patch": 2
+        "Minor": 114,
+        "Patch": 0
     },
     "groups": [
         {

--- a/Tasks/VSMobileCenterTest/task.loc.json
+++ b/Tasks/VSMobileCenterTest/task.loc.json
@@ -11,8 +11,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 112,
-    "Patch": 2
+    "Minor": 114,
+    "Patch": 0
   },
   "groups": [
     {

--- a/Tasks/VSMobileCenterUpload/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VSMobileCenterUpload/Strings/resources.resjson/en-US/resources.resjson
@@ -1,5 +1,5 @@
 {
-  "loc.friendlyName": "Visual Studio Mobile Center Upload",
+  "loc.friendlyName": "Mobile Center Upload",
   "loc.helpMarkDown": "Upload mobile app packages to Visual Studio Mobile Center",
   "loc.description": "Upload mobile app packages to Visual Studio Mobile Center",
   "loc.instanceNameFormat": "Deploy $(app) to Visual Studio Mobile Center",

--- a/Tasks/VSMobileCenterUpload/task.json
+++ b/Tasks/VSMobileCenterUpload/task.json
@@ -1,7 +1,7 @@
 {
     "id": "B832BEC5-8C27-4FEF-9FB8-6BEC8524AD8A",
     "name": "VSMobileCenterUpload",
-    "friendlyName": "Visual Studio Mobile Center Upload",
+    "friendlyName": "Mobile Center Upload",
     "description": "Upload mobile app packages to Visual Studio Mobile Center",
     "helpMarkDown": "Upload mobile app packages to Visual Studio Mobile Center",
     "category": "Deploy",
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 114,
-        "Patch": 0
+        "Patch": 1
     },
     "groups": [
         {

--- a/Tasks/VSMobileCenterUpload/task.loc.json
+++ b/Tasks/VSMobileCenterUpload/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 114,
-    "Patch": 0
+    "Patch": 1
   },
   "groups": [
     {


### PR DESCRIPTION
These name changes were approved by Mobile Center.