### PR TITLE
Add Portable PDB check to short circuit Source Indexing

### DIFF
--- a/Tasks/PublishSymbols/IndexHelpers/IndexFunctions.ps1
+++ b/Tasks/PublishSymbols/IndexHelpers/IndexFunctions.ps1
@@ -51,6 +51,13 @@ function Invoke-IndexSources {
                 #    continue
                 #}
 
+                $bytes = Get-Content $symbolsFilePath -Encoding byte -TotalCount 4
+                $data = [System.Text.Encoding]::ASCII.GetString($bytes)
+                if ($data.equals("BSJB")) {
+                    Write-Verbose "Skipping: $symbolsFilePath because it is a Portable PDB"
+                    continue
+                }
+
                 # Get the source file paths embedded in the symbols file.
                 [string[]]$sourceFilePaths = Get-SourceFilePaths -SymbolsFilePath $symbolsFilePath -SourcesRootPath $provider.SourcesRootPath -TreatNotIndexedAsWarning:$TreatNotIndexedAsWarning
                 if (!$sourceFilePaths.Count) {


### PR DESCRIPTION
Fixes #4567.

I've tried this locally outside of the VSTS ecosystem and it works, but I'm not sure how to bootstrap this inside the VSTS ecosystem.

So I feel like someone from the team will have to try this out on their setups before really merging this.