### PR TITLE
Bump tasklib version for quoting fix

### DIFF
--- a/Tasks/Maven/package.json
+++ b/Tasks/Maven/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "glob": "7.1.0",
     "request": "^2.74.0",
-    "vsts-task-lib": "0.9.7",
+    "vsts-task-lib": "1.1.0",
     "xml2js": "^0.4.16"
   }
 }

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -19,7 +19,7 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 118,
+        "Minor": 119,
         "Patch": 0
     },
     "minimumAgentVersion": "1.89.0",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -19,7 +19,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 118,
+    "Minor": 119,
     "Patch": 0
   },
   "minimumAgentVersion": "1.89.0",


### PR DESCRIPTION
This tasklib version fixes a case when there is a space in both the path to mvn and the pom.xml file.