### PR TITLE
Change msdeploy utility so it can recognize WAR files

### DIFF
--- a/Tasks/AzureRmWebAppDeployment/task.json
+++ b/Tasks/AzureRmWebAppDeployment/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 3,
         "Minor": 2,
-        "Patch": 2
+        "Patch": 3
     },
     "releaseNotes": "What's new in Version 3.0: <br/>&nbsp;&nbsp;Supports File Transformations (XDT) <br/>&nbsp;&nbsp;Supports Variable Substitutions(XML, JSON) <br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more Information.",
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeployment/task.loc.json
+++ b/Tasks/AzureRmWebAppDeployment/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 3,
     "Minor": 2,
-    "Patch": 2
+    "Patch": 3
   },
   "releaseNotes": "What's new in Version 3.0: <br/>&nbsp;&nbsp;Supports File Transformations (XDT) <br/>&nbsp;&nbsp;Supports Variable Substitutions(XML, JSON) <br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more Information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/Common/webdeployment-common/msdeployutility.ts
+++ b/Tasks/Common/webdeployment-common/msdeployutility.ts
@@ -40,9 +40,10 @@ export function getMSDeployCmdArgs(webAppPackage: string, webAppName: string, pu
     else {
         if (webAppPackage && webAppPackage.toLowerCase().endsWith('.war')) {
             tl.debug('WAR: webAppPackage = ' + webAppPackage);
-            let warFile = path.basename(webAppPackage.toLowerCase().slice(0, webAppPackage.length - '.war'.length));
+            let warFile = path.basename(webAppPackage.slice(0, webAppPackage.length - '.war'.length));
+            let warExt = webAppPackage.slice(webAppPackage.length - '.war'.length)
             tl.debug('WAR: warFile = ' + warFile);
-            warFile = (virtualApplication) ? warFile + "/" + virtualApplication + '.war' : warFile + '.war';
+            warFile = (virtualApplication) ? warFile + "/" + virtualApplication + warExt : warFile + warExt;
             tl.debug('WAR: warFile = ' + warFile);
             msDeployCmdArgs += " -source:contentPath=\'" + webAppPackage + "\'";
             // tomcat, jetty location on server => /site/webapps/

--- a/Tasks/Common/webdeployment-common/msdeployutility.ts
+++ b/Tasks/Common/webdeployment-common/msdeployutility.ts
@@ -37,14 +37,26 @@ export function getMSDeployCmdArgs(webAppPackage: string, webAppName: string, pu
         msDeployCmdArgs += " -source:IisApp=\'" + webAppPackage + "\'";
         msDeployCmdArgs += " -dest:iisApp=\'" + webApplicationDeploymentPath + "\'";
     }
-    else {       
-        msDeployCmdArgs += " -source:package=\'" + webAppPackage + "\'";
+    else {
+        if (webAppPackage && webAppPackage.toLowerCase().endsWith('.war')) {
+            tl.debug('WAR: webAppPackage = ' + webAppPackage);
+            let warFile = path.basename(webAppPackage.toLowerCase().slice(0, webAppPackage.length - '.war'.length));
+            tl.debug('WAR: warFile = ' + warFile);
+            warFile = (virtualApplication) ? warFile + "/" + virtualApplication + '.war' : warFile + '.war';
+            tl.debug('WAR: warFile = ' + warFile);
+            msDeployCmdArgs += " -source:contentPath=\'" + webAppPackage + "\'";
+            // tomcat, jetty location on server => /site/webapps/
+            tl.debug('WAR: dest = /site/webapps/' + warFile);
+            msDeployCmdArgs += " -dest:contentPath=\'/site/webapps/" + warFile + "\'";
+        } else {
+            msDeployCmdArgs += " -source:package=\'" + webAppPackage + "\'";
 
-        if(isParamFilePresentInPacakge) {
-            msDeployCmdArgs += " -dest:auto";
-        }
-        else {
-            msDeployCmdArgs += " -dest:contentPath=\'" + webApplicationDeploymentPath + "\'";
+            if(isParamFilePresentInPacakge) {
+                msDeployCmdArgs += " -dest:auto";
+            }
+            else {
+                msDeployCmdArgs += " -dest:contentPath=\'" + webApplicationDeploymentPath + "\'";
+            }
         }
     }
 


### PR DESCRIPTION
Change msdeploy utility so it can recognize WAR files
    - the .war extension failed previously so this minimal change should do no harm.
    - updating the version number of AzureRMWebAppDeployment to force a rebuild that will include the changes made in the common folder.
    - Later we will tackle the problem of transforming the files inside the WAR to allow for deployments to other environments. This change makes it easy to deploy from a build to one and only one environment.