### PR TITLE
Changes to support vstest console in DTA flow for vstest v2 task

### DIFF
--- a/Tasks/VsTest/distributedtest.ts
+++ b/Tasks/VsTest/distributedtest.ts
@@ -66,6 +66,7 @@ export class DistributedTest {
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.LocalTestDropPath', this.dtaTestConfig.testDropLocation);
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.EnableConsoleLogs', 'true');
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.UseVsTestConsole', this.dtaTestConfig.useVsTestConsole);
+        utils.Helper.addToProcessEnvVars(envVars, 'DTA.TestPlatformVersion', this.dtaTestConfig.vsTestVersion);
         if (this.dtaTestConfig.pathtoCustomTestAdapters) {
             const testAdapters = tl.findMatch(this.dtaTestConfig.pathtoCustomTestAdapters, '**\\*TestAdapter.dll');
             if (!testAdapters || (testAdapters && testAdapters.length === 0)) {

--- a/Tasks/VsTest/distributedtest.ts
+++ b/Tasks/VsTest/distributedtest.ts
@@ -65,6 +65,7 @@ export class DistributedTest {
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.MiniMatchSourceFilter', 'true');
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.LocalTestDropPath', this.dtaTestConfig.testDropLocation);
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.EnableConsoleLogs', 'true');
+        utils.Helper.addToProcessEnvVars(envVars, 'DTA.UseVsTestConsole', this.dtaTestConfig.useVsTestConsole);
         if (this.dtaTestConfig.pathtoCustomTestAdapters) {
             const testAdapters = tl.findMatch(this.dtaTestConfig.pathtoCustomTestAdapters, '**\\*TestAdapter.dll');
             if (!testAdapters || (testAdapters && testAdapters.length === 0)) {

--- a/Tasks/VsTest/models.ts
+++ b/Tasks/VsTest/models.ts
@@ -41,6 +41,7 @@ export interface DtaTestConfigurations extends TestConfigurations {
     customSlicingenabled: boolean;
     dtaEnvironment: DtaEnvironment;
     numberOfAgentsInPhase: number;
+    useVsTestConsole: string;
 }
 
 export interface DtaEnvironment {

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 60
+        "Patch": 61
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 60
+    "Patch": 61
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/taskinputparser.ts
+++ b/Tasks/VsTest/taskinputparser.ts
@@ -11,6 +11,7 @@ const uuid = require('node-uuid');
 export function getDistributedTestConfigurations() {
     const dtaConfiguration = {} as models.DtaTestConfigurations;
     initTestConfigurations(dtaConfiguration);
+    dtaConfiguration.useVsTestConsole = 'true';
 
     if (dtaConfiguration.vsTestLocationMethod === utils.Constants.vsTestVersionString && dtaConfiguration.vsTestVersion === '12.0') {
         throw (tl.loc('vs2013NotSupportedInDta'));
@@ -33,13 +34,10 @@ export function getDistributedTestConfigurations() {
     }
     tl._writeLine(tl.loc('dtaNumberOfAgents', dtaConfiguration.numberOfAgentsInPhase));
 
-    let useVsTestConsole = tl.getVariable('UseVsTestConsole');
+    const useVsTestConsole = tl.getVariable('UseVsTestConsole');
     if (useVsTestConsole) {
         dtaConfiguration.useVsTestConsole = useVsTestConsole;
-    }
-    else {
-        dtaConfiguration.useVsTestConsole = 'true';
-    }
+    }    
 
     dtaConfiguration.dtaEnvironment = initDtaEnvironment();
     return dtaConfiguration;

--- a/Tasks/VsTest/taskinputparser.ts
+++ b/Tasks/VsTest/taskinputparser.ts
@@ -33,6 +33,14 @@ export function getDistributedTestConfigurations() {
     }
     tl._writeLine(tl.loc('dtaNumberOfAgents', dtaConfiguration.numberOfAgentsInPhase));
 
+    let useVsTestConsole = tl.getVariable('UseVsTestConsole');
+    if (useVsTestConsole) {
+        dtaConfiguration.useVsTestConsole = useVsTestConsole;
+    }
+    else {
+        dtaConfiguration.useVsTestConsole = 'true';
+    }
+
     dtaConfiguration.dtaEnvironment = initDtaEnvironment();
     return dtaConfiguration;
 }

--- a/Tasks/VsTest/versionfinder.ts
+++ b/Tasks/VsTest/versionfinder.ts
@@ -78,12 +78,14 @@ function locateTestWindow(testConfig: models.TestConfigurations): string {
         tl.debug('Searching for latest Visual Studio');
         const vstestconsole15Path = getVSTestConsole15Path();
         if (vstestconsole15Path) {
+            testConfig.vsTestVersion = "15.0";
             return vstestconsole15Path;
         }
 
         // fallback
         tl.debug('Unable to find an instance of Visual Studio 2017..');
         tl.debug('Searching for Visual Studio 2015..');
+        testConfig.vsTestVersion = "14.0";
         return getVSTestLocation(14);
     }
 


### PR DESCRIPTION
Description: VsTestV2 task in multi agent mode depends on test platform for test discovery , execution and publishing. This change set enables using vstest console for the same.

Testing: Manual

MsengPR: https://mseng.visualstudio.com/VSOnline/Automated%20Testing/_git/VSO/pullrequest/225693?path=%2FTa%2FAgent%2FVS.TestService.AgentExecutionHost%2FExecutionHostConfiguration.cs&discussionId=2190379&_a=overview