### PR TITLE
Bug fix in AzurePowerShell.ps1

### DIFF
--- a/Tasks/AzurePowerShell/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShell/AzurePowerShell.ps1
@@ -83,7 +83,7 @@ try {
         }
 }
 finally {
-    if ($__vstsAzPSInlineScriptPath -and (Test-Path -LiteralPath $__vstsAzPSInlineScriptPath) ) {
+    if ((Get-Variable -Name __vstsAzPSInlineScriptPath -ErrorAction SilentlyContinue) -and (Test-Path -LiteralPath $__vstsAzPSInlineScriptPath) ) {
         Remove-Item -LiteralPath $__vstsAzPSInlineScriptPath -ErrorAction 'SilentlyContinue'
     }
 }

--- a/Tasks/AzurePowerShell/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShell/AzurePowerShell.ps1
@@ -25,6 +25,7 @@ try {
     Initialize-Azure
 
     # Trace the expression as it will be invoked.
+    $__vstsAzPSInlineScriptPath = $null
     If ($scriptType -eq "InlineScript") {
         $__vstsAzPSInlineScriptPath = [System.IO.Path]::Combine(([System.IO.Path]::GetTempPath()), ([guid]::NewGuid().ToString() + ".ps1"));
         ($scriptInline | Out-File $__vstsAzPSInlineScriptPath)
@@ -83,7 +84,7 @@ try {
         }
 }
 finally {
-    if ((Get-Variable -Name __vstsAzPSInlineScriptPath -ErrorAction SilentlyContinue) -and (Test-Path -LiteralPath $__vstsAzPSInlineScriptPath) ) {
+    if ($__vstsAzPSInlineScriptPath -and (Test-Path -LiteralPath $__vstsAzPSInlineScriptPath) ) {
         Remove-Item -LiteralPath $__vstsAzPSInlineScriptPath -ErrorAction 'SilentlyContinue'
     }
 }


### PR DESCRIPTION
Fixes the build warning: "The variable '$__vstsAzPSInlineScriptPath' cannot be retrieved because it has not been set." The warning occurs when $scriptType equals 'FilePath'.