### PR TITLE
Users/pspill/no cred config on prem

### DIFF
--- a/Tasks/DotNetCoreCLI/Tests/DotnetMockHelper.ts
+++ b/Tasks/DotNetCoreCLI/Tests/DotnetMockHelper.ts
@@ -46,6 +46,11 @@ export class DotnetMockHelper {
         })
     }
 
+    public setOnPremServerUris() {
+        process.env['SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'] = "https://example.privatedomain.com/defaultcollection";
+        process.env['ENDPOINT_URL_SYSTEMVSSCONNECTION'] = "https://example.privatedomain.com/defaultcollection";
+    }
+
     private registerNugetVersionMockInternal(productVersion: string, versionInfoVersion: number[]) {
         this.registerMockWithMultiplePaths(['nuget-task-common/pe-parser/index', './pe-parser/index'], {
             getFileVersionInfoAsync: function(nuGetExePath) {

--- a/Tasks/DotNetCoreCLI/Tests/L0.ts
+++ b/Tasks/DotNetCoreCLI/Tests/L0.ts
@@ -292,7 +292,7 @@ describe('DotNetCoreExe Suite', function () {
         done();
     });
 
-    it('pushes successfully to internal feed using NuGet.exe', (done: MochaDone) => {
+    it('pushes successfully to internal hosted feed', (done: MochaDone) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, './PushTests/internalFeed.js')
@@ -306,4 +306,21 @@ describe('DotNetCoreExe Suite', function () {
         assert.equal(tr.errorIssues.length, 0, "should have no errors");
         done();
     });
+
+    it('pushes successfully to internal onprem feed, does not set auth in config', (done: MochaDone) => {
+        this.timeout(1000);
+
+        let tp = path.join(__dirname, './PushTests/internalFeedOnPrem.js')
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run()
+        assert(tr.invokedToolCount == 1, 'should have run dotnet once');
+        assert(tr.ran('c:\\path\\dotnet.exe nuget push c:\\agent\\home\\directory\\foo.nupkg --source https://vsts/packagesource --api-key VSTS'), 'it should have run dotnet');
+        assert(tr.stdOutContained('Push to internal OnPrem server detected. Credential configuration will be skipped.'), "should detect internal onprem push");
+        assert(tr.stdOutContained('dotnet output'), "should have dotnet output");
+        assert(tr.succeeded, 'should have succeeded');
+        assert.equal(tr.errorIssues.length, 0, "should have no errors");
+        done();
+    });
+
 });

--- a/Tasks/DotNetCoreCLI/Tests/PushTests/internalFeedOnPrem.ts
+++ b/Tasks/DotNetCoreCLI/Tests/PushTests/internalFeedOnPrem.ts
@@ -1,0 +1,56 @@
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+import util = require('../DotnetMockHelper');
+
+let taskPath = path.join(__dirname, '../..', 'dotnetcore.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+let nmh: util.DotnetMockHelper = new util.DotnetMockHelper(tmr);
+
+nmh.setNugetVersionInputDefault();
+nmh.setOnPremServerUris();
+tmr.setInput('command', 'push');
+tmr.setInput('searchPatternPush', 'foo.nupkg');
+tmr.setInput('nuGetFeedType', 'internal');
+tmr.setInput('feedPublish', 'FeedFooId');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "osType": {},
+    "checkPath": {
+        "c:\\agent\\home\\directory\\foo.nupkg": true,
+        "c:\\path\\dotnet.exe": true
+    },
+    "which": {
+        "dotnet": "c:\\path\\dotnet.exe"
+    },
+    "exec": {
+        "c:\\path\\dotnet.exe nuget push c:\\agent\\home\\directory\\foo.nupkg --source https://vsts/packagesource --api-key VSTS": {
+            "code": 0,
+            "stdout": "dotnet output",
+            "stderr": ""
+        }
+    },
+    "exist": {},
+    "stats": {
+        "c:\\agent\\home\\directory\\foo.nupkg": {
+            "isFile": true
+        }
+    },
+    "rmRF": {
+        "c:\\agent\\home\\directory\\NuGet_1": {
+            "success": true
+        }
+    },
+    "findMatch": {
+        "foo.nupkg" : ["c:\\agent\\home\\directory\\foo.nupkg"]
+    }
+};
+nmh.setAnswers(a);
+
+nmh.registerNugetUtilityMock(["c:\\agent\\home\\directory\\foo.nupkg"]);
+nmh.registerDefaultNugetVersionMock();
+nmh.registerToolRunnerMock();
+nmh.registerNugetConfigMock();
+nmh.RegisterLocationServiceMocks();
+
+tmr.run();

--- a/Tasks/DotNetCoreCLI/package.json
+++ b/Tasks/DotNetCoreCLI/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-tasks-dotnetcoreexe",
-  "version": "0.1.0",
+  "version": "2.0.1",
   "description": "Dotnet core exe",
   "main": "dotnetcore.js",
   "scripts": {

--- a/Tasks/DotNetCoreCLI/pushcommand.ts
+++ b/Tasks/DotNetCoreCLI/pushcommand.ts
@@ -61,11 +61,13 @@ export async function run(): Promise<void> {
 
         // Setting up auth info
         let externalAuthArr = commandHelper.GetExternalAuthInfoArray("externalEndpoint");
-        let accessToken = auth.getSystemAccessToken();
 
+        let accessToken = auth.getSystemAccessToken();
         const isInternalFeed: boolean = nugetFeedType === "internal";
         let useCredConfig = useCredentialConfiguration(isInternalFeed);
-        let authInfo = new auth.NuGetExtendedAuthInfo(new auth.InternalAuthInfo(urlPrefixes, accessToken, /*useCredProvider*/ null, /*useCredConfig*/ useCredConfig), externalAuthArr);
+        let internalAuthInfo = new auth.InternalAuthInfo(urlPrefixes, accessToken, /*useCredProvider*/ null, useCredConfig);
+
+        let authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo, externalAuthArr);
 
         let configFile = null;
         let apiKey: string;
@@ -171,7 +173,8 @@ function dotNetNuGetPushAsync(dotnetPath: string, packageFile: string, feedUri: 
 }
 
 function useCredentialConfiguration(isInternalFeed: boolean): boolean {
-    // if we are pushing to an internal on-premises server, then credential configuration is not possible -- only integrated authentication works
+    // if we are pushing to an internal on-premises server, then credential configuration is not possible
+    // and integrated authentication must be used
     let useCredConfig = !(isInternalFeed && commandHelper.isOnPremisesTfs());
     if (!useCredConfig) {
         tl.debug("Push to internal OnPrem server detected. Credential configuration will be skipped.")

--- a/Tasks/DotNetCoreCLI/task.json
+++ b/Tasks/DotNetCoreCLI/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "2.0.0",
     "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DotNetCoreCLI/task.loc.json
+++ b/Tasks/DotNetCoreCLI/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
In "dotnet nuget push", we should detect if we are pushing to an internal on prem server.  If yes, skip credential configuration -- integrated auth must be used.