### PR TITLE
Fix for ..\directory type entries for search folder

### DIFF
--- a/Tasks/VsTest/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VsTest/Strings/resources.resjson/en-US/resources.resjson
@@ -112,6 +112,5 @@
   "loc.messages.vstestLocationSpecified": "%s, specified location : %s",
   "loc.messages.uitestsparallel": "Running UI tests in parallel on the same machine can lead to errors. Consider disabling the ‘run in parallel’ option or run UI tests using a separate task. To learn more, see https://aka.ms/paralleltestexecution ",
   "loc.messages.pathToCustomAdaptersInvalid": "Path to custom adapters '%s' should be a directory and it should exist.",
-  "loc.messages.pathToCustomAdaptersContainsNoAdapters": "Path to custom adapters '%s' does not contain any test adapters, provide a valid path.",
-  "loc.messages.ResolveSearchFolder": "Resolving the path to test drop location"
+  "loc.messages.pathToCustomAdaptersContainsNoAdapters": "Path to custom adapters '%s' does not contain any test adapters, provide a valid path."
 }

--- a/Tasks/VsTest/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VsTest/Strings/resources.resjson/en-US/resources.resjson
@@ -112,5 +112,6 @@
   "loc.messages.vstestLocationSpecified": "%s, specified location : %s",
   "loc.messages.uitestsparallel": "Running UI tests in parallel on the same machine can lead to errors. Consider disabling the ‘run in parallel’ option or run UI tests using a separate task. To learn more, see https://aka.ms/paralleltestexecution ",
   "loc.messages.pathToCustomAdaptersInvalid": "Path to custom adapters '%s' should be a directory and it should exist.",
-  "loc.messages.pathToCustomAdaptersContainsNoAdapters": "Path to custom adapters '%s' does not contain any test adapters, provide a valid path."
+  "loc.messages.pathToCustomAdaptersContainsNoAdapters": "Path to custom adapters '%s' does not contain any test adapters, provide a valid path.",
+  "loc.messages.ResolveSearchFolder": "Resolving the path to test drop location"
 }

--- a/Tasks/VsTest/helpers.ts
+++ b/Tasks/VsTest/helpers.ts
@@ -38,6 +38,13 @@ export class Helper {
         return obj === null || obj === '' || obj === undefined;
     }
 
+    public static isNullOrWhitespace(input) {
+        if (typeof input === 'undefined' || input === null) {
+            return true;
+        }
+        return input.replace(/\s/g, '').length < 1;
+    }
+
     public static pathExistsAsFile(path: string) {
         return tl.exist(path) && tl.stats(path).isFile();
     }

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 49
+        "Patch": 50
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -399,6 +399,7 @@
         "vstestLocationSpecified": "%s, specified location : %s",
         "uitestsparallel": "Running UI tests in parallel on the same machine can lead to errors. Consider disabling the ‘run in parallel’ option or run UI tests using a separate task. To learn more, see https://aka.ms/paralleltestexecution ",
         "pathToCustomAdaptersInvalid": "Path to custom adapters '%s' should be a directory and it should exist.",
-        "pathToCustomAdaptersContainsNoAdapters": "Path to custom adapters '%s' does not contain any test adapters, provide a valid path."
+        "pathToCustomAdaptersContainsNoAdapters": "Path to custom adapters '%s' does not contain any test adapters, provide a valid path.",
+        "ResolveSearchFolder": "Resolving the path to test drop location"
     }
 }

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -399,7 +399,6 @@
         "vstestLocationSpecified": "%s, specified location : %s",
         "uitestsparallel": "Running UI tests in parallel on the same machine can lead to errors. Consider disabling the ‘run in parallel’ option or run UI tests using a separate task. To learn more, see https://aka.ms/paralleltestexecution ",
         "pathToCustomAdaptersInvalid": "Path to custom adapters '%s' should be a directory and it should exist.",
-        "pathToCustomAdaptersContainsNoAdapters": "Path to custom adapters '%s' does not contain any test adapters, provide a valid path.",
-        "ResolveSearchFolder": "Resolving the path to test drop location"
+        "pathToCustomAdaptersContainsNoAdapters": "Path to custom adapters '%s' does not contain any test adapters, provide a valid path."
     }
 }

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -399,7 +399,6 @@
     "vstestLocationSpecified": "ms-resource:loc.messages.vstestLocationSpecified",
     "uitestsparallel": "ms-resource:loc.messages.uitestsparallel",
     "pathToCustomAdaptersInvalid": "ms-resource:loc.messages.pathToCustomAdaptersInvalid",
-    "pathToCustomAdaptersContainsNoAdapters": "ms-resource:loc.messages.pathToCustomAdaptersContainsNoAdapters",
-    "ResolveSearchFolder": "ms-resource:loc.messages.ResolveSearchFolder"
+    "pathToCustomAdaptersContainsNoAdapters": "ms-resource:loc.messages.pathToCustomAdaptersContainsNoAdapters"
   }
 }

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -399,6 +399,7 @@
     "vstestLocationSpecified": "ms-resource:loc.messages.vstestLocationSpecified",
     "uitestsparallel": "ms-resource:loc.messages.uitestsparallel",
     "pathToCustomAdaptersInvalid": "ms-resource:loc.messages.pathToCustomAdaptersInvalid",
-    "pathToCustomAdaptersContainsNoAdapters": "ms-resource:loc.messages.pathToCustomAdaptersContainsNoAdapters"
+    "pathToCustomAdaptersContainsNoAdapters": "ms-resource:loc.messages.pathToCustomAdaptersContainsNoAdapters",
+    "ResolveSearchFolder": "ms-resource:loc.messages.ResolveSearchFolder"
   }
 }

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 49
+    "Patch": 50
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/taskinputparser.ts
+++ b/Tasks/VsTest/taskinputparser.ts
@@ -7,7 +7,6 @@ import * as utils from './helpers';
 import * as os from 'os';
 import * as versionFinder from './versionfinder';
 const uuid = require('node-uuid');
-import {isNullOrWhitespace} from './vstest'
 
 export function getDistributedTestConfigurations() {
     tl.setResourcePath(path.join(__dirname, 'task.json'));
@@ -98,7 +97,7 @@ function initTestConfigurations(testConfiguration: models.TestConfigurations) {
     tl._writeLine(tl.loc('testSelectorInput', testConfiguration.testSelection));
 
     testConfiguration.testDropLocation = tl.getInput('searchFolder');
-    if (!isNullOrWhitespace(testConfiguration.testDropLocation))
+    if (!utils.Helper.isNullOrWhitespace(testConfiguration.testDropLocation))
     {
         testConfiguration.testDropLocation = path.resolve(testConfiguration.testDropLocation);
     }
@@ -108,7 +107,7 @@ function initTestConfigurations(testConfiguration: models.TestConfigurations) {
     tl._writeLine(tl.loc('testFilterCriteriaInput', testConfiguration.testcaseFilter));
 
     testConfiguration.settingsFile = tl.getPathInput('runSettingsFile');
-    if (!isNullOrWhitespace(testConfiguration.settingsFile))
+    if (!utils.Helper.isNullOrWhitespace(testConfiguration.settingsFile))
     {
         testConfiguration.settingsFile = path.resolve(testConfiguration.settingsFile);
     }
@@ -125,7 +124,7 @@ function initTestConfigurations(testConfiguration: models.TestConfigurations) {
     testConfiguration.tiaConfig = getTiaConfiguration();
 
     testConfiguration.pathtoCustomTestAdapters = tl.getInput('pathtoCustomTestAdapters');
-    if (!isNullOrWhitespace(testConfiguration.pathtoCustomTestAdapters))
+    if (!utils.Helper.isNullOrWhitespace(testConfiguration.pathtoCustomTestAdapters))
     {
         testConfiguration.pathtoCustomTestAdapters = path.resolve(testConfiguration.pathtoCustomTestAdapters);
     }

--- a/Tasks/VsTest/taskinputparser.ts
+++ b/Tasks/VsTest/taskinputparser.ts
@@ -7,6 +7,7 @@ import * as utils from './helpers';
 import * as os from 'os';
 import * as versionFinder from './versionfinder';
 const uuid = require('node-uuid');
+import {isNullOrWhitespace} from './vstest'
 
 export function getDistributedTestConfigurations() {
     tl.setResourcePath(path.join(__dirname, 'task.json'));
@@ -97,12 +98,20 @@ function initTestConfigurations(testConfiguration: models.TestConfigurations) {
     tl._writeLine(tl.loc('testSelectorInput', testConfiguration.testSelection));
 
     testConfiguration.testDropLocation = tl.getInput('searchFolder');
+    if (!isNullOrWhitespace(testConfiguration.testDropLocation))
+    {
+        testConfiguration.testDropLocation = path.resolve(testConfiguration.testDropLocation);
+    }
     tl._writeLine(tl.loc('searchFolderInput', testConfiguration.testDropLocation));
 
     testConfiguration.testcaseFilter = tl.getInput('testFiltercriteria');
     tl._writeLine(tl.loc('testFilterCriteriaInput', testConfiguration.testcaseFilter));
 
     testConfiguration.settingsFile = tl.getPathInput('runSettingsFile');
+    if (!isNullOrWhitespace(testConfiguration.settingsFile))
+    {
+        testConfiguration.settingsFile = path.resolve(testConfiguration.settingsFile);
+    }
     tl._writeLine(tl.loc('runSettingsFileInput', testConfiguration.settingsFile));
 
     testConfiguration.overrideTestrunParameters = tl.getInput('overrideTestrunParameters');
@@ -116,6 +125,10 @@ function initTestConfigurations(testConfiguration: models.TestConfigurations) {
     testConfiguration.tiaConfig = getTiaConfiguration();
 
     testConfiguration.pathtoCustomTestAdapters = tl.getInput('pathtoCustomTestAdapters');
+    if (!isNullOrWhitespace(testConfiguration.pathtoCustomTestAdapters))
+    {
+        testConfiguration.pathtoCustomTestAdapters = path.resolve(testConfiguration.pathtoCustomTestAdapters);
+    }
     if (testConfiguration.pathtoCustomTestAdapters &&
         !utils.Helper.pathExistsAsDirectory(testConfiguration.pathtoCustomTestAdapters)) {
         throw new Error(tl.loc('pathToCustomAdaptersInvalid', testConfiguration.pathtoCustomTestAdapters));

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -83,8 +83,8 @@ function getTestAssemblies(): string[] {
         vstestConfig.testDropLocation = systemDefaultWorkingDirectory;
         tl.debug('Search directory empty, defaulting to ' + vstestConfig.testDropLocation);
     }
-    
-    tl.debug("Searching for test assemblies in: " + vstestConfig.testDropLocation);    
+
+    tl.debug('Searching for test assemblies in: ' + vstestConfig.testDropLocation);
     return tl.findMatch(vstestConfig.testDropLocation, vstestConfig.sourceFilter);
 }
 

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -79,7 +79,7 @@ export function startTest() {
 }
 
 function getTestAssemblies(): string[] {
-    if (isNullOrWhitespace(vstestConfig.testDropLocation)) {
+    if (utils.Helper.isNullOrWhitespace(vstestConfig.testDropLocation)) {
         vstestConfig.testDropLocation = systemDefaultWorkingDirectory;
         tl.debug('Search directory empty, defaulting to ' + vstestConfig.testDropLocation);
     }
@@ -131,7 +131,7 @@ function getVstestArguments(settingsFile: string, tiaEnabled: boolean): string[]
     }
 
     argsArray.push('/logger:trx');
-    if (isNullOrWhitespace(vstestConfig.pathtoCustomTestAdapters)) {
+    if (utils.Helper.isNullOrWhitespace(vstestConfig.pathtoCustomTestAdapters)) {
         if (systemDefaultWorkingDirectory && isTestAdapterPresent(vstestConfig.testDropLocation)) {
                 argsArray.push('/TestAdapterPath:\"' + systemDefaultWorkingDirectory + '\"');
             }
@@ -193,7 +193,7 @@ function uploadTestResults(testResultsDirectory: string): Q.Promise<string> {
     let resultFile: string;
     const defer = Q.defer<string>();
     let resultFiles;
-    if (!isNullOrWhitespace(testResultsDirectory)) {
+    if (!utils.Helper.isNullOrWhitespace(testResultsDirectory)) {
         resultFiles = tl.findMatch(testResultsDirectory, path.join(testResultsDirectory, '*.trx'));
     }
 
@@ -924,12 +924,3 @@ function responseContainsNoTests(filePath: string): Q.Promise<boolean> {
         }
     });
 }
-
-function isNullOrWhitespace(input) {
-    if (typeof input === 'undefined' || input === null) {
-        return true;
-    }
-    return input.replace(/\s/g, '').length < 1;
-}
-
-export {isNullOrWhitespace};

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -84,8 +84,10 @@ function getTestAssemblies(): string[] {
         tl.debug('Search directory empty, defaulting to ' + vstestConfig.testDropLocation);
     }
 
-    tl.debug('Searching for test assemblies in: ' + vstestConfig.testDropLocation);
-    return tl.findMatch(vstestConfig.testDropLocation, vstestConfig.sourceFilter);
+    tl.debug("Resolving the test drop location");
+    let resolvedPath = path.resolve(vstestConfig.testDropLocation);
+    tl.debug("Searching for test assemblies in: " + resolvedPath);    
+    return tl.findMatch(resolvedPath, vstestConfig.sourceFilter);
 }
 
 function getVstestArguments(settingsFile: string, tiaEnabled: boolean): string[] {

--- a/Tasks/VsTest/vstest.ts
+++ b/Tasks/VsTest/vstest.ts
@@ -39,8 +39,17 @@ export function startTest() {
         tiaConfig = vstestConfig.tiaConfig;
 
         // We need to resolve the path of directory inputs like the run settings file and the custom adapters path
-        resolvedRunSettingsFilePath = path.resolve(vstestConfig.settingsFile);
-        resolvedCustomAdaptersPath = path.resolve(vstestConfig.pathtoCustomTestAdapters);
+        if (!isNullOrWhitespace(vstestConfig.settingsFile))
+        {
+            resolvedRunSettingsFilePath = path.resolve(vstestConfig.settingsFile);
+            tl.debug('Resolved path for Run Settings file:' + resolvedRunSettingsFilePath);
+        }
+
+        if (!isNullOrWhitespace(vstestConfig.pathtoCustomTestAdapters))
+        {
+            resolvedCustomAdaptersPath = path.resolve(vstestConfig.pathtoCustomTestAdapters);
+            tl.debug('Resolved path for Custom Adapters: ' + resolvedCustomAdaptersPath);
+        }
 
         //Try to find the results directory for clean up. This may change later if runsettings has results directory and location go runsettings file changes.
         resultsDirectory = getTestResultsDirectory(resolvedRunSettingsFilePath, path.join(workingDirectory, 'TestResults'));
@@ -90,7 +99,7 @@ function getTestAssemblies(): string[] {
         tl.debug('Search directory empty, defaulting to ' + vstestConfig.testDropLocation);
     }
 
-    tl.debug("Resolving the test drop location");
+    tl.debug(tl.loc("ResolveSearchFolder"));
     let resolvedPath = path.resolve(vstestConfig.testDropLocation);
     tl.debug("Searching for test assemblies in: " + resolvedPath);    
     return tl.findMatch(resolvedPath, vstestConfig.sourceFilter);

--- a/Tests-Legacy/L0/VsTest/_suite.ts
+++ b/Tests-Legacy/L0/VsTest/_suite.ts
@@ -1121,7 +1121,7 @@ describe('VsTest Suite', function () {
                 done(err);
             });
     });
-
+    
     it('Vstest task with settings file path with double dots is supported', (done) => {
 
         setResponseFile('vstestGood.json');
@@ -1168,7 +1168,7 @@ describe('VsTest Suite', function () {
                 done(err);
             });
     });
-
+    
     it('Vstest task with custom adapter path with double dots is supported', (done) => {
 
         setResponseFile('vstestGood.json');
@@ -1217,6 +1217,5 @@ describe('VsTest Suite', function () {
                 console.log(tr.stdout);
                 done(err);
             });
-    })
-
+    });    
 });

--- a/Tests-Legacy/L0/VsTest/_suite.ts
+++ b/Tests-Legacy/L0/VsTest/_suite.ts
@@ -388,7 +388,7 @@ describe('VsTest Suite', function () {
 
     it('Vstest task with settings file', (done) => {
 
-        const vstestCmd = [sysVstestLocation, '/source/dir/someFile1', '/Settings:settings.runsettings', '/logger:trx'].join(' ');
+        const vstestCmd = [sysVstestLocation, '/source/dir/someFile1', '/Settings:E:\\settings.runsettings', '/logger:trx'].join(' ');
         setResponseFile('vstestGood.json');
 
         const tr = new trm.TaskRunner('VSTest');
@@ -396,7 +396,7 @@ describe('VsTest Suite', function () {
         tr.setInput('testAssemblyVer2', '/source/dir/someFile1');
         tr.setInput('vstestLocationMethod', 'version');
         tr.setInput('vsTestVersion', '14.0');
-        tr.setInput('runSettingsFile', 'settings.runsettings');
+        tr.setInput('runSettingsFile', 'E:\\settings.runsettings');
 
         tr.run()
             .then(() => {
@@ -544,7 +544,7 @@ describe('VsTest Suite', function () {
 
     it('Vstest task with custom adapter path', (done) => {
 
-        const vstestCmd = [sysVstestLocation, '/source/dir/someFile1', '/logger:trx', '/TestAdapterPath:path/to/customadapters'].join(' ');
+        const vstestCmd = [sysVstestLocation, '/source/dir/someFile1', '/logger:trx', '/TestAdapterPath:E:\\path\\to\\customadapters'].join(' ');
         setResponseFile('vstestGood.json');
 
         const tr = new trm.TaskRunner('VSTest');
@@ -552,7 +552,7 @@ describe('VsTest Suite', function () {
         tr.setInput('testAssemblyVer2', '/source/dir/someFile1');
         tr.setInput('vstestLocationMethod', 'version');
         tr.setInput('vsTestVersion', '14.0');
-        tr.setInput('pathtoCustomTestAdapters', 'path/to/customadapters');
+        tr.setInput('pathtoCustomTestAdapters', 'E:/path/to/customadapters');
 
         tr.run()
             .then(() => {
@@ -597,7 +597,7 @@ describe('VsTest Suite', function () {
 
     it('Vstest task with runsettings file and tia.enabled set to false', (done) => {
 
-        const vstestCmd = [sysVstestLocation, '/source/dir/someFile1', '/Settings:settings.runsettings', '/logger:trx'].join(' ');
+        const vstestCmd = [sysVstestLocation, '/source/dir/someFile1', '/Settings:E:\\settings.runsettings', '/logger:trx'].join(' ');
         setResponseFile('vstestGoodWithTiaDisabled.json');
 
         const tr = new trm.TaskRunner('VSTest');
@@ -605,7 +605,7 @@ describe('VsTest Suite', function () {
         tr.setInput('testAssemblyVer2', '/source/dir/someFile1');
         tr.setInput('vstestLocationMethod', 'version');
         tr.setInput('vsTestVersion', '14.0');
-        tr.setInput('runSettingsFile', 'settings.runsettings');
+        tr.setInput('runSettingsFile', 'E:\\settings.runsettings');
 
         tr.run()
             .then(() => {
@@ -624,7 +624,7 @@ describe('VsTest Suite', function () {
 
     it('Vstest task with runsettings file and tia.enabled undefined', (done) => {
 
-        const vstestCmd = [sysVstestLocation, '/source/dir/someFile1', '/Settings:settings.runsettings', '/logger:trx'].join(' ');
+        const vstestCmd = [sysVstestLocation, '/source/dir/someFile1', '/Settings:E:\\settings.runsettings', '/logger:trx'].join(' ');
         setResponseFile('vstestGood.json');
 
         const tr = new trm.TaskRunner('VSTest');
@@ -632,7 +632,7 @@ describe('VsTest Suite', function () {
         tr.setInput('testAssemblyVer2', '/source/dir/someFile1');
         tr.setInput('vstestLocationMethod', 'version');
         tr.setInput('vsTestVersion', '14.0');
-        tr.setInput('runSettingsFile', 'settings.runsettings');
+        tr.setInput('runSettingsFile', 'E:\\settings.runsettings');
 
         tr.run()
             .then(() => {
@@ -744,7 +744,7 @@ describe('VsTest Suite', function () {
             .fail((err) => {
                 done(err);
             });
-});
+    });
 
     it('Vstest task should not use diag option when system.debug is not set', (done) => {
 
@@ -1087,7 +1087,7 @@ describe('VsTest Suite', function () {
                 assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
                 assert(tr.succeeded, 'task should have succeeded');
                 assert(tr.ran(vstestCmd), 'should have run vstest');
-                assert(tr.stdout.search(/Searching for test assemblies in: E:\\source/) >= 0, 'searching in the wrong path');
+                assert(tr.stdout.search(/Search folder : E:\\source/) >= 0, 'searching in the wrong path');
                 done();
             })
             .fail((err) => {
@@ -1113,7 +1113,7 @@ describe('VsTest Suite', function () {
                 assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
                 assert(tr.succeeded, 'task should have succeeded');
                 assert(tr.ran(vstestCmd), 'should have run vstest');
-                assert(tr.stdout.search(/Searching for test assemblies in: E:\\source\\dir/) >= 0, 'searching in the wrong path');
+                assert(tr.stdout.search(/Search folder : E:\\source\\dir/) >= 0, 'searching in the wrong path');
                 done();
             })
             .fail((err) => {
@@ -1121,4 +1121,102 @@ describe('VsTest Suite', function () {
                 done(err);
             });
     });
+
+    it('Vstest task with settings file path with double dots is supported', (done) => {
+
+        setResponseFile('vstestGood.json');
+
+        const tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testSelector', 'testAssemblies');
+        tr.setInput('testAssemblyVer2', '/source/dir/someFile1');
+        tr.setInput('vstestLocationMethod', 'version');
+        tr.setInput('vsTestVersion', '14.0');
+        tr.setInput('runSettingsFile', 'E:\\source\\dir\\..\\settings.runsettings');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.stdout.search(/Run settings file : E:\\source\\settings.runsettings/) >= 0, 'should publish test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    });
+
+    it('Vstest task with settings file path with single dots is supported', (done) => {
+        setResponseFile('vstestGood.json');
+
+        const tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testSelector', 'testAssemblies');
+        tr.setInput('testAssemblyVer2', '/source/dir/someFile1');
+        tr.setInput('vstestLocationMethod', 'version');
+        tr.setInput('vsTestVersion', '14.0');
+        tr.setInput('runSettingsFile', 'E:\\source\\dir\\.\\settings.runsettings');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.stdout.search(/Run settings file : E:\\source\\dir\\settings.runsettings/) >= 0, 'should publish test results.');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    });
+
+    it('Vstest task with custom adapter path with double dots is supported', (done) => {
+
+        setResponseFile('vstestGood.json');
+
+        const tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testSelector', 'testAssemblies');
+        tr.setInput('testAssemblyVer2', '/source/dir/someFile1');
+        tr.setInput('vstestLocationMethod', 'version');
+        tr.setInput('vsTestVersion', '14.0');
+        tr.setInput('pathtoCustomTestAdapters', 'E:/path/to/../customadapters');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.stdout.search(/Path to custom adapters : E:\\path\\customadapters/) >= 0, 'should publish test results.');
+                done();
+            })
+            .fail((err) => {
+                console.log(tr.stdout);
+                done(err);
+            });
+    });
+
+    it('Vstest task with custom adapter path with single dots is supported', (done) => {
+
+        setResponseFile('vstestGood.json');
+
+        const tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testSelector', 'testAssemblies');
+        tr.setInput('testAssemblyVer2', '/source/dir/someFile1');
+        tr.setInput('vstestLocationMethod', 'version');
+        tr.setInput('vsTestVersion', '14.0');
+        tr.setInput('pathtoCustomTestAdapters', 'E:/path/to/./customadapters');
+
+        tr.run()
+            .then(() => {
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.stdout.search(/Path to custom adapters : E:\\path\\to\\customadapters/) >= 0, 'should publish test results.');
+                done();
+            })
+            .fail((err) => {
+                console.log(tr.stdout);
+                done(err);
+            });
+    })
+
 });

--- a/Tests-Legacy/L0/VsTest/_suite.ts
+++ b/Tests-Legacy/L0/VsTest/_suite.ts
@@ -1069,4 +1069,56 @@ describe('VsTest Suite', function () {
                 done(err);
             });
     });
+
+    it('Vstest search folder field supports double dots', (done) => {
+        const vstestCmd = [sysVstestLocation, '/source/dir/someFile2 /source/dir/someFile1', '/logger:trx'].join(' ');
+        setResponseFile('vstestGood.json');
+
+        const tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testSelector', 'testAssemblies');       
+        tr.setInput('testAssemblyVer2', '/source/dir/some/*pattern');
+        tr.setInput('vstestLocationMethod', 'version');
+        tr.setInput('vsTestVersion', '14.0');
+        tr.setInput('searchFolder','E:\\source\\dir\\..');        
+
+        tr.run()
+            .then(() => {                
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran(vstestCmd), 'should have run vstest');
+                assert(tr.stdout.search(/Searching for test assemblies in: E:\\source/) >= 0, 'searching in the wrong path');
+                done();
+            })
+            .fail((err) => {
+                console.log(tr.stdout);
+                done(err);
+            });
+    });
+
+    it('Vstest search folder field supports single dots', (done) => {
+        const vstestCmd = [sysVstestLocation, '/source/dir/someFile2 /source/dir/someFile1', '/logger:trx'].join(' ');
+        setResponseFile('vstestGood.json');
+
+        const tr = new trm.TaskRunner('VSTest');
+        tr.setInput('testSelector', 'testAssemblies');       
+        tr.setInput('testAssemblyVer2', '/source/dir/some/*pattern');
+        tr.setInput('vstestLocationMethod', 'version');
+        tr.setInput('vsTestVersion', '14.0');
+        tr.setInput('searchFolder','E:\\source\\.\\dir');        
+
+        tr.run()
+            .then(() => {                
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.ran(vstestCmd), 'should have run vstest');
+                assert(tr.stdout.search(/Searching for test assemblies in: E:\\source\\dir/) >= 0, 'searching in the wrong path');
+                done();
+            })
+            .fail((err) => {
+                console.log(tr.stdout);
+                done(err);
+            });
+    });
 });

--- a/Tests-Legacy/L0/VsTest/_suite.ts
+++ b/Tests-Legacy/L0/VsTest/_suite.ts
@@ -1087,7 +1087,7 @@ describe('VsTest Suite', function () {
                 assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
                 assert(tr.succeeded, 'task should have succeeded');
                 assert(tr.ran(vstestCmd), 'should have run vstest');
-                assert(tr.stdout.search(/Search folder : E:\\source/) >= 0, 'searching in the wrong path');
+                assert(tr.stdout.search(/Search folder : E:\\source/) >= 0, 'searching in the wrong path with double dots');
                 done();
             })
             .fail((err) => {
@@ -1113,7 +1113,7 @@ describe('VsTest Suite', function () {
                 assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
                 assert(tr.succeeded, 'task should have succeeded');
                 assert(tr.ran(vstestCmd), 'should have run vstest');
-                assert(tr.stdout.search(/Search folder : E:\\source\\dir/) >= 0, 'searching in the wrong path');
+                assert(tr.stdout.search(/Search folder : E:\\source\\dir/) >= 0, 'searching in the wrong path with single dots');
                 done();
             })
             .fail((err) => {
@@ -1138,7 +1138,7 @@ describe('VsTest Suite', function () {
                 assert(tr.resultWasSet, 'task should have set a result');
                 assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
                 assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.stdout.search(/Run settings file : E:\\source\\settings.runsettings/) >= 0, 'should publish test results.');
+                assert(tr.stdout.search(/Run settings file : E:\\source\\settings.runsettings/) >= 0, 'wrong path for settings file with double dots');
                 done();
             })
             .fail((err) => {
@@ -1161,7 +1161,7 @@ describe('VsTest Suite', function () {
                 assert(tr.resultWasSet, 'task should have set a result');
                 assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
                 assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.stdout.search(/Run settings file : E:\\source\\dir\\settings.runsettings/) >= 0, 'should publish test results.');
+                assert(tr.stdout.search(/Run settings file : E:\\source\\dir\\settings.runsettings/) >= 0, 'wrong path for settings file with single dots');
                 done();
             })
             .fail((err) => {
@@ -1185,7 +1185,7 @@ describe('VsTest Suite', function () {
                 assert(tr.resultWasSet, 'task should have set a result');
                 assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
                 assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.stdout.search(/Path to custom adapters : E:\\path\\customadapters/) >= 0, 'should publish test results.');
+                assert(tr.stdout.search(/Path to custom adapters : E:\\path\\customadapters/) >= 0, 'wrong path for custom adapters with double dots');
                 done();
             })
             .fail((err) => {
@@ -1210,7 +1210,7 @@ describe('VsTest Suite', function () {
                 assert(tr.resultWasSet, 'task should have set a result');
                 assert(tr.stderr.length === 0, 'should not have written to stderr. error: ' + tr.stderr);
                 assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.stdout.search(/Path to custom adapters : E:\\path\\to\\customadapters/) >= 0, 'should publish test results.');
+                assert(tr.stdout.search(/Path to custom adapters : E:\\path\\to\\customadapters/) >= 0, 'wrong path for custom adapters with single dots');
                 done();
             })
             .fail((err) => {

--- a/Tests-Legacy/L0/VsTest/vstestGood.json
+++ b/Tests-Legacy/L0/VsTest/vstestGood.json
@@ -54,7 +54,27 @@
             "code": 0,
             "stdout": "vstest"
         },
+        "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /Settings:E:\\settings.runsettings /logger:trx": {
+            "code": 0,
+            "stdout": "vstest"
+        },
+        "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /Settings:E:\\source\\settings.runsettings /logger:trx": {
+            "code": 0,
+            "stdout": "vstest"
+        },
+        "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /Settings:E:\\source\\dir\\settings.runsettings /logger:trx": {
+            "code": 0,
+            "stdout": "vstest"
+        },
         "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /logger:trx /TestAdapterPath:path/to/customadapters": {
+            "code": 0,
+            "stdout": "vstest"
+        },
+        "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /logger:trx /TestAdapterPath:E:\\path\\to\\customadapters": {
+            "code": 0,
+            "stdout": "vstest"
+        },
+        "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /logger:trx /TestAdapterPath:E:\\path\\customadapters": {
             "code": 0,
             "stdout": "vstest"
         },
@@ -96,16 +116,33 @@
     },
     "exist": {
         "settings.runsettings": true,
+        "E:\\settings.runsettings": true,
         "random.runsettings": false,
         "path/to/customadapters": true,
+        "E:\\path\\to\\customadapters": true,
         "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\TE.TestModes.dll": false,
         "some\\path\\to\\vstest.console.exe": true,
         "some\\illegal\\path\\to\\vstest.console.exe": false,
-        "\\path\\to\\vstest\\directory": true
+        "\\path\\to\\vstest\\directory": true,
+        "E:\\source\\settings.runsettings": true,
+        "E:\\source\\dir\\settings.runsettings":true,
+        "E:\\path\\customadapters":true
     },
     "stats": {
         "settings.runsettings": {
             "isFile": true
+        },
+        "E:\\settings.runsettings": {
+            "isFile": true
+        },
+        "E:\\source\\settings.runsettings": {
+            "isFile": true
+        },
+        "E:\\source\\dir\\settings.runsettings": {
+            "isFile": true
+        },
+        "E:\\path\\customadapters": {
+            "isDirectory": true
         },
         "random.runsettings": {
             "isFile": false
@@ -114,6 +151,9 @@
             "isFile": true
         },
         "path/to/customadapters": {
+            "isDirectory": true
+        },
+        "E:\\path\\to\\customadapters": {
             "isDirectory": true
         },
         "\\path\\to\\vstest\\directory": {

--- a/Tests-Legacy/L0/VsTest/vstestGood.json
+++ b/Tests-Legacy/L0/VsTest/vstestGood.json
@@ -81,11 +81,7 @@
         "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /logger:trx /TestAdapterPath:E:\\path\\customadapters": {
             "code": 0,
             "stdout": "vstest"
-        },
-        "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /logger:trx /TestAdapterPath:\\test-machine\\path\\to\\customadapters": {
-            "code": 0,
-            "stdout": "vstest"
-        },
+        },        
         "some\\path\\to\\vstest.console.exe /source/dir/someFile1 /logger:trx": {
             "code": 0,
             "stdout": "vstest"
@@ -134,9 +130,7 @@
         "\\path\\to\\vstest\\directory": true,
         "E:\\source\\settings.runsettings": true,
         "E:\\source\\dir\\settings.runsettings":true,
-        "E:\\path\\customadapters":true,
-        "\\\\test-machine\\source\\dir\\settings.runsettings": true,
-        "\\\\test-machine\\path\\to\\customadapters": true
+        "E:\\path\\customadapters":true
     },
     "stats": {
         "settings.runsettings": {
@@ -149,9 +143,6 @@
             "isFile": true
         },
         "E:\\source\\dir\\settings.runsettings": {
-            "isFile": true
-        },
-        "\\\\test-machine\\source\\dir\\settings.runsettings": {
             "isFile": true
         },
         "E:\\path\\customadapters": {
@@ -171,9 +162,6 @@
         },
         "\\path\\to\\vstest\\directory": {
             "isDirectory": true
-        },
-        "\\\\test-machine\\path\\to\\customadapters": {
-            "isDirectory": true
-        }        
+        }       
     }
 }

--- a/Tests-Legacy/L0/VsTest/vstestGood.json
+++ b/Tests-Legacy/L0/VsTest/vstestGood.json
@@ -66,6 +66,10 @@
             "code": 0,
             "stdout": "vstest"
         },
+        "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /Settings:\\\\test-machine\\source\\dir\\settings.runsettings /logger:trx": {
+            "code": 0,
+            "stdout": "vstest"
+        },
         "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /logger:trx /TestAdapterPath:path/to/customadapters": {
             "code": 0,
             "stdout": "vstest"
@@ -75,6 +79,10 @@
             "stdout": "vstest"
         },
         "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /logger:trx /TestAdapterPath:E:\\path\\customadapters": {
+            "code": 0,
+            "stdout": "vstest"
+        },
+        "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /logger:trx /TestAdapterPath:\\test-machine\\path\\to\\customadapters": {
             "code": 0,
             "stdout": "vstest"
         },
@@ -119,14 +127,16 @@
         "E:\\settings.runsettings": true,
         "random.runsettings": false,
         "path/to/customadapters": true,
-        "E:\\path\\to\\customadapters": true,
+        "E:\\path\\to\\customadapters": true,        
         "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\TE.TestModes.dll": false,
         "some\\path\\to\\vstest.console.exe": true,
         "some\\illegal\\path\\to\\vstest.console.exe": false,
         "\\path\\to\\vstest\\directory": true,
         "E:\\source\\settings.runsettings": true,
         "E:\\source\\dir\\settings.runsettings":true,
-        "E:\\path\\customadapters":true
+        "E:\\path\\customadapters":true,
+        "\\\\test-machine\\source\\dir\\settings.runsettings": true,
+        "\\\\test-machine\\path\\to\\customadapters": true
     },
     "stats": {
         "settings.runsettings": {
@@ -139,6 +149,9 @@
             "isFile": true
         },
         "E:\\source\\dir\\settings.runsettings": {
+            "isFile": true
+        },
+        "\\\\test-machine\\source\\dir\\settings.runsettings": {
             "isFile": true
         },
         "E:\\path\\customadapters": {
@@ -158,6 +171,9 @@
         },
         "\\path\\to\\vstest\\directory": {
             "isDirectory": true
-        }
+        },
+        "\\\\test-machine\\path\\to\\customadapters": {
+            "isDirectory": true
+        }        
     }
 }

--- a/Tests-Legacy/L0/VsTest/vstestGoodWithTiaDisabled.json
+++ b/Tests-Legacy/L0/VsTest/vstestGoodWithTiaDisabled.json
@@ -22,6 +22,10 @@
             "code": 0,
             "stdout": "vstest"
         },
+        "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe /source/dir/someFile1 /Settings:E:\\settings.runsettings /logger:trx": {
+            "code": 0,
+            "stdout": "vstest"
+        },
         "wmic datafile where name='\\\\vs\\\\IDE\\\\CommonExtensions\\\\Microsoft\\\\TestWindow\\\\vstest.console.exe' get Version /Value": {
 			"code": 0,
 			"stdout" : "version=14.0.0.0"
@@ -36,7 +40,8 @@
     "exist": {
         "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\TE.TestModes.dll": true,
         "settings.runsettings": true,
-        "settings.testsettings": true
+        "settings.testsettings": true,
+        "E:\\settings.runsettings": true
     },
     "stats": {
         "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\TE.TestModes.dll": {
@@ -46,6 +51,9 @@
             "isFile": true
         },
         "settings.testsettings": {
+            "isFile": true
+        },
+        "E:\\settings.runsettings": {
             "isFile": true
         }
     }


### PR DESCRIPTION
Problem: The root directory path for searching test assemblies does not support ..\directory type entries. 
Fix: This fix resolves this issue.
Testing: Unit and Manual