### PR TITLE
Users/lukillgo/copyfilesssh

### DIFF
--- a/Tasks/CopyFilesOverSSH/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CopyFilesOverSSH/Strings/resources.resjson/en-US/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.overwrite": "Overwrite",
   "loc.input.help.overwrite": "Replace existing files in the target folder.",
   "loc.input.label.failOnEmptySource": "Fail if no files found to copy",
-  "loc.input.help.failOnEmptySource": "Fail if the Source folder does not have files to copy.",
+  "loc.input.help.failOnEmptySource": "Fail if the source folder does not have files to copy.",
   "loc.input.label.flattenFolders": "Flatten folders",
   "loc.input.help.flattenFolders": "Flatten the folder structure and copy all files into the specified target folder on the remote machine.",
   "loc.messages.UseDefaultPort": "Using port 22 which is the default for SSH since no port was specified.",

--- a/Tasks/CopyFilesOverSSH/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CopyFilesOverSSH/Strings/resources.resjson/en-US/resources.resjson
@@ -16,7 +16,7 @@
   "loc.input.help.cleanTargetFolder": "Delete all existing files in the target folder before copying.",
   "loc.input.label.overwrite": "Overwrite",
   "loc.input.help.overwrite": "Replace existing files in the target folder.",
-  "loc.input.label.failOnEmptySource": "Fail when the Source folder is empty",
+  "loc.input.label.failOnEmptySource": "Fail if no files found to copy",
   "loc.input.help.failOnEmptySource": "Fail if the Source folder does not have files to copy.",
   "loc.input.label.flattenFolders": "Flatten folders",
   "loc.input.help.flattenFolders": "Flatten the folder structure and copy all files into the specified target folder on the remote machine.",

--- a/Tasks/CopyFilesOverSSH/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CopyFilesOverSSH/Strings/resources.resjson/en-US/resources.resjson
@@ -16,6 +16,8 @@
   "loc.input.help.cleanTargetFolder": "Delete all existing files in the target folder before copying.",
   "loc.input.label.overwrite": "Overwrite",
   "loc.input.help.overwrite": "Replace existing files in the target folder.",
+  "loc.input.label.failOnEmptySource": "Fail when the Source folder is empty",
+  "loc.input.help.failOnEmptySource": "Fail if the Source folder does not have files to copy.",
   "loc.input.label.flattenFolders": "Flatten folders",
   "loc.input.help.flattenFolders": "Flatten the folder structure and copy all files into the specified target folder on the remote machine.",
   "loc.messages.UseDefaultPort": "Using port 22 which is the default for SSH since no port was specified.",

--- a/Tasks/CopyFilesOverSSH/copyfilesoverssh.ts
+++ b/Tasks/CopyFilesOverSSH/copyfilesoverssh.ts
@@ -161,6 +161,7 @@ async function run() {
         // read the copy options
         var cleanTargetFolder:boolean = tl.getBoolInput('cleanTargetFolder', false);
         var overwrite:boolean = tl.getBoolInput('overwrite', false);
+        var failOnEmptySource:boolean = tl.getBoolInput('failOnEmptySource', false);
         var flattenFolders:boolean = tl.getBoolInput('flattenFolders', false);
 
         if(!tl.stats(sourceFolder).isDirectory()) {
@@ -218,6 +219,8 @@ async function run() {
                 await sshHelper.uploadFile(fileToCopy, targetPath);
             }
             tl._writeLine(tl.loc('CopyCompleted', filesToCopy.length));
+        } else if(failOnEmptySource) {
+            throw tl.loc('NothingToCopy');
         } else {
             tl.warning(tl.loc('NothingToCopy'));
         }

--- a/Tasks/CopyFilesOverSSH/copyfilesoverssh.ts
+++ b/Tasks/CopyFilesOverSSH/copyfilesoverssh.ts
@@ -149,7 +149,14 @@ async function run() {
         // contents is a multiline input containing glob patterns
         var contents:string[] = tl.getDelimitedInput('contents', '\n', true);
         var sourceFolder:string = tl.getPathInput('sourceFolder', true, true);
-        var targetFolder:string = tl.getInput('targetFolder', true);
+        var targetFolder:string = tl.getInput('targetFolder');
+
+        if (!targetFolder) {
+            targetFolder = "./"
+        } else {
+            // '~/' is unsupported
+            targetFolder = targetFolder.replace(/^~\//, "./")
+        }
 
         // read the copy options
         var cleanTargetFolder:boolean = tl.getBoolInput('cleanTargetFolder', false);

--- a/Tasks/CopyFilesOverSSH/task.json
+++ b/Tasks/CopyFilesOverSSH/task.json
@@ -59,7 +59,7 @@
             "type": "string",
             "label": "Target folder",
             "defaultValue": "",
-            "required": true,
+            "required": false,
             "helpMarkDown": "Target folder on the remote machine to where files will be copied. Example: /home/user/MySite."
         },
         {

--- a/Tasks/CopyFilesOverSSH/task.json
+++ b/Tasks/CopyFilesOverSSH/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 1,
-        "Patch": 4
+        "Minor": 115,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.102.0",

--- a/Tasks/CopyFilesOverSSH/task.json
+++ b/Tasks/CopyFilesOverSSH/task.json
@@ -83,7 +83,7 @@
         {
             "name": "failOnEmptySource",
             "type": "boolean",
-            "label": "Fail when the Source folder is empty",
+            "label": "Fail if no files found to copy",
             "defaultValue": "false",
             "required": false,
             "helpMarkDown": "Fail if the Source folder does not have files to copy.",

--- a/Tasks/CopyFilesOverSSH/task.json
+++ b/Tasks/CopyFilesOverSSH/task.json
@@ -81,6 +81,15 @@
             "groupName": "advanced"
         },
         {
+            "name": "failOnEmptySource",
+            "type": "boolean",
+            "label": "Fail when the Source folder is empty",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Fail if the Source folder does not have files to copy.",
+            "groupName": "advanced"
+        },
+        {
             "name": "flattenFolders",
             "type": "boolean",
             "label": "Flatten folders",

--- a/Tasks/CopyFilesOverSSH/task.json
+++ b/Tasks/CopyFilesOverSSH/task.json
@@ -86,7 +86,7 @@
             "label": "Fail if no files found to copy",
             "defaultValue": "false",
             "required": false,
-            "helpMarkDown": "Fail if the Source folder does not have files to copy.",
+            "helpMarkDown": "Fail if no matching files to be copied are found under the source folder.",
             "groupName": "advanced"
         },
         {

--- a/Tasks/CopyFilesOverSSH/task.loc.json
+++ b/Tasks/CopyFilesOverSSH/task.loc.json
@@ -81,6 +81,15 @@
       "groupName": "advanced"
     },
     {
+      "name": "failOnEmptySource",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.failOnEmptySource",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.failOnEmptySource",
+      "groupName": "advanced"
+    },
+    {
       "name": "flattenFolders",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.flattenFolders",

--- a/Tasks/CopyFilesOverSSH/task.loc.json
+++ b/Tasks/CopyFilesOverSSH/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 1,
-    "Patch": 4
+    "Minor": 115,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.102.0",
@@ -59,7 +59,7 @@
       "type": "string",
       "label": "ms-resource:loc.input.label.targetFolder",
       "defaultValue": "",
-      "required": true,
+      "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.targetFolder"
     },
     {


### PR DESCRIPTION
This branch addresses two issues:
1) It allows for a blank target folder (which defaults to their home folder), and allows the user to use '~' to reference their home folder.
2) Added a checkbox to allow for a copy to fail if there weren't any files found to copy over.
