### PR TITLE
If full path for net.exe is available make use of it.

### DIFF
--- a/Tasks/WindowsMachineFileCopy/RoboCopyJob.ps1
+++ b/Tasks/WindowsMachineFileCopy/RoboCopyJob.ps1
@@ -232,8 +232,7 @@ param (
     finally
     {
         if($machineShare)
-        {
-            
+        {            
             $dtl_deleteMap = iex "$netExeCommand use `"$machineShare`" /D /Y";  
         }
     }

--- a/Tasks/WindowsMachineFileCopy/RoboCopyJob.ps1
+++ b/Tasks/WindowsMachineFileCopy/RoboCopyJob.ps1
@@ -161,16 +161,31 @@ param (
         return ""
     }
     
+    function Get-NetExeCommand
+    {
+        $netExePath = Join-Path -path (get-item env:\windir).value -ChildPath system32\net.exe
+        if(Test-Path $netExePath)
+        {
+            Write-Verbose "Found the net exe path $netExePath. Net command will be $netExePath"
+            return $netExePath
+        }
+        
+        Write-Verbose "Unable to get the path for net.exe. Net command will be 'net'"
+        return 'net'
+    }
+    
     $machineShare = Get-MachineShare -fqdn $fqdn -targetPath $targetPath    
     $destinationNetworkPath = Get-DestinationNetworkPath -targetPath $targetPath -machineShare $machineShare
     
     Validate-Credential $credential
     $userName = Get-DownLevelLogonName -fqdn $fqdn -userName $($credential.UserName)
     $password = $($credential.Password) 
+    
+    $netExeCommand = Get-NetExeCommand
 
     if($machineShare)
     {
-        $command = "net use `"$machineShare`""
+        $command = "$netExeCommand use `"$machineShare`""
         if($userName)
         {
             $command += " /user:`"$userName`" `'$($password -replace "['`]", '$&$&')`'"
@@ -218,7 +233,8 @@ param (
     {
         if($machineShare)
         {
-            net use $machineShare /D /Y;  
+            
+            $dtl_deleteMap = iex "$netExeCommand use `"$machineShare`" /D /Y";  
         }
     }
 }

--- a/Tasks/WindowsMachineFileCopy/task.json
+++ b/Tasks/WindowsMachineFileCopy/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 39
+        "Patch": 40
     },
     "minimumAgentVersion": "1.104.0",
     "groups": [

--- a/Tasks/WindowsMachineFileCopy/task.loc.json
+++ b/Tasks/WindowsMachineFileCopy/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 39
+    "Patch": 40
   },
   "minimumAgentVersion": "1.104.0",
   "groups": [


### PR DESCRIPTION
If full path for net.exe is available make use of it. In case PATH env variable is not in good state making use of full path for net.exe ensures task dose not fail for 'net' command