### PR TITLE
bumped up testselector version (for xunit 2.0 publish fix)

### DIFF
--- a/Tasks/VsTest/make.json
+++ b/Tasks/VsTest/make.json
@@ -2,7 +2,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://testselector.blob.core.windows.net/testselector/3663651/TestSelector.zip",
+                "url": "https://testselector.blob.core.windows.net/testselector/3782564/TestSelector.zip",
                 "dest": "./"
             },
             {

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 26
+        "Patch": 27
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 26
+    "Patch": 27
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
The TIA feature will still not work (meaning it will run all test always if we use xunit 2). That is being investigated separately 

1) Tested the fix for repro scenario 