### PR TITLE
FtpUpload: Validate server URL

### DIFF
--- a/Tasks/FtpUpload/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/FtpUpload/Strings/resources.resjson/en-US/resources.resjson
@@ -25,12 +25,14 @@
   "loc.input.help.preservePaths": "If selected, the relative local directory structure is recreated under the remote directory where files are uploaded.  Otherwise, files are uploaded directly to the remote directory without creating additional subdirectories.<p>For example, suppose your source folder is: <b>`/home/user/source/`</b> and contains the file: <b>`foo/bar/foobar.txt`</b>, and your remote directory is: <b>`/uploads/`</b>.<br>If selected, the file is uploaded to: <b>`/uploads/foo/bar/foobar.txt`</b>.  Otherwise, to: <b>`/uploads/foobar.txt`</b>.",
   "loc.input.label.trustSSL": "Trust server certificate",
   "loc.input.help.trustSSL": "Selecting this option results in the FTP server's SSL certificate being trusted with ftps://, even if it is self-signed or cannot be validated by a Certificate Authority (CA).",
-  "loc.messages.FTPConnected": "connected: %s",
   "loc.messages.CleanRemoteDir": "cleaning remote directory: %s",
+  "loc.messages.ConnectPort": "connecting to: %s:%s",
+  "loc.messages.Disconnected": "disconnected",
+  "loc.messages.DisconnectHost": "disconnecting from: %s",
+  "loc.messages.FTPConnected": "connected: %s",
+  "loc.messages.FTPNoHostSpecified": "The FTP server URL must include a host name",
+  "loc.messages.FTPNoProtocolSpecified": "The FTP server URL must begin with ftp:// or ftps://",
   "loc.messages.UploadRemoteDir": "uploading files to remote directory: %s",
   "loc.messages.UploadSucceedMsg": "FTP upload successful %s",
-  "loc.messages.UploadSucceedRes": "FTP upload successful",
-  "loc.messages.DisconnectHost": "disconnecting from: %s",
-  "loc.messages.Disconnected": "disconnected",
-  "loc.messages.ConnectPort": "connecting to: %s:%s"
+  "loc.messages.UploadSucceedRes": "FTP upload successful"
 }

--- a/Tasks/FtpUpload/ftpuploadtask.ts
+++ b/Tasks/FtpUpload/ftpuploadtask.ts
@@ -62,6 +62,13 @@ function doWork() {
     tl.setResourcePath(path.join( __dirname, 'task.json'));
 
     var ftpOptions: FtpOptions = getFtpOptions();
+    if (!ftpOptions.serverEndpointUrl.protocol) {
+        tl.setResult(tl.TaskResult.Failed, tl.loc('FTPNoProtocolSpecified'));
+    }
+    if (!ftpOptions.serverEndpointUrl.hostname) {
+        tl.setResult(tl.TaskResult.Failed, tl.loc('FTPNoHostSpecified'));
+    }
+
     var ftpClient: any = new Client();
     var ftpHelper: ftputils.FtpHelper = new ftputils.FtpHelper(ftpOptions, ftpClient);
 

--- a/Tasks/FtpUpload/task.json
+++ b/Tasks/FtpUpload/task.json
@@ -17,8 +17,8 @@
     "demands": [],
     "version": {
         "Major": 1,
-        "Minor": 114,
-        "Patch": 1
+        "Minor": 116,
+        "Patch": 0
     },
     "instanceNameFormat": "FTP Upload: $(rootFolder)",
     "groups": [

--- a/Tasks/FtpUpload/task.json
+++ b/Tasks/FtpUpload/task.json
@@ -146,13 +146,15 @@
         }
     },
     "messages": {
-        "FTPConnected": "connected: %s",
         "CleanRemoteDir": "cleaning remote directory: %s",
+        "ConnectPort": "connecting to: %s:%s",
+        "Disconnected": "disconnected",
+        "DisconnectHost": "disconnecting from: %s",
+        "FTPConnected": "connected: %s",
+        "FTPNoHostSpecified": "The FTP server URL must include a host name",
+        "FTPNoProtocolSpecified": "The FTP server URL must begin with ftp:// or ftps://",
         "UploadRemoteDir": "uploading files to remote directory: %s",
         "UploadSucceedMsg": "FTP upload successful %s",
-        "UploadSucceedRes": "FTP upload successful",
-        "DisconnectHost": "disconnecting from: %s",
-        "Disconnected": "disconnected",
-        "ConnectPort": "connecting to: %s:%s"
+        "UploadSucceedRes": "FTP upload successful"
     }
 }

--- a/Tasks/FtpUpload/task.loc.json
+++ b/Tasks/FtpUpload/task.loc.json
@@ -17,8 +17,8 @@
   "demands": [],
   "version": {
     "Major": 1,
-    "Minor": 114,
-    "Patch": 1
+    "Minor": 116,
+    "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [

--- a/Tasks/FtpUpload/task.loc.json
+++ b/Tasks/FtpUpload/task.loc.json
@@ -146,13 +146,15 @@
     }
   },
   "messages": {
-    "FTPConnected": "ms-resource:loc.messages.FTPConnected",
     "CleanRemoteDir": "ms-resource:loc.messages.CleanRemoteDir",
+    "ConnectPort": "ms-resource:loc.messages.ConnectPort",
+    "Disconnected": "ms-resource:loc.messages.Disconnected",
+    "DisconnectHost": "ms-resource:loc.messages.DisconnectHost",
+    "FTPConnected": "ms-resource:loc.messages.FTPConnected",
+    "FTPNoHostSpecified": "ms-resource:loc.messages.FTPNoHostSpecified",
+    "FTPNoProtocolSpecified": "ms-resource:loc.messages.FTPNoProtocolSpecified",
     "UploadRemoteDir": "ms-resource:loc.messages.UploadRemoteDir",
     "UploadSucceedMsg": "ms-resource:loc.messages.UploadSucceedMsg",
-    "UploadSucceedRes": "ms-resource:loc.messages.UploadSucceedRes",
-    "DisconnectHost": "ms-resource:loc.messages.DisconnectHost",
-    "Disconnected": "ms-resource:loc.messages.Disconnected",
-    "ConnectPort": "ms-resource:loc.messages.ConnectPort"
+    "UploadSucceedRes": "ms-resource:loc.messages.UploadSucceedRes"
   }
 }

--- a/Tests-Legacy/L0/FtpUpload/_suite.ts
+++ b/Tests-Legacy/L0/FtpUpload/_suite.ts
@@ -68,6 +68,7 @@ describe(jobName + ' Suite', function () {
                     done(err);
                 });
         });
+
         it(os + ' check args: no filePatterns', (done) => {
             setResponseFile(responseFile);
 
@@ -127,6 +128,7 @@ describe(jobName + ' Suite', function () {
                     done(err);
                 });
         });
+
         it(os + ' check args: no overwrite', (done) => {
             setResponseFile(responseFile);
 
@@ -148,6 +150,7 @@ describe(jobName + ' Suite', function () {
                     done(err);
                 });
         });
+
         it(os + ' check args: no preservePaths', (done) => {
             setResponseFile(responseFile);
 
@@ -170,6 +173,7 @@ describe(jobName + ' Suite', function () {
                     done(err);
                 });
         });
+
         it(os + ' check args: trustSSL', (done) => {
             setResponseFile(responseFile);
 
@@ -193,12 +197,17 @@ describe(jobName + ' Suite', function () {
                     done(err);
                 });
         });
-        it(os + ' check args: bogusURL', (done) => {
+
+        it(os + ' check args: missing protocol on server URL (ftp:// or ftps://)', (done) => {
             setResponseFile(responseFile);
 
             var tr = new trm.TaskRunner(jobName, true);
-            tr.setInput('credsType', 'serviceEndpoint');
-            tr.setInput('serverEndpoint', 'ID1');
+            tr.setInput('credsType', 'inputs');
+
+            tr.setInput('serverUrl', 'noprotocol.microsoft.com');
+            tr.setInput('username', 'myUsername');
+            tr.setInput('password', 'myPassword');
+
             tr.setInput('rootFolder', 'rootFolder');
             tr.setInput('filePatterns', '**');
             tr.setInput('remotePath', '/upload/');
@@ -209,7 +218,7 @@ describe(jobName + ' Suite', function () {
 
             tr.run()
                 .then(() => {
-                    assert(tr.stderr.indexOf('Unhandled:Cannot read property \'toLowerCase\' of null') != -1, 'should have written to stderr');
+                    assert(tr.stderr.indexOf('The FTP server URL must begin with ftp:// or ftps://') != -1, 'A protocol should have been required in the server URL.');
                     assert(tr.failed, 'task should have failed');
                     done();
                 })
@@ -219,5 +228,34 @@ describe(jobName + ' Suite', function () {
                 });
         });
 
+        it(os + ' check args: missing host name on server URL', (done) => {
+            setResponseFile(responseFile);
+
+            var tr = new trm.TaskRunner(jobName, true);
+            tr.setInput('credsType', 'inputs');
+
+            tr.setInput('serverUrl', 'ftps://');
+            tr.setInput('username', 'myUsername');
+            tr.setInput('password', 'myPassword');
+
+            tr.setInput('rootFolder', 'rootFolder');
+            tr.setInput('filePatterns', '**');
+            tr.setInput('remotePath', '/upload/');
+            tr.setInput('clean', 'true');
+            tr.setInput('overwrite', 'true');
+            tr.setInput('preservePaths', 'true');
+            tr.setInput('trustSSL', 'true');
+
+            tr.run()
+                .then(() => {
+                    assert(tr.stderr.indexOf('The FTP server URL must include a host name') != -1, 'A host name should have been required in the server URL.');
+                    assert(tr.failed, 'task should have failed');
+                    done();
+                })
+                .fail((err) => {
+                    console.log(err)
+                    done(err);
+                });
+        });
     });
 });

--- a/Tests-Legacy/L0/FtpUpload/ftpUploadLinux.json
+++ b/Tests-Legacy/L0/FtpUpload/ftpUploadLinux.json
@@ -3,7 +3,7 @@
         "osType" : "Linux"
     },
     "getVariable": {
-        "ENDPOINT_URL_ID1": "bogusURL",
+        "ENDPOINT_URL_ID1": "ftp://valid.microsoft.com",
         "ENDPOINT_AUTH_ID1": "{\"scheme\":\"UsernamePassword\", \"parameters\": {\"username\": \"uname\", \"password\": \"pword\"}}",
         "build.sourcesDirectory": "/"
     },

--- a/Tests-Legacy/L0/FtpUpload/ftpUploadWin.json
+++ b/Tests-Legacy/L0/FtpUpload/ftpUploadWin.json
@@ -3,7 +3,7 @@
         "osType" : "Windows"
     },
     "getVariable": {
-        "ENDPOINT_URL_ID1": "bogusURL",
+        "ENDPOINT_URL_ID1": "ftp://valid.microsoft.com",
         "ENDPOINT_AUTH_ID1": "{\"scheme\":\"UsernamePassword\", \"parameters\": {\"username\": \"uname\", \"password\": \"pword\"}}",
         "build.sourcesDirectory": "/"
     },


### PR DESCRIPTION
This addresses issue #3956 by validating that an FTP server URL must begin with a protocol (ftp:// or ftps://) and include a host name.