### PR TITLE
#970768: Don't write JaCoCo configuration in 'pluginManagement'

### DIFF
--- a/Tasks/Common/codecoverage-tools/jacoco/jacoco.maven.ccenabler.ts
+++ b/Tasks/Common/codecoverage-tools/jacoco/jacoco.maven.ccenabler.ts
@@ -129,17 +129,6 @@ export class JacocoMavenCodeCoverageEnabler extends cc.JacocoCodeCoverageEnabler
             } else {
                 pluginsNode = buildNode.plugins;
             }
-            /* if plugins node doesn't exist look for pluginManagement */
-        } else if (buildNode.pluginManagement) {
-            if (typeof buildNode.pluginManagement === "string") {
-                buildNode.pluginManagement = {};
-            }
-            if (buildNode.pluginManagement instanceof Array) {
-                pluginsNode = buildNode.pluginManagement[0].plugins;
-            } else {
-                pluginsNode = buildNode.pluginManagement.plugins;
-            }
-            /* if both doesn't exist, create plugins */
         } else {
             buildNode.plugins = {};
             pluginsNode = buildNode.plugins;


### PR DESCRIPTION
Put JaCoCo configuration in plugins and not pluginManagement.  