### PR TITLE
fix a bug intruduced with refactoring

### DIFF
--- a/Tasks/Gradle/CodeAnalysis/SonarQube/metrics.ts
+++ b/Tasks/Gradle/CodeAnalysis/SonarQube/metrics.ts
@@ -103,7 +103,7 @@ export class SonarQubeMetrics {
      */
     public fetchAnalysisDetails(analysisId?: string): Q.Promise<Object> {
         // Use the cache if available
-        if (!this.analysisDetails) {
+        if (this.analysisDetails) {
             return Q.when(this.analysisDetails);
         }
 

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -15,8 +15,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 113,
-        "Patch": 1
+        "Minor": 115,
+        "Patch": 0 
     },
     "demands": [
         "java"

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -15,8 +15,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 113,
-    "Patch": 1
+    "Minor": 115,
+    "Patch": 0
   },
   "demands": [
     "java"


### PR DESCRIPTION
I believe this condition was inverted during last refactoring:

```
-        if (!(this.analysisDetails == undefined || this.analysisDetails == null)) {
+        if (!this.analysisDetails) {
```

The original condition asserts analysisDetails is Not undefined and Not null; after refactoring the condition is asserting analysisDetails IS undefined or IS null. 

Remove the inversion in the condition. 