### PR TITLE
Fixed overriding test run parameters

### DIFF
--- a/Tasks/VsTest/settingshelper.ts
+++ b/Tasks/VsTest/settingshelper.ts
@@ -170,17 +170,21 @@ export async function updateSettingsFileAsRequired(settingsFile: string, isParal
 }
 
 function updateRunSettingsWithParameters(result: any, overrideParametersString: string) {
-    const overrideParameters = parameterParser.parse(overrideParametersString);            
-    if (result.RunSettings && result.RunSettings.TestRunParameters && result.RunSettings.TestRunParameters[0] && 
+    const overrideParameters = parameterParser.parse(overrideParametersString);
+    if (result.RunSettings && result.RunSettings.TestRunParameters && result.RunSettings.TestRunParameters[0] &&
         result.RunSettings.TestRunParameters[0].Parameter) {
-            tl.debug('Overriding test run parameters.');
-            const parametersArray = result.RunSettings.TestRunParameters[0].Parameter;
-            parametersArray.forEach(function (parameter) {
-                const key = parameter.$.Name;
-                if (overrideParameters[key] && overrideParameters[key].value) {
+        tl.debug('Overriding test run parameters.');
+        const parametersArray = result.RunSettings.TestRunParameters[0].Parameter;
+        parametersArray.forEach(function (parameter) {
+            const key = parameter.$.Name || parameter.$.name;
+            if (overrideParameters[key] && overrideParameters[key].value) {
+                if (parameter.$.Value) {
                     parameter.$.Value = overrideParameters[key].value;
+                } else {
+                    parameter.$.value = overrideParameters[key].value;
                 }
-            });
+            }
+        });
     }
     return result;
 }

--- a/Tasks/VsTest/settingshelper.ts
+++ b/Tasks/VsTest/settingshelper.ts
@@ -176,9 +176,9 @@ function updateRunSettingsWithParameters(result: any, overrideParametersString: 
             tl.debug('Overriding test run parameters.');
             const parametersArray = result.RunSettings.TestRunParameters[0].Parameter;
             parametersArray.forEach(function (parameter) {
-                const key = parameter.$.name;
+                const key = parameter.$.Name;
                 if (overrideParameters[key] && overrideParameters[key].value) {
-                    parameter.$.value = overrideParameters[key].value;
+                    parameter.$.Value = overrideParameters[key].value;
                 }
             });
     }

--- a/Tests-Legacy/L0/VsTest/_suite.ts
+++ b/Tests-Legacy/L0/VsTest/_suite.ts
@@ -941,6 +941,7 @@ describe('VsTest Suite', function () {
                       });
         } catch (error) {
             assert.fail('updateSettingsFileAsRequired failed');
+            done(error);
         }
     });
 
@@ -957,6 +958,7 @@ describe('VsTest Suite', function () {
                       });
         } catch (error) {
             assert.fail('updateSettingsFileAsRequired failed');
+            done(error);
         }
     });
 
@@ -973,6 +975,7 @@ describe('VsTest Suite', function () {
                       });
         } catch (error) {
             assert.fail('updateSettingsFileAsRequired failed');
+            done(error);
         }
     });
 
@@ -990,6 +993,7 @@ describe('VsTest Suite', function () {
                       });
         } catch (error) {
             assert.fail('updateSettingsFileAsRequired failed');
+            done(error);
         }
     });
 
@@ -1006,6 +1010,34 @@ describe('VsTest Suite', function () {
                       });
         } catch (error) {
             assert.fail('updateSettingsFileAsRequired failed');
+            done(error);
+        }
+    });
+
+    it('Updating runsettings with overridden parameters', (done) => {
+        try {
+            const settingsFilePath = path.join(__dirname, 'data', 'ValidWithoutRunConfiguration.runsettings');
+            const overriddenParams = '-webAppUrl testVal -webAppInvalid testVal3';
+            settingsHelper.updateSettingsFileAsRequired(settingsFilePath, false, { tiaEnabled: false }, undefined, false, overriddenParams)
+                .then(function (settingsXml: string) {
+                    utils.Helper.getXmlContents(settingsXml)
+                        .then(function (settings) {
+                            let isValid = false;
+                            const parametersArray = settings.RunSettings.TestRunParameters[0].Parameter;
+                            parametersArray.forEach(function (parameter) {
+                                if (parameter.$.Name === 'webAppUrl' && parameter.$.Value === 'testVal') {
+                                    isValid = true;
+                                } else if (parameter.$.Name === 'webAppInvalid'){
+                                    isValid = false;
+                                }
+                            });
+                            assert.ok(isValid, 'testrun paremeters must be overridden');
+                            done();
+                        });
+                });
+        } catch (error) {
+            assert.fail('updateSettingsFileAsRequired failed');
+            done(error);
         }
     });
 

--- a/Tests-Legacy/L0/VsTest/_suite.ts
+++ b/Tests-Legacy/L0/VsTest/_suite.ts
@@ -1017,21 +1017,27 @@ describe('VsTest Suite', function () {
     it('Updating runsettings with overridden parameters', (done) => {
         try {
             const settingsFilePath = path.join(__dirname, 'data', 'ValidWithoutRunConfiguration.runsettings');
-            const overriddenParams = '-webAppUrl testVal -webAppInvalid testVal3';
+            const overriddenParams = '-webAppUrl testVal -webAppInvalid testVal3 -webAppPassword testPass';
+            let webAppUrlValue = '';
+            let webAppPasswordValue = '';
+
             settingsHelper.updateSettingsFileAsRequired(settingsFilePath, false, { tiaEnabled: false }, undefined, false, overriddenParams)
                 .then(function (settingsXml: string) {
                     utils.Helper.getXmlContents(settingsXml)
                         .then(function (settings) {
-                            let isValid = false;
                             const parametersArray = settings.RunSettings.TestRunParameters[0].Parameter;
                             parametersArray.forEach(function (parameter) {
-                                if (parameter.$.Name === 'webAppUrl' && parameter.$.Value === 'testVal') {
-                                    isValid = true;
-                                } else if (parameter.$.Name === 'webAppInvalid'){
-                                    isValid = false;
+                                if (parameter.$.Name === 'webAppUrl') {
+                                    webAppUrlValue = parameter.$.Value;
+                                } else if (parameter.$.Name === 'webAppInvalid') {
+                                    assert.fail(parameter.$.Name, undefined, 'test param should not exist');
+                                } else if (parameter.$.name === 'webAppPassword') {
+                                    webAppPasswordValue = parameter.$.value;
                                 }
                             });
-                            assert.ok(isValid, 'testrun paremeters must be overridden');
+
+                            assert.equal(webAppUrlValue, 'testVal', 'test run parameters must be overridden');
+                            assert.equal(webAppPasswordValue, 'testPass', 'test run parameters must be overridden');
                             done();
                         });
                 });

--- a/Tests-Legacy/L0/VsTest/data/ValidWithoutRunConfiguration.runsettings
+++ b/Tests-Legacy/L0/VsTest/data/ValidWithoutRunConfiguration.runsettings
@@ -3,6 +3,6 @@
     <TestRunParameters>
         <Parameter Name="webAppUrl" Value="http://localhost" />
         <Parameter Name="-webAppUserName" Value="Admin" />
-        <Parameter Name="webAppPassword" Value="Password" />
+        <Parameter name="webAppPassword" value="Password" />
     </TestRunParameters>
 </RunSettings>

--- a/Tests-Legacy/L0/VsTest/data/ValidWithoutRunConfiguration.runsettings
+++ b/Tests-Legacy/L0/VsTest/data/ValidWithoutRunConfiguration.runsettings
@@ -2,7 +2,7 @@
 <RunSettings>
     <TestRunParameters>
         <Parameter Name="webAppUrl" Value="http://localhost" />
-        <Parameter Name="-webAppUserName" Value="Admin" />
+        <Parameter name="-webAppUserName" Value="Admin" />
         <Parameter name="webAppPassword" value="Password" />
     </TestRunParameters>
 </RunSettings>

--- a/Tests-Legacy/L0/VsTest/data/ValidWithoutRunConfiguration.runsettings
+++ b/Tests-Legacy/L0/VsTest/data/ValidWithoutRunConfiguration.runsettings
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
     <TestRunParameters>
-        <Parameter name="webAppUrl" value="http://localhost" />
-        <Parameter name="-webAppUserName" value="Admin" />
-        <Parameter name="webAppPassword" value="Password" />
+        <Parameter Name="webAppUrl" Value="http://localhost" />
+        <Parameter Name="-webAppUserName" Value="Admin" />
+        <Parameter Name="webAppPassword" Value="Password" />
     </TestRunParameters>
 </RunSettings>


### PR DESCRIPTION
Standard runsettings template has "Test run parameters with Name and Value properties".
it should be case insensitive, currently fixing for standard templates 'Name/Value or name/value'