### PR TITLE
Remove DotNetCoreCLI from M120 release train

### DIFF
--- a/make-options.json
+++ b/make-options.json
@@ -28,7 +28,6 @@
         "DeployVisualStudioTestAgent",
         "Docker",
         "DockerCompose",
-        "DotNetCoreCLI",
         "DownloadBuildArtifact",
         "ExtractFiles",
         "FtpUpload",


### PR DESCRIPTION
Remove the DotNetCoreCLI task from the M120 release train as version 2.x is not ready yet.