### PR TITLE
Set min agent version for SSH tasks

### DIFF
--- a/Tasks/CopyFilesOverSSH/task.json
+++ b/Tasks/CopyFilesOverSSH/task.json
@@ -20,6 +20,7 @@
         "Patch": 3
     },
     "demands": [],
+    "minimumAgentVersion": "2.102.0",
     "instanceNameFormat": "Securely copy files to the remote machine",
     "groups": [
         {

--- a/Tasks/CopyFilesOverSSH/task.loc.json
+++ b/Tasks/CopyFilesOverSSH/task.loc.json
@@ -20,6 +20,7 @@
     "Patch": 3
   },
   "demands": [],
+  "minimumAgentVersion": "2.102.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [
     {

--- a/Tasks/SSH/task.json
+++ b/Tasks/SSH/task.json
@@ -20,6 +20,7 @@
         "Patch": 4
     },
     "demands": [],
+    "minimumAgentVersion": "2.102.0",
     "instanceNameFormat": "Run shell $(runOptions) on remote machine",
     "groups": [
         {

--- a/Tasks/SSH/task.loc.json
+++ b/Tasks/SSH/task.loc.json
@@ -20,6 +20,7 @@
     "Patch": 4
   },
   "demands": [],
+  "minimumAgentVersion": "2.102.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [
     {


### PR DESCRIPTION
This addresses #3369 where the SSH tasks rely on a minimum agent version **2.102.0** for this commit which changes the way SSH service endpoint credentials are stored:
https://github.com/Microsoft/vsts-agent/commit/b70f8c7ec9c121a7562fc61a21a5d44c37eac8fd

The first released .NET Core agent [that was supported in production](https://github.com/Microsoft/vsts-agent/releases?after=v2.104.2) was **2.103.0**, so setting **2.102.0** as a minimum should be a safe.