### PR TITLE
Improve grammar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Tasks are simply tool runners.  They know how to run MSBuild, VSTest, etc... in 
 
 For uploading custom tasks to VSTS use the [TFS Cross Platform Command Line utility](https://github.com/Microsoft/tfs-cli).
 
-Tasks can also be deployed with an Visual Studio Team Service Extension. See [this tutorial](https://www.visualstudio.com/en-us/docs/integrate/extensions/develop/add-build-task) how to package tasks inside an extension.
+Tasks can also be deployed with a Visual Studio Team Service Extension. See [this tutorial](https://www.visualstudio.com/en-us/docs/integrate/extensions/develop/add-build-task) how to package tasks inside an extension.
 
 ## Contributing
 We take contributions.  [Read here](docs/contribute.md) how to contribute.

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 ![Tasks](/taskbanner.png "Tasks")
 
 ## Overview
-This repo contains the tasks that are provided out of the box with Visual Studio Team Services and Team Foundation Server.
+This repo contains the tasks that are provided out-of-the-box with Visual Studio Team Services and Team Foundation Server.
 
-This provides open examples on how we write tasks which will help you write other tasks which can be uploaded to your account or server.  See writing tasks below.
+This provides open examples on how we write tasks which will help you write other tasks which can be uploaded to your account or server.  See **Writing Tasks** below.
 
 ## Status
 |   | Build & Test |
 |---|:-----:|
-|![Win](docs/res/win_med.png) **Windows**|![Build & Test](https://mseng.visualstudio.com/_apis/public/build/definitions/b924d696-3eae-4116-8443-9a18392d8544/1474/badge?branch=master)| 
-|![OSX](docs/res/apple_med.png) **OSX**|![Build & Test](https://mseng.visualstudio.com/_apis/public/build/definitions/b924d696-3eae-4116-8443-9a18392d8544/4213/badge?branch=master)| 
+|![macOS](docs/res/apple_med.png) **macOS**|![Build & Test](https://mseng.visualstudio.com/_apis/public/build/definitions/b924d696-3eae-4116-8443-9a18392d8544/4213/badge?branch=master)| 
 |![Ubuntu14](docs/res/ubuntu_med.png) **Ubuntu 14.04**|![Build & Test](https://mseng.visualstudio.com/_apis/public/build/definitions/b924d696-3eae-4116-8443-9a18392d8544/4088/badge?branch=master)|
+|![Win](docs/res/win_med.png) **Windows**|![Build & Test](https://mseng.visualstudio.com/_apis/public/build/definitions/b924d696-3eae-4116-8443-9a18392d8544/1474/badge?branch=master)|
 
 ## How to Use Tasks
 
-[Documentation is here](https://aka.ms/tfbuild)
+See the documentation for [Continuous integration and deployment](https://aka.ms/tfbuild).
 
 ## Writing Tasks
 
@@ -25,7 +25,7 @@ Tasks are simply tool runners.  They know how to run MSBuild, VSTest, etc... in 
 
 For uploading custom tasks to VSTS use the [TFS Cross Platform Command Line utility](https://github.com/Microsoft/tfs-cli).
 
-Tasks can also be deployed with a Visual Studio Team Service Extension. See [this tutorial](https://www.visualstudio.com/en-us/docs/integrate/extensions/develop/add-build-task) how to package tasks inside an extension.
+Tasks can also be deployed with a Visual Studio Team Services extension. See [this tutorial](https://www.visualstudio.com/en-us/docs/integrate/extensions/develop/add-build-task) for how to package tasks inside an extension.
 
 ## Contributing
 We take contributions.  [Read here](docs/contribute.md) how to contribute.


### PR DESCRIPTION
Use an before a word that starts with a vowel sound. If it does not start with a vowel sound, use a.