### PR TITLE
Adding output vars to JenkinsQueueJob task

### DIFF
--- a/Tasks/JenkinsQueueJob/jenkinsqueuejobtask.ts
+++ b/Tasks/JenkinsQueueJob/jenkinsqueuejobtask.ts
@@ -111,6 +111,8 @@ async function doWork() {
         var rootJob = await util.pollCreateRootJob(queueUri, jobQueue, taskOptions);
         //start the job queue
         jobQueue.start();
+        //store the job name in the output variable
+        tl.setVariable("JENKINS_JOB_ID", rootJob.executableNumber.toString());
     } catch (e) {
         tl.debug(e.message);
         tl._writeError(e);

--- a/Tasks/JenkinsQueueJob/task.json
+++ b/Tasks/JenkinsQueueJob/task.json
@@ -12,9 +12,9 @@
     "author": "Microsoft",
     "demands": [],
     "version": {
-        "Major": 1,
-        "Minor": 119,
-        "Patch": 2
+        "Major": 2,
+        "Minor": 120,
+        "Patch": 0
     },
     "groups": [
         {
@@ -97,6 +97,12 @@
                 "resizable": "true",
                 "rows": "4"
             }
+        }
+    ],
+    "outputVariables" : [
+        {
+            "name" : "JENKINS_JOB_ID",
+            "description" : "The ID of the Jenkins job instance queued by this task. Use this variable in the Jenkins Download Artifacts task to download the artifacts for this particular job instance."
         }
     ],
     "execution": {

--- a/Tasks/JenkinsQueueJob/task.loc.json
+++ b/Tasks/JenkinsQueueJob/task.loc.json
@@ -12,9 +12,9 @@
   "author": "Microsoft",
   "demands": [],
   "version": {
-    "Major": 1,
-    "Minor": 119,
-    "Patch": 2
+    "Major": 2,
+    "Minor": 120,
+    "Patch": 0
   },
   "groups": [
     {
@@ -97,6 +97,12 @@
         "resizable": "true",
         "rows": "4"
       }
+    }
+  ],
+  "outputVariables": [
+    {
+      "name": "JENKINS_JOB_ID",
+      "description": "The ID of the Jenkins job instance queued by this task. Use this variable in the Jenkins Download Artifacts task to download the artifacts for this particular job instance."
     }
   ],
   "execution": {


### PR DESCRIPTION
- Since output vars require a new version of the agent, I bumped the major version of the task to 2 (this allows the user to choose when to upgrade)
- This is part of internal user story #982063
