### PR TITLE
Made test configuration in RFT task mandatory

### DIFF
--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -71,7 +71,7 @@
             "type": "pickList",
             "label": "Test Plan",
             "defaultValue": "",
-            "required": false,
+            "required": true,
             "properties": {
                 "DisableManageLink": "True"
             },
@@ -84,7 +84,7 @@
             "type": "pickList",
             "label": "Test Suite",
             "defaultValue": "",
-            "required": false,
+            "required": true,
             "properties": {
                 "MultiSelect": "True",
                 "DisableManageLink": "True"

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 49
+        "Patch": 50
     },
     "demands": [],
     "minimumAgentVersion": "1.104.0",
@@ -98,7 +98,7 @@
             "type": "pickList",
             "label": "Test Configuration",
             "defaultValue": "",
-            "required": false,
+            "required": true,
             "properties": {
                 "DisableManageLink": "True"
             },

--- a/Tasks/RunDistributedTests/task.loc.json
+++ b/Tasks/RunDistributedTests/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 49
+    "Patch": 50
   },
   "demands": [],
   "minimumAgentVersion": "1.104.0",
@@ -98,7 +98,7 @@
       "type": "pickList",
       "label": "ms-resource:loc.input.label.testConfiguration",
       "defaultValue": "",
-      "required": false,
+      "required": true,
       "properties": {
         "DisableManageLink": "True"
       },


### PR DESCRIPTION
Tested in both old and new editor that when users uses test assemblies
we block user from running tests.

Also tested existing build def without config. they will continue to fail. when user edits the def they wont be able to save till they choose config