### PR TITLE
Add support for --device and --privileged flags.

### DIFF
--- a/Tasks/Docker/containerrun.ts
+++ b/Tasks/Docker/containerrun.ts
@@ -13,6 +13,11 @@ export function run(connection: ContainerConnection): any {
         command.arg("-d");
     }
 
+    var privileged = tl.getBoolInput("privileged");
+    if (privileged) {
+        command.arg("--privileged");
+    }
+
     var entrypoint = tl.getInput("entrypoint");
     if (entrypoint) {
         command.arg(["--entrypoint", entrypoint]);
@@ -57,6 +62,10 @@ export function run(connection: ContainerConnection): any {
 
     tl.getDelimitedInput("volumes", "\n").forEach(volume => {
         command.arg(["-v", volume]);
+    });
+
+    tl.getDelimitedInput("devices", "\n").forEach(device => {
+        command.arg(["--device", device]);
     });
 
     var workDir = tl.getInput("workDir");

--- a/Tasks/Docker/task.json
+++ b/Tasks/Docker/task.json
@@ -197,7 +197,8 @@
             },
             "label": "Devices",
             "visibleRule": "action = Run an image",
-            "helpMarkDown": "Devices to map from the host. Specify each device-file:device-file on a new line."
+            "helpMarkDown": "Devices to map from the host. Specify each device-file:device-file on a new line.",
+            "groupName": "advanced"
         },
         {
             "name": "envVars",
@@ -245,7 +246,8 @@
             "label": "Privileged",
             "defaultValue": "false",
             "visibleRule": "action = Run an image",
-            "helpMarkDown": "Give the container privileges on the host."
+            "helpMarkDown": "Give the container privileges on the host.",
+            "groupName": "advanced"
         },
         {
             "name": "restartPolicy",

--- a/Tasks/Docker/task.json
+++ b/Tasks/Docker/task.json
@@ -243,7 +243,7 @@
             "name": "privileged",
             "type": "boolean",
             "label": "Privileged",
-            "defaultValue": "true",
+            "defaultValue": "false",
             "visibleRule": "action = Run an image",
             "helpMarkDown": "Give the container privileges on the host."
         },

--- a/Tasks/Docker/task.json
+++ b/Tasks/Docker/task.json
@@ -189,6 +189,17 @@
             "helpMarkDown": "Volumes to mount from the host. Specify each host-dir:container-dir on a new line."
         },
         {
+            "name": "devices",
+            "type": "multiLine",
+            "properties": {
+                "resizable": "true",
+                "rows": "2"
+            },
+            "label": "Devices",
+            "visibleRule": "action = Run an image",
+            "helpMarkDown": "Devices to map from the host. Specify each device-file:device-file on a new line."
+        },
+        {
             "name": "envVars",
             "type": "multiLine",
             "properties": {
@@ -227,6 +238,14 @@
             "defaultValue": "true",
             "visibleRule": "action = Run an image",
             "helpMarkDown": "Run the Docker container in the background."
+        },
+        {
+            "name": "privileged",
+            "type": "boolean",
+            "label": "Privileged",
+            "defaultValue": "true",
+            "visibleRule": "action = Run an image",
+            "helpMarkDown": "Give the container privileges on the host."
         },
         {
             "name": "restartPolicy",


### PR DESCRIPTION
I'm using Docker to deploy code to a Raspberry Pi device. In my scenario I need the container to be able to access attached peripherals on the Docker host, in my case ```/dev/i2c-1``` and ```/dev/video0```. Docker supports this already via the ```--device``` flag when launching a container - so I've added it into the task definition and the containerrun.ts module. Whilst I was at it I also added support for the ```--privileged``` flag.