### PR TITLE
Fixes in iOS signing

### DIFF
--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -97,7 +97,7 @@ export async function installCertInTemporaryKeychain(keychainPath: string, keych
 
     await listVerifyCommand.exec();
 
-    if (listVerifyOutput.indexOf(keychainPath) < 0) {
+    if (!listVerifyOutput || listVerifyOutput.indexOf(keychainPath) < 0) {
         throw tl.loc('TempKeychainSetupFailed');
     }
 
@@ -228,7 +228,7 @@ export async function getProvisioningProfileType(provProfilePath: string) {
         //get ProvisionsAllDevices - this will exist for enterprise profiles
         var provisionsAllDevices: string = await printFromPlist('ProvisionsAllDevices', tmpPlist);
         tl.debug('provisionsAllDevices = ' + provisionsAllDevices);
-        if (provisionsAllDevices && provisionsAllDevices.toLowerCase() === 'true') {
+        if (provisionsAllDevices && provisionsAllDevices.trim().toLowerCase() === 'true') {
             //ProvisionsAllDevices = true in enterprise profiles
             provProfileType = 'enterprise';
         } else {

--- a/Tasks/XamariniOS/task.json
+++ b/Tasks/XamariniOS/task.json
@@ -11,7 +11,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 116,
+        "Minor": 117,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/XamariniOS/task.loc.json
+++ b/Tasks/XamariniOS/task.loc.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 116,
+    "Minor": 117,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/XamariniOS/xamarinios.ts
+++ b/Tasks/XamariniOS/xamarinios.ts
@@ -90,7 +90,7 @@ async function run() {
                 let keychainPwd: string = '_xamariniostask_TmpKeychain_Pwd#1';
 
                 //create a temporary keychain and install the p12 into that keychain
-                tl.debug('installed cert in temp keychain');
+                tl.debug('installing cert in temp keychain');
                 await sign.installCertInTemporaryKeychain(keychain, keychainPwd, p12, p12pwd, false);
                 codesignKeychain = keychain;
 

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -11,7 +11,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 116,
+        "Minor": 117,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 116,
+    "Minor": 117,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
- Fix issue in detecting "enterprise" provisioning profiles on Sierra
- Better error handling to detect when installing certificate and listing keychains does not work