### PR TITLE
fix to ensure we dont print warning by default

### DIFF
--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 22
+        "Patch": 23
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 22
+    "Patch": 23
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -144,7 +144,7 @@ function getVstestArguments(settingsFile: string, tiaEnabled: boolean): string[]
             });
         }
         else {
-            if (!tl.exist(settingsFile)) {
+            if (!tl.exist(settingsFile)) { // because this ia filepath input build puts default path in the input. To avoid that we are checking this
                 tl.warning(tl.loc("InvalidSettingsFile", settingsFile));
             }
         }

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -144,7 +144,9 @@ function getVstestArguments(settingsFile: string, tiaEnabled: boolean): string[]
             });
         }
         else {
-            tl.warning(tl.loc("InvalidSettingsFile", settingsFile));
+            if (!tl.exist(settingsFile)) {
+                tl.warning(tl.loc("InvalidSettingsFile", settingsFile));
+            }
         }
     }
 


### PR DESCRIPTION
because param type is a filepath the framework return default directory,
even though user didnt enter anything. we were warning in that case as
well. Fixing that issue.

Other fixes to fail the task will don't in master