### PR TITLE
Improve task "AzureCloudPowerShellDeployment" to support both classic storage account and the one created via ARM template

### DIFF
--- a/Tasks/AzureCloudPowerShellDeployment/Publish-AzureCloudDeployment.ps1
+++ b/Tasks/AzureCloudPowerShellDeployment/Publish-AzureCloudDeployment.ps1
@@ -16,6 +16,7 @@ try{
     $DiagnosticStorageAccountKeys = Get-VstsInput -Name DiagnosticStorageAccountKeys
     $NewServiceAdditionalArguments = Get-VstsInput -Name NewServiceAdditionalArguments
     $NewServiceAffinityGroup = Get-VstsInput -Name NewServiceAffinityGroup
+    $StorageAccountResourceGroup = Get-VstsInput -Name StorageAccountResourceGroup
 
     # Initialize Azure.
     Import-Module $PSScriptRoot\ps_modules\VstsAzureHelpers_
@@ -61,7 +62,7 @@ try{
         $azureService = Invoke-Expression -Command $azureService
     }
 
-    $diagnosticExtensions = Get-DiagnosticsExtensions $StorageAccount $serviceConfigFile $storageAccountKeysMap
+    $diagnosticExtensions = Get-DiagnosticsExtensions $StorageAccount $serviceConfigFile $storageAccountKeysMap $StorageAccountResourceGroup
 
     $label = $DeploymentLabel
 

--- a/Tasks/AzureCloudPowerShellDeployment/task.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.json
@@ -162,6 +162,18 @@
             "properties": {
                 "EditableOptions": "True"
             }
+        },
+        {
+            "name": "StorageAccountResourceGroup",
+            "type": "string",
+            "label": "Resource Group",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Resource Group for storage account",
+            "groupName": "newServiceAdvancedOptions",
+            "properties": {
+                "EditableOptions": "True"
+            }
         }
     ],
     "dataSourceBindings": [


### PR DESCRIPTION
Hi @jpricketMSFT 

I have tried to improve the task "Azure Cloud Service Deployment" to support both classic storage account
and the one created via ARM template.

Would you please help to check the solution? Please let me know if you have questions.

Kind regards,
Jin