### PR TITLE
Read NpmTasks.ExtraUrlPrefixesForTesting build variable in Npm task

### DIFF
--- a/Tasks/Npm/npmtask.ts
+++ b/Tasks/Npm/npmtask.ts
@@ -199,6 +199,14 @@ function addBuildCredProviderEnv(env: EnvironmentDictionary) : EnvironmentDictio
     var urlPrefixes : string[] = assumeNpmUriPrefixes(serviceUri);
     tl.debug(`discovered URL prefixes: ${urlPrefixes}`);
 
+    // Note to readers: This variable will be going away once we have a fix for the location service for
+    // customers behind proxies
+    let testPrefixes = tl.getVariable("NpmTasks.ExtraUrlPrefixesForTesting");
+    if (testPrefixes) {
+        urlPrefixes = urlPrefixes.concat(testPrefixes.split(";"));
+        tl.debug(`all URL prefixes: ${urlPrefixes}`);
+    }
+
     // These env variables are using NUGET because the credential provider that is being used
     // was built only when NuGet was supported. It is basically using environment variable to
     // pull out the access token, hence can be used in Npm scenario as well.


### PR DESCRIPTION
The npm task sets an envar with a list of allowed url prefixes for credential acquisition -- the vsts-npm-auth.exe will only attempt to acquire credentials for a source if the url of the package source contains one of these prefixes.

To test npm in devfabric, we need to enable npm to read a build variable that contains additional test prefixes, so that we can authenticate with debfabric.