### PR TITLE
DTAv2 infinite reboot and autologon warning changes

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/SetupTestMachineForUITests.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/SetupTestMachineForUITests.ps1
@@ -1,4 +1,112 @@
-﻿function Set-DisableScreenSaverReg {
+﻿function CheckForAutoLogonPrerequisites()
+{
+    # checking prerequisites for autologon
+    if(IsAutoLogonDisabled)
+    {
+        Write-Verbose -Message "Admin auto logon is disabled" -Verbose
+    }
+ 
+    #check for both 64 bit & 32 bit, as policy can be used from both 
+    $policy64registryPath = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\policies\system"
+    $policy32registryPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\policies\system"
+    
+    #check only for 32 bit reg key as winlogon process is 32 bit 
+    $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon"
+    
+    if( LegalNoticeKeysAreNotEmpty($policy64registryPath) -or LegalNoticeKeysAreNotEmpty($policy32registryPath) )
+    {
+        Write-Verbose -Message "Show logon message policy is enabled" -Verbose
+    }
+    elseif(LegalNoticeKeysAreNotEmpty($registryPath))
+    {
+        Write-Verbose -Message "Show logon message is enabled" -Verbose
+    }
+}
+
+function IsAutoLogonDisabled()
+{
+    #check only for 32 bit reg key as winlogon process is 32 bit 
+    $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon"
+
+    if (-not (Test-Path $registryPath))
+    {
+        Write-Verbose -Message "Registry path $registryPath not found" -Verbose
+        return $true
+    }
+    
+    $autoadminLogon = (Get-ItemProperty $registryPath -ErrorAction SilentlyContinue).AutoAdminLogon
+    if ([string]::IsNullOrEmpty($autoadminLogon))
+    {
+        Write-Verbose -Message "Registry path $registryPath found. AutoAdminLogon key is not set." -Verbose
+        return $true
+    }
+    elseif($autoadminLogon -eq "1")
+    {
+        return $false
+    }
+
+    Write-Verbose -Message "Registry path $registryPath found. AutoAdminLogon key is not enabled." -Verbose
+    return $true
+}
+
+function LegalNoticeKeysAreNotEmpty([string] $registryPath)
+{
+    if (-not (Test-Path $registryPath))
+    {
+        Write-Verbose -Message "Registry path $registryPath not found" -Verbose
+        return $false
+    }
+    
+    $legalCaption = (Get-ItemProperty $registryPath -ErrorAction SilentlyContinue).legalnoticecaption
+    $legalText = (Get-ItemProperty $registryPath -ErrorAction SilentlyContinue).legalnoticetext
+    if ((-not [string]::IsNullOrEmpty($legalCaption)) -and (-not [string]::IsNullOrEmpty($legalText)))
+    {
+        Write-Verbose -Message "Registry path $registryPath found. Both keys legalnoticecaption and legalnoticetext are not empty." -Verbose
+        return $true
+    }
+
+    return $false
+}
+
+function Update-RebootCount([string] $environmentURL)
+{
+    #this is to detect whether OS is 64 bit or 32 bit
+    if ([IntPtr]::Size -eq 8)
+    {
+        $testAgentRegPath = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\TestAgentConfig"
+    }
+    else
+    {
+        $testAgentRegPath = "HKLM:\SOFTWARE\Microsoft\TestAgentConfig" 
+    }
+
+    #in case registry key is not found create a new one with required values
+    if (-not (Test-Path $testAgentRegPath))
+    {
+        New-Item -Path $testAgentRegPath -Force -ErrorAction SilentlyContinue | Out-Null
+        Write-Verbose -Message ("Updating machine reboot count to 1") -Verbose
+        New-ItemProperty -Path $testAgentRegPath -Name "MachineRebootCount" -Value 1 -PropertyType DWord -Force -ErrorAction SilentlyContinue | Out-Null
+        New-ItemProperty -Path $testAgentRegPath -Name "EnvironmentURL" -Value $environmentURL -PropertyType String -Force -ErrorAction SilentlyContinue | Out-Null
+        return 1;
+    }
+ 
+    [int]$machineRebootCount = (Get-ItemProperty $testAgentRegPath -ErrorAction SilentlyContinue).MachineRebootCount
+    $savedEnvURL = (Get-ItemProperty $testAgentRegPath -ErrorAction SilentlyContinue).EnvironmentURL
+
+    if (($machineRebootCount -eq $null) -or ([string]::Compare($savedEnvURL, $environmentURL, $True) -ne 0))
+    {
+        $machineRebootCount = 0
+    }
+
+    [int]$machineRebootCount = $machineRebootCount + 1;
+    Write-Verbose -Message "Updating machine reboot count to : $machineRebootCount" -Verbose
+    Set-ItemProperty -Path $testAgentRegPath -Name "MachineRebootCount" -Value $machineRebootCount -Force | Out-Null
+    Set-ItemProperty -Path $testAgentRegPath -Name "EnvironmentURL" -Value $environmentURL -Force | Out-Null
+
+    return $machineRebootCount
+}
+
+function Set-DisableScreenSaverReg {
     Set-ItemProperty -Path 'REGISTRY::HKEY_CURRENT_USER\Control Panel\Desktop' -Name ScreenSaveActive -Value 0 -ErrorAction SilentlyContinue
     $groupPolicy = (Get-ItemProperty -Path 'REGISTRY::HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\Control Panel\Desktop' -ErrorAction SilentlyContinue).ScreenSaveActive
     if($groupPolicy -eq "1"){
@@ -614,7 +722,10 @@ namespace MS.VS.TestTools.Config
     return [MS.VS.TestTools.Config.EnumerateUsers]::IsActiveSessionExists($TestUserDomain, $TestUserName)
 }
 
-function SetupTestMachine($TestUserName, $TestUserPassword) {
+function SetupTestMachine($TestUserName, $TestUserPassword, $EnvironmentURL) {
+
+    # checking prerequisites for autologon and printing required log messages. Do not send output of this function to null as we need those log messages to print required warnings
+    CheckForAutoLogonPrerequisites
 
     # For UI Test scenarios, we need to disable the screen saver and enable auto logon
     $DomainUser = $TestUserName.Split("\")
@@ -636,6 +747,11 @@ function SetupTestMachine($TestUserName, $TestUserPassword) {
     $isTestUserLogged = IsTestUserCurrentlyLoggedIn -TestUserDomain $Domain -TestUserName $TestUser
     if(-not $isTestUserLogged)
     {
+        $rebootCount = Update-RebootCount($EnvironmentURL)
+        if($rebootCount -gt 3)
+        {
+            throw ("Stopping test machine setup as it exceeded maximum number of reboots. If you are running test agent in interactive mode, please make sure that autologon is enabled and no legal notice is displayed on logon in test machines.")
+        }
         Write-Verbose "Currently test user is not logged in. Rebooting machine." -Verbose
         Set-EnableAutoLogon -TestUserDomain $Domain -TestUserName $TestUser -TestUserPassword $TestUserPassword
         return 3010
@@ -645,4 +761,4 @@ function SetupTestMachine($TestUserName, $TestUserPassword) {
     return 0
 }
 
-return SetupTestMachine -TestUserName $testUserName -TestUserPassword $testUserPassword
+return SetupTestMachine -TestUserName $testUserName -TestUserPassword $testUserPassword -EnvironmentURL $environmentURL

--- a/Tasks/DeployVisualStudioTestAgent/make.json
+++ b/Tasks/DeployVisualStudioTestAgent/make.json
@@ -2,7 +2,7 @@
      "externals": {
          "archivePackages": [
             {
-                "url": "https://testexecution.blob.core.windows.net/testplatformdeployment/3778663/TestPlatform.Deployment.zip",
+                "url": "https://testexecution.blob.core.windows.net/testplatformdeployment/3789358/TestPlatform.Deployment.zip",
                 "dest": "./"
             }
         ],

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 9
+        "Patch": 10
     },
     "preview": "true",
     "releaseNotes": "<ul><li>Support for Visual Studio Test Agent 2017: You can now deploy and run tests using multiple versions of Visual Studio Test Agent. Versions 2015 and 2017 are supported.</li><li>Machine groups created from the Test hub are no longer supported. You can continue to use a list of machines or Azure resource groups.</li></ul>",

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 9
+    "Patch": 10
   },
   "preview": "true",
   "releaseNotes": "<ul><li>Support for Visual Studio Test Agent 2017: You can now deploy and run tests using multiple versions of Visual Studio Test Agent. Versions 2015 and 2017 are supported.</li><li>Machine groups created from the Test hub are no longer supported. You can continue to use a list of machines or Azure resource groups.</li></ul>",


### PR DESCRIPTION
Validate the necessary prereqs for DTA configuration

Description: Check for Auologon and legal notice enable and issue warnings. Handle infinite reboot scenarios

Changes done:

Registry checks added to check for legalnotice and autologon and add necessary log messages for warning to be shown
Added Update-RebootCount function which save reboot count and dtlenvironment url in registry. Configure test agent throws a error if this count has reached a value more than 3. This count is increased before returning restart code.
Tested for infinite reboot scenario. Failing after 3 restarts. Also adding necessary log messages.


Refer to PR https://github.com/Microsoft/vsts-tasks/pull/3987 for master branch PR.