### PR TITLE
bump ps3 lib [REFERENCE ONLY - DO NOT MERGE]

### DIFF
--- a/Tasks/AzureCloudPowerShellDeployment/make.json
+++ b/Tasks/AzureCloudPowerShellDeployment/make.json
@@ -9,11 +9,12 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",

--- a/Tasks/AzureFileCopy/make.json
+++ b/Tasks/AzureFileCopy/make.json
@@ -27,11 +27,12 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",

--- a/Tasks/AzurePowerShell/make.json
+++ b/Tasks/AzurePowerShell/make.json
@@ -9,11 +9,12 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.8.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",

--- a/Tasks/DeployVisualStudioTestAgent/make.json
+++ b/Tasks/DeployVisualStudioTestAgent/make.json
@@ -15,11 +15,12 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",

--- a/Tasks/IISWebAppManagementOnMachineGroup/make.json
+++ b/Tasks/IISWebAppManagementOnMachineGroup/make.json
@@ -14,11 +14,12 @@
             },
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",

--- a/Tasks/PublishSymbols/make.json
+++ b/Tasks/PublishSymbols/make.json
@@ -60,11 +60,12 @@
             },
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",

--- a/Tasks/ServiceFabricComposeDeploy/make.json
+++ b/Tasks/ServiceFabricComposeDeploy/make.json
@@ -9,11 +9,12 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",

--- a/Tasks/ServiceFabricDeploy/make.json
+++ b/Tasks/ServiceFabricDeploy/make.json
@@ -13,11 +13,12 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",

--- a/Tasks/ServiceFabricPowerShell/make.json
+++ b/Tasks/ServiceFabricPowerShell/make.json
@@ -9,11 +9,12 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",

--- a/Tasks/ServiceFabricPowerShell/task.loc.json
+++ b/Tasks/ServiceFabricPowerShell/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "Cmd"

--- a/Tasks/ServiceFabricUpdateAppVersions/make.json
+++ b/Tasks/ServiceFabricUpdateAppVersions/make.json
@@ -3,11 +3,12 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",

--- a/Tasks/SqlAzureDacpacDeployment/make.json
+++ b/Tasks/SqlAzureDacpacDeployment/make.json
@@ -9,11 +9,12 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",

--- a/Tasks/SqlDacpacDeploymentOnMachineGroup/make.json
+++ b/Tasks/SqlDacpacDeploymentOnMachineGroup/make.json
@@ -14,11 +14,12 @@
             },
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",

--- a/Tasks/XamarinAndroid/make.json
+++ b/Tasks/XamarinAndroid/make.json
@@ -22,11 +22,12 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {
                         "source": [
+                            "*.dll",
                             "*.ps1",
                             "*.psd1",
                             "*.psm1",


### PR DESCRIPTION
This fixes a current limitation on the size of the environment block. The fix is in the task lib, so each tasks needs to consume the new lib to get the fix.

My intention for this PR is to create a go-by only. I would prefer if each task owner updates their task.

Most of the tasks are on 0.7.1 and the fix is in 0.8.2. There are no breaking changes between those versions so I don't expect any problems ([release notes here](https://github.com/Microsoft/vsts-task-lib/blob/master/powershell/Docs/ReleaseNotes.md)).

Also, I worked with one customer to verify the fix in their release. They are using the task SqlAzureDacpacDeployment.