### PR TITLE
Fix discovery of VS 15

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -36,6 +36,17 @@
             Write-Warning $_
         }
 
+        $TestWindowPath = $null
+        $VsPath = $null
+        if ($TestAgentVersion -eq "15.0") {
+            $instance = Get-VisualStudio_15_0
+            if ($instance) {
+                $VsPath = [System.IO.Path]::Combine($instance.Path, "Common7", "IDE")
+                $TestWindowPath = [System.IO.Path]::Combine($VsPath, "CommonExtensions", "Microsoft", "TestWindow")
+                Write-Verbose "VS path $VsPath; Test window path $TestWindowPath" -Verbose
+            }
+        }
+
         # Fix Assembly Redirections
         # VSTS uses Newton Json 8.0 while the System.Net.Http uses 6.0
         # Redirection to Newton Json 8.0
@@ -109,6 +120,10 @@
             $Processinfo.EnvironmentVariables.Add("DTA.EnvironmentUri", $EnvironmentUrl);
             $Processinfo.EnvironmentVariables.Add("DTA.TeamFoundationCollectionUri", $TfsCollection);
             $Processinfo.EnvironmentVariables.Add("DTA.TestPlatformVersion", $TestAgentVersion);
+            if ($VsPath) {
+                $Processinfo.EnvironmentVariables.Add("DTA.VisualStudio.Path", $VsPath);
+                $Processinfo.EnvironmentVariables.Add("DTA.TestWindow.Path", $TestWindowPath);
+            }
             $Processinfo.UseShellExecute = $false
             $Processinfo.LoadUserProfile = $false
             $Processinfo.CreateNoWindow = $true

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 4
+        "Patch": 5
     },
     "runsOn": [
         "Agent"

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 4
+    "Patch": 5
   },
   "runsOn": [
     "Agent"


### PR DESCRIPTION
* There's an interesting aspect where C# tries to load the VS COM Api for first time and throws below error while the PS seems to work as usually.  This fix will make sure PS passes the information to C# layer instead of using API from C#

> COM Api Exception: System.Runtime.InteropServices.COMException (0x800703FA): Retrieving the COM class factory for component with CLSID {177F0C4A-1CD3-4DE7-A32C-71DBBB9FA36D} failed due to the following error: 800703fa Illegal operation attempted on a registry key that has been marked for deletion. (Exception from HRESULT: 0x800703FA).
>    at Microsoft.VisualStudio.TestService.Utility.VsSetupInstance.GetInstances()

