### PR TITLE
Fix loading Quality Tools assembly loading

### DIFF
--- a/Tasks/VsTest/distributedtest.ts
+++ b/Tasks/VsTest/distributedtest.ts
@@ -59,16 +59,27 @@ export class DistributedTest {
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.MiniMatchSourceFilter', 'true');
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.LocalTestDropPath', this.dtaTestConfig.testDropLocation);
 
-        if(this.dtaTestConfig.vsTestLocationMethod === utils.Constants.vsTestVersionString) {
+        if (this.dtaTestConfig.vsTestLocationMethod === utils.Constants.vsTestVersionString) {
             utils.Helper.addToProcessEnvVars(envVars, 'DTA.TestPlatformVersion', this.dtaTestConfig.vsTestVersion);
         }
 
-        var exeInfo = await versionFinder.locateTestWindow(this.dtaTestConfig);
-        if(exeInfo) {
-            tl.debug("Adding env var DTA.TestWindow.Path = " + exeInfo.location);
+        const exeInfo = await versionFinder.locateTestWindow(this.dtaTestConfig);
+        if (exeInfo) {
+            tl.debug('Adding env var DTA.TestWindow.Path = ' + exeInfo.location);
+
+            // Split the TestWindow path out of full path - if we can't find it, will assume
+            // that this is nuget/xcopyable package where the dlls are present in test window folder
+            const testWindowRelativeDir = 'CommonExtensions\\Microsoft\\TestWindow';
+            if (exeInfo.location && exeInfo.location.indexOf(testWindowRelativeDir) !== -1) {
+                const ideLocation = exeInfo.location.split(testWindowRelativeDir)[0];
+                tl.debug('Adding env var DTA.VisualStudio.Path = ' + ideLocation);
+                utils.Helper.addToProcessEnvVars(envVars, 'DTA.VisualStudio.Path', ideLocation);
+            } else {
+                utils.Helper.addToProcessEnvVars(envVars, 'DTA.VisualStudio.Path', exeInfo.location);
+            }
             utils.Helper.addToProcessEnvVars(envVars, 'DTA.TestWindow.Path', exeInfo.location);
         } else {
-            tl.error(tl.loc('VstestNotFound', utils.Helper.getVSVersion( parseFloat(this.dtaTestConfig.vsTestVersion))));
+            tl.error(tl.loc('VstestNotFound', utils.Helper.getVSVersion(parseFloat(this.dtaTestConfig.vsTestVersion))));
         }
 
         // We are logging everything to a DTAExecutionHost.exe.log file and reading it at the end and adding to the build task debug logs

--- a/Tasks/VsTest/make.json
+++ b/Tasks/VsTest/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/3673529/TestExecution.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/3766237/TestExecution.zip",
                 "dest": "./Modules"
             }
         ]

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 22
+        "Patch": 23
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 22
+    "Patch": 23
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
In VS installation, Test platform uses Quality Tools to generate the TRX file.
DTA Engine doesn't load Quality tools as it's responsibility of Test platform.
However TP doesn't load the TRX generator which in return we generate TRX with no test cases.

* Explicitly load Quality tools if required from IDE\PrivateAssemblies IDE\PublicAssemblies.