### PR TITLE
Chaging search logic for test adapters

### DIFF
--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -179,7 +179,7 @@ function getVstestArguments(settingsFile: string, tiaEnabled: boolean): string[]
         } else {
             argsArray.push('/TestAdapterPath:\"' + path.dirname(vstestConfig.pathtoCustomTestAdapters) + '\"');
         }
-    } else if (systemDefaultWorkingDirectory && isNugetRestoredAdapterPresent(vstestConfig.testDropLocation)) {
+    } else if (systemDefaultWorkingDirectory && isTestAdapterPresent(vstestConfig.testDropLocation)) {
         argsArray.push('/TestAdapterPath:\"' + systemDefaultWorkingDirectory + '\"');
     }
 
@@ -533,7 +533,7 @@ function getVstestTestsList(vsVersion: number): Q.Promise<string> {
         } else {
             argsArray.push('/TestAdapterPath:\"' + path.dirname(vstestConfig.pathtoCustomTestAdapters) + '\"');
         }
-    } else if (systemDefaultWorkingDirectory && isNugetRestoredAdapterPresent(vstestConfig.testDropLocation)) {
+    } else if (systemDefaultWorkingDirectory && isTestAdapterPresent(vstestConfig.testDropLocation)) {
         argsArray.push('/TestAdapterPath:\"' + systemDefaultWorkingDirectory + '\"');
     }
 
@@ -871,7 +871,7 @@ function cleanUp(temporarySettingsFile: string) {
     }
 }
 
-function isNugetRestoredAdapterPresent(rootDirectory: string): boolean {
+function isTestAdapterPresent(rootDirectory: string): boolean {
     const allFiles = tl.find(rootDirectory);
     const adapterFiles = tl.match(allFiles, '**\\*TestAdapter.dll', { matchBase: true, nocase: true });
 

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -179,7 +179,7 @@ function getVstestArguments(settingsFile: string, tiaEnabled: boolean): string[]
         } else {
             argsArray.push('/TestAdapterPath:\"' + path.dirname(vstestConfig.pathtoCustomTestAdapters) + '\"');
         }
-    } else if (systemDefaultWorkingDirectory && isNugetRestoredAdapterPresent(systemDefaultWorkingDirectory)) {
+    } else if (systemDefaultWorkingDirectory && isNugetRestoredAdapterPresent(vstestConfig.testDropLocation)) {
         argsArray.push('/TestAdapterPath:\"' + systemDefaultWorkingDirectory + '\"');
     }
 
@@ -533,7 +533,7 @@ function getVstestTestsList(vsVersion: number): Q.Promise<string> {
         } else {
             argsArray.push('/TestAdapterPath:\"' + path.dirname(vstestConfig.pathtoCustomTestAdapters) + '\"');
         }
-    } else if (systemDefaultWorkingDirectory && isNugetRestoredAdapterPresent(systemDefaultWorkingDirectory)) {
+    } else if (systemDefaultWorkingDirectory && isNugetRestoredAdapterPresent(vstestConfig.testDropLocation)) {
         argsArray.push('/TestAdapterPath:\"' + systemDefaultWorkingDirectory + '\"');
     }
 
@@ -873,19 +873,10 @@ function cleanUp(temporarySettingsFile: string) {
 
 function isNugetRestoredAdapterPresent(rootDirectory: string): boolean {
     const allFiles = tl.find(rootDirectory);
-    const adapterFiles = tl.match(allFiles, '**\\packages\\**\\*TestAdapter.dll', { matchBase: true, nocase: true });
+    const adapterFiles = tl.match(allFiles, '**\\*TestAdapter.dll', { matchBase: true, nocase: true });
 
     if (adapterFiles && adapterFiles.length !== 0) {
-        for (let i = 0; i < adapterFiles.length; i++) {
-            const adapterFile = adapterFiles[i];
-            const packageIndex = adapterFile.indexOf('packages') + 7;
-            const packageFolder = adapterFile.substr(0, packageIndex);
-            const parentFolder = path.dirname(packageFolder);
-            const solutionFiles = tl.match(allFiles, path.join(parentFolder, '*.sln'), { matchBase: true, nocase: true });
-            if (solutionFiles && solutionFiles.length !== 0) {
-                return true;
-            }
-        }
+        return true;
     }
     return false;
 }

--- a/Tests-Legacy/L0/VsTest/_suite.ts
+++ b/Tests-Legacy/L0/VsTest/_suite.ts
@@ -570,7 +570,7 @@ describe('VsTest Suite', function () {
             });
     })
 
-    it('Vstest task with Nuget restored adapter path', (done) => {
+    it('Vstest task with test adapter should be found automatically', (done) => {
 
         const vstestCmd = [sysVstestLocation, '/source/dir/someFile1', '/logger:trx', '/TestAdapterPath:/source/dir'].join(' ');
         setResponseFile('vstestGoodwithNugetAdapter.json');

--- a/Tests-Legacy/L0/VsTest/vstestGoodRunInParallel.json
+++ b/Tests-Legacy/L0/VsTest/vstestGoodRunInParallel.json
@@ -8,7 +8,7 @@
         "vs15Helper": "/path/to/vs15Helper.ps1"
     },
     "match": {
-        "**\\packages\\**\\*TestAdapter.dll": []
+        "**\\*TestAdapter.dll": []
     },
     "findMatch": {
         "/source/dir/some/*pattern": [

--- a/Tests-Legacy/L0/VsTest/vstestGoodwithNugetAdapter.json
+++ b/Tests-Legacy/L0/VsTest/vstestGoodwithNugetAdapter.json
@@ -8,7 +8,7 @@
         "vs15Helper": "/path/to/vs15Helper.ps1"
     },
     "match": {
-        "**\\packages\\**\\*TestAdapter.dll": [
+        "**\\*TestAdapter.dll": [
             "/source/dir/packages/adapter/a.TestAdapter.dll",
             "/source/dir/packages/adapter/b.testadapter.dll"
         ],


### PR DESCRIPTION
Changing test adapter logic, similar to DTA flow.
Tested default flows in build and release for mstestv2 and nunit 