### PR TITLE
Fixing bug where JenkinsQueueJob task waits

### DIFF
--- a/Tasks/JenkinsQueueJob/job.ts
+++ b/Tasks/JenkinsQueueJob/job.ts
@@ -167,6 +167,12 @@ export class Job {
     }
 
     setStreaming(executableNumber: number): void {
+        // If we aren't waiting for the job to finish then we should end it now
+        if (!this.queue.taskOptions.captureConsole) { // transition to Finishing
+            this.changeState(JobState.Streaming);
+            this.changeState(JobState.Finishing);
+            return;
+        }
         if (this.state == JobState.New || this.state == JobState.Locating) {
             this.executableNumber = executableNumber;
             this.executableUrl = Util.addUrlSegment(this.taskUrl, this.executableNumber.toString());

--- a/Tasks/JenkinsQueueJob/task.json
+++ b/Tasks/JenkinsQueueJob/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 119,
-        "Patch": 0
+        "Patch": 2
     },
     "groups": [
         {

--- a/Tasks/JenkinsQueueJob/task.loc.json
+++ b/Tasks/JenkinsQueueJob/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 119,
-    "Patch": 0
+    "Patch": 2
   },
   "groups": [
     {


### PR DESCRIPTION
even when the capture console checkbox is not checked
Bug #1017420