### PR TITLE
Override project .npmrc when install from a local feed

### DIFF
--- a/Tasks/Npm/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Npm/Strings/resources.resjson/en-US/resources.resjson
@@ -43,5 +43,7 @@
   "loc.messages.DebugLogNotFound": "Couldn't find a debug log in the cache or working directory",
   "loc.messages.NpmFailed": "Npm failed with return code: %s",
   "loc.messages.FoundNpmDebugLog": "Found npm debug log, make sure the path matches with the one in npm's output: %s",
-  "loc.messages.TestDebugLog": "Trying debug log location: %s"
+  "loc.messages.TestDebugLog": "Trying debug log location: %s",
+  "loc.messages.OverridingProjectNpmrc": "Overriding project .npmrc: %s",
+  "loc.messages.RestoringProjectNpmrc": "Restoring project .npmrc"
 }

--- a/Tasks/Npm/Tests/L0.ts
+++ b/Tasks/Npm/Tests/L0.ts
@@ -127,6 +127,8 @@ describe('Npm Task', function () {
 
         assert.equal(tr.invokedToolCount, 2, 'task should have run npm');
         assert(tr.stdOutContained('npm install successful'), 'npm should have installed the package');
+        assert(tr.stdOutContained('OverridingProjectNpmrc'), 'install from feed shoud override project .npmrc');
+        assert(tr.stdOutContained('RestoringProjectNpmrc'), 'install from .npmrc shoud restore project .npmrc');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();
@@ -141,6 +143,8 @@ describe('Npm Task', function () {
 
         assert.equal(tr.invokedToolCount, 2, 'task should have run npm');
         assert(tr.stdOutContained('npm install successful'), 'npm should have installed the package');
+        assert(!tr.stdOutContained('OverridingProjectNpmrc'), 'install from .npmrc shoud not override project .npmrc');
+        assert(!tr.stdOutContained('RestoringProjectNpmrc'), 'install from .npmrc shoud not restore project .npmrc');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();
@@ -171,6 +175,8 @@ describe('Npm Task', function () {
 
         assert.equal(tr.invokedToolCount, 2, 'task should have run npm');
         assert(tr.stdOutContained('npm publish successful'), 'npm should have installed the package');
+        assert(tr.stdOutContained('OverridingProjectNpmrc'), 'publish should always ooverrideverride project .npmrc');
+        assert(tr.stdOutContained('RestoringProjectNpmrc'), 'publish should always restore project .npmrc');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();

--- a/Tasks/Npm/Tests/install-feed.ts
+++ b/Tasks/Npm/Tests/install-feed.ts
@@ -17,6 +17,7 @@ tmr.mockNpmCommand('install', {
     code: 0,
     stdout: 'npm install successful'
 } as TaskLibAnswerExecResult);
+tmr.answers.rmRF[path.join(process.cwd(), '.npmrc')] = { success: true };
 tmr.RegisterLocationServiceMocks();
 
 tmr.run();

--- a/Tasks/Npm/Tests/publish-external.ts
+++ b/Tasks/Npm/Tests/publish-external.ts
@@ -24,7 +24,7 @@ tmr.mockNpmCommand('publish', {
     code: 0,
     stdout: 'npm publish successful'
 } as TaskLibAnswerExecResult);
-tmr.answers.rmRF['workingDir\\.npmrc'] = { success: true };
+tmr.answers.rmRF[path.join('workingDir', '.npmrc')] = { success: true };
 tmr.RegisterLocationServiceMocks();
 
 tmr.run();

--- a/Tasks/Npm/Tests/publish-feed.ts
+++ b/Tasks/Npm/Tests/publish-feed.ts
@@ -17,7 +17,7 @@ tmr.mockNpmCommand('publish', {
     code: 0,
     stdout: 'npm publish successful'
 } as TaskLibAnswerExecResult);
-tmr.answers.rmRF['workingDir\\.npmrc'] = { success: true };
+tmr.answers.rmRF[path.join('workingDir', '.npmrc')] = { success: true };
 tmr.RegisterLocationServiceMocks();
 
 tmr.run();

--- a/Tasks/Npm/npmcustom.ts
+++ b/Tasks/Npm/npmcustom.ts
@@ -11,11 +11,13 @@ export async function run(command?: string): Promise<void> {
     let workingDir = tl.getInput(NpmTaskInput.WorkingDir) || process.cwd();
     let npmrc = util.getTempNpmrcPath();
     let npmRegistries: INpmRegistry[] = await util.getLocalNpmRegistries(workingDir);
+    let overrideNpmrc = false;
 
     let registryLocation = tl.getInput(NpmTaskInput.CustomRegistry);
     switch (registryLocation) {
         case RegistryLocation.Feed:
             tl.debug(tl.loc('UseFeed'));
+            overrideNpmrc = true;
             let feedId = tl.getInput(NpmTaskInput.CustomFeed, true);
             npmRegistries.push(await NpmRegistry.FromFeedId(feedId));
             break;
@@ -39,7 +41,7 @@ export async function run(command?: string): Promise<void> {
         util.appendToNpmrc(npmrc, `${registry.auth}\n`);
     }
 
-    let npm = new NpmToolRunner(workingDir, npmrc);
+    let npm = new NpmToolRunner(workingDir, npmrc, overrideNpmrc);
     npm.line(command || tl.getInput(NpmTaskInput.CustomCommand, true));
 
     await npm.exec();

--- a/Tasks/Npm/npmpublish.ts
+++ b/Tasks/Npm/npmpublish.ts
@@ -28,16 +28,11 @@ export async function run(command?: string): Promise<void> {
     util.appendToNpmrc(npmrc, `registry=${npmRegistry.url}\n`);
     util.appendToNpmrc(npmrc, `${npmRegistry.auth}\n`);
 
-    let npm = new NpmToolRunner(workingDir, npmrc);
+    // For publish, always override their project .npmrc
+    let npm = new NpmToolRunner(workingDir, npmrc, true);
     npm.line('publish');
 
-    // We delete their project .npmrc so it won't override our user .npmrc
-    const projectNpmrc = `${workingDir}\\.npmrc`;
-    util.saveFile(projectNpmrc);
-    tl.rmRF(projectNpmrc);
-
     await npm.exec();
-    util.restoreFile(projectNpmrc);
 
     tl.rmRF(npmrc);
     tl.rmRF(util.getTempPath());

--- a/Tasks/Npm/package.json
+++ b/Tasks/Npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-npm-task",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "VSTS NPM Task",
   "main": "npmtask.js",
   "scripts": {

--- a/Tasks/Npm/task.json
+++ b/Tasks/Npm/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 2
+        "Patch": 3
     },
     "runsOn": [
         "Agent",
@@ -167,6 +167,8 @@
         "DebugLogNotFound": "Couldn't find a debug log in the cache or working directory",
         "NpmFailed": "Npm failed with return code: %s",
         "FoundNpmDebugLog": "Found npm debug log, make sure the path matches with the one in npm's output: %s",
-        "TestDebugLog": "Trying debug log location: %s"
+        "TestDebugLog": "Trying debug log location: %s",
+        "OverridingProjectNpmrc": "Overriding project .npmrc: %s",
+        "RestoringProjectNpmrc": "Restoring project .npmrc"
     }
 }

--- a/Tasks/Npm/task.loc.json
+++ b/Tasks/Npm/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 2
+    "Patch": 3
   },
   "runsOn": [
     "Agent",
@@ -167,6 +167,8 @@
     "DebugLogNotFound": "ms-resource:loc.messages.DebugLogNotFound",
     "NpmFailed": "ms-resource:loc.messages.NpmFailed",
     "FoundNpmDebugLog": "ms-resource:loc.messages.FoundNpmDebugLog",
-    "TestDebugLog": "ms-resource:loc.messages.TestDebugLog"
+    "TestDebugLog": "ms-resource:loc.messages.TestDebugLog",
+    "OverridingProjectNpmrc": "ms-resource:loc.messages.OverridingProjectNpmrc",
+    "RestoringProjectNpmrc": "ms-resource:loc.messages.RestoringProjectNpmrc"
   }
 }


### PR DESCRIPTION
Whenever we want to install from a specific feed in a VSTS account, override the project's .npmrc if there's one.