### PR TITLE
bug fixes for windows7 support on DTA V2.

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/InstallTestAgent.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/InstallTestAgent.ps1
@@ -26,11 +26,10 @@ function InstallTestAgent2017 {
 
     # First we need to install the certificates for TA 2017
     $SetupDir = Split-Path -Path $SetupPath    
-
-    $osVersion = [environment]::OSVersion.Version
     $certFiles = Get-ChildItem -Path "$SetupDir\certificates\*.p12" -ErrorAction SilentlyContinue
     if($certFiles -and $certFiles.Length -gt 0)
     {
+        $osVersion = [environment]::OSVersion.Version
         Write-Verbose "Installing test agent certificates" -Verbose
         if ($osVersion.Major -eq "6" -and $osVersion.Minor -eq "1") {
             ## Windows 7 SP1. Import-PfxCertificate is not present in windows 7

--- a/Tasks/DeployVisualStudioTestAgent/README.md
+++ b/Tasks/DeployVisualStudioTestAgent/README.md
@@ -6,7 +6,7 @@ To learn more about the general usage of the task, please see https://msdn.micro
 
 ### Prerequisites
 The task requires:
-- .NET 4.6.1 on Windows8 or Windows 2K8R2
+- .NET 4.6.1 on Windows7 or Windows 2K8R2
 - Test machines should have PSRemoting enabled (run 'Enable-PSRemoting' on Windows Powershell)
 ### WinRM setup
 This task uses the [Windows Remote Management](https://msdn.microsoft.com/en-us/library/aa384426.aspx) (WinRM) to access domain-joined or workgroup, on-premises physical or virtual machines.

--- a/Tasks/DeployVisualStudioTestAgent/README.md
+++ b/Tasks/DeployVisualStudioTestAgent/README.md
@@ -7,6 +7,7 @@ To learn more about the general usage of the task, please see https://msdn.micro
 ### Prerequisites
 The task requires:
 - .NET 4.6.1 on Windows7 or Windows 2K8R2
+- PowerShell 3 or newer
 - Test machines should have PSRemoting enabled (run 'Enable-PSRemoting' on Windows Powershell)
 ### WinRM setup
 This task uses the [Windows Remote Management](https://msdn.microsoft.com/en-us/library/aa384426.aspx) (WinRM) to access domain-joined or workgroup, on-premises physical or virtual machines.

--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -171,14 +171,16 @@
 
                 $rootFolder = $ScheduleObject.GetFolder('\') #'
                 $newTask = $rootFolder.RegisterTaskDefinition("DTA", $TaskDefinition, 6, '', '', 3)
-                Write-Verbose "Starting scheduled task" -Verbose
-                $rootFolder.DeleteTask("DTA", 0)
+                Write-Verbose "Starting scheduled task on Windows 7." -Verbose
+
+		        Start-Sleep -Seconds 30
+                $p = Get-Process -Name "DTAExecutionHost"
+                $rootFolder.DeleteTask("DTA", 0)                
             }
             else {
                 # Windows 8 or above
                 $action = New-ScheduledTaskAction -Execute "$SetupPath\DTAExecutionHost.exe" -Argument $dtaArgs
                 $trigger = New-ScheduledTaskTrigger -AtLogOn
-                $exePath = "$SetupPath\DTAExecutionHost.exe $dtaArgs"
 
                 Unregister-ScheduledTask -TaskName "DTA" -Confirm:$false -OutVariable out -ErrorVariable err -ErrorAction SilentlyContinue | Out-Null
                 Register-ScheduledTask -Action $action -Trigger $trigger -TaskName "DTA" -Description "DTA UI" -RunLevel Highest -OutVariable out -ErrorVariable err | Out-Null
@@ -186,12 +188,12 @@
                 
                 Start-ScheduledTask -TaskName "DTA" -OutVariable out -ErrorVariable err | Out-Null
                 Write-Verbose "Starting scheduled task output: $out error: $err" -Verbose
+
+		        Start-Sleep -Seconds 30
+		        $p = Get-Process -Name "DTAExecutionHost"
                 Unregister-ScheduledTask  -TaskName "DTA" -Confirm:$false -ErrorAction SilentlyContinue
             }
-            
-            Start-Sleep -Seconds 10
 
-            $p = Get-Process -Name "DTAExecutionHost" -ErrorAction SilentlyContinue
             if ($p) {
                 return 0
             }

--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -172,8 +172,7 @@
                 $rootFolder = $ScheduleObject.GetFolder('\') #'
                 $newTask = $rootFolder.RegisterTaskDefinition("DTA", $TaskDefinition, 6, '', '', 3)
                 Write-Verbose "Starting scheduled task on Windows 7." -Verbose
-
-		        Start-Sleep -Seconds 30
+                Start-Sleep -Seconds 30
                 $p = Get-Process -Name "DTAExecutionHost"
                 $rootFolder.DeleteTask("DTA", 0)                
             }

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 10
+        "Patch": 11
     },
     "runsOn": [
         "Agent"

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 10
+    "Patch": 11
   },
   "runsOn": [
     "Agent"


### PR DESCRIPTION
Win7 related bugs:
1. Cert install
2. Launch of DTAExecutionHost.exe
Updated the ReadMe.md as well.

Running manual and automated tests in parallel.