### PR TITLE
Handle non existence of app manifest in older build

### DIFF
--- a/Tasks/ServiceFabricUpdateAppVersions/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ServiceFabricUpdateAppVersions/Strings/resources.resjson/en-US/resources.resjson
@@ -32,6 +32,7 @@
   "loc.messages.PreviousBuildNumberLabel": "Previous build number: '{0}'",
   "loc.messages.PreviousBuildLocationLabel": "Previous build location: '{0}'",
   "loc.messages.NoPreviousSuccessfulBuild": "Could not find previous build to compare against.",
+  "loc.messages.NoManifestInPreviousBuild": "Previous build does not contains application manifest. Force updating application type version.",
   "loc.messages.UpdatedApplicationTypeVersion": "Updated application type '{0}' to version '{1}'.",
   "loc.messages.UpdatedServiceVerison": "Updated service '{0}' to version '{1}'.",
   "loc.messages.UpdatedPackageVerison": "Updated package '{0}\\{1}' to version '{2}'.",

--- a/Tasks/ServiceFabricUpdateAppVersions/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ServiceFabricUpdateAppVersions/Strings/resources.resjson/en-US/resources.resjson
@@ -32,7 +32,7 @@
   "loc.messages.PreviousBuildNumberLabel": "Previous build number: '{0}'",
   "loc.messages.PreviousBuildLocationLabel": "Previous build location: '{0}'",
   "loc.messages.NoPreviousSuccessfulBuild": "Could not find previous build to compare against.",
-  "loc.messages.NoManifestInPreviousBuild": "Previous build does not contains application manifest. Force updating application type version.",
+  "loc.messages.NoManifestInPreviousBuild": "Previous build does not contains application manifest. Force updating all manifest versions.",
   "loc.messages.UpdatedApplicationTypeVersion": "Updated application type '{0}' to version '{1}'.",
   "loc.messages.UpdatedServiceVerison": "Updated service '{0}' to version '{1}'.",
   "loc.messages.UpdatedPackageVerison": "Updated package '{0}\\{1}' to version '{2}'.",

--- a/Tasks/ServiceFabricUpdateAppVersions/Tests/L0.ts
+++ b/Tasks/ServiceFabricUpdateAppVersions/Tests/L0.ts
@@ -42,6 +42,9 @@ describe('ServiceFabricUpdateAppVersions Suite', function () {
         it('(Update-ApplicationVersions) app version prefix changed', (done) => {
             psr.run(path.join(__dirname, 'Update-ApplicationVersions.VersionPrefixChanged.ps1'), done);
         })
+        it('(Update-ApplicationVersions) old app manifest not found', (done) => {
+            psr.run(path.join(__dirname, 'Update-ApplicationVersions.OldManifestNotFound.ps1'), done);
+        })
         it('(Update-ServiceVersions) no changes', (done) => {
             psr.run(path.join(__dirname, 'Update-ServiceVersions.NoChanges.ps1'), done);
         })

--- a/Tasks/ServiceFabricUpdateAppVersions/Tests/Update-ApplicationVersions.OldManifestNotFound.ps1
+++ b/Tasks/ServiceFabricUpdateAppVersions/Tests/Update-ApplicationVersions.OldManifestNotFound.ps1
@@ -1,0 +1,4 @@
+[CmdletBinding()]
+param()
+
+. "$PSScriptRoot\Test-ApplicationVersions.ps1" PreviousPackageNoManifest

--- a/Tasks/ServiceFabricUpdateAppVersions/Update-ApplicationVersions.ps1
+++ b/Tasks/ServiceFabricUpdateAppVersions/Update-ApplicationVersions.ps1
@@ -65,11 +65,19 @@ try {
 
             $oldAppPackagePath = Join-Path $oldDropLocation $newAppPackagePath.SubString((Get-VstsTaskVariable -Name Build.SourcesDirectory -Require).Length + 1)
             $oldAppManifestPath = Join-Path $oldAppPackagePath $appManifestName
-            $oldAppManifestXml = [XML](Get-Content $oldAppManifestPath)
+            if (Test-Path $oldAppManifestPath)
+            {
+                $oldAppManifestXml = [XML](Get-Content $oldAppManifestPath)
 
-            # Set the version to the version from the previous build (including its suffix). This will be overwritten if we find any changes, otherwise it will match the previous build by design.
-            # Set it before we search for changes so that we can compare the xml without the old version suffix causing a false positive. 
-            $newAppManifestXml.ApplicationManifest.ApplicationTypeVersion = $oldAppManifestXml.ApplicationManifest.ApplicationTypeVersion
+                # Set the version to the version from the previous build (including its suffix). This will be overwritten if we find any changes, otherwise it will match the previous build by design.
+                # Set it before we search for changes so that we can compare the xml without the old version suffix causing a false positive. 
+                $newAppManifestXml.ApplicationManifest.ApplicationTypeVersion = $oldAppManifestXml.ApplicationManifest.ApplicationTypeVersion
+            }
+            else
+            {
+                Write-Warning (Get-VstsLocString -Key NoManifestInPreviousBuild)
+                $updateAllVersions = $true 
+            }
         }
         else
         {

--- a/Tasks/ServiceFabricUpdateAppVersions/task.json
+++ b/Tasks/ServiceFabricUpdateAppVersions/task.json
@@ -120,7 +120,7 @@
         "PreviousBuildNumberLabel": "Previous build number: '{0}'",
         "PreviousBuildLocationLabel": "Previous build location: '{0}'",
         "NoPreviousSuccessfulBuild": "Could not find previous build to compare against.",
-        "NoManifestInPreviousBuild": "Previous build does not contains application manifest. Force updating application type version.",
+        "NoManifestInPreviousBuild": "Previous build does not contains application manifest. Force updating all manifest versions.",
         "UpdatedApplicationTypeVersion": "Updated application type '{0}' to version '{1}'.",
         "UpdatedServiceVerison": "Updated service '{0}' to version '{1}'.",
         "UpdatedPackageVerison": "Updated package '{0}\\{1}' to version '{2}'.",

--- a/Tasks/ServiceFabricUpdateAppVersions/task.json
+++ b/Tasks/ServiceFabricUpdateAppVersions/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 9
+        "Patch": 10
     },
     "minimumAgentVersion": "1.95.0",
     "instanceNameFormat": "Update Service Fabric App Versions",
@@ -120,6 +120,7 @@
         "PreviousBuildNumberLabel": "Previous build number: '{0}'",
         "PreviousBuildLocationLabel": "Previous build location: '{0}'",
         "NoPreviousSuccessfulBuild": "Could not find previous build to compare against.",
+        "NoManifestInPreviousBuild": "Previous build does not contains application manifest. Force updating application type version.",
         "UpdatedApplicationTypeVersion": "Updated application type '{0}' to version '{1}'.",
         "UpdatedServiceVerison": "Updated service '{0}' to version '{1}'.",
         "UpdatedPackageVerison": "Updated package '{0}\\{1}' to version '{2}'.",

--- a/Tasks/ServiceFabricUpdateAppVersions/task.loc.json
+++ b/Tasks/ServiceFabricUpdateAppVersions/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 9
+    "Patch": 10
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -120,6 +120,7 @@
     "PreviousBuildNumberLabel": "ms-resource:loc.messages.PreviousBuildNumberLabel",
     "PreviousBuildLocationLabel": "ms-resource:loc.messages.PreviousBuildLocationLabel",
     "NoPreviousSuccessfulBuild": "ms-resource:loc.messages.NoPreviousSuccessfulBuild",
+    "NoManifestInPreviousBuild": "ms-resource:loc.messages.NoManifestInPreviousBuild",
     "UpdatedApplicationTypeVersion": "ms-resource:loc.messages.UpdatedApplicationTypeVersion",
     "UpdatedServiceVerison": "ms-resource:loc.messages.UpdatedServiceVerison",
     "UpdatedPackageVerison": "ms-resource:loc.messages.UpdatedPackageVerison",


### PR DESCRIPTION
Earlier task used to fail if older build drop did not contain application manifest file. Now, comparison will be skipped and new version will be applied. I have checked that same fix is not needed for service manifests as the check already exists. Related issue #4399 