### PR TITLE
add mavenOption when executing help:effective-pom

### DIFF
--- a/Tasks/Maven/maventask.ts
+++ b/Tasks/Maven/maventask.ts
@@ -151,6 +151,9 @@ async function execBuild() {
             mvnRun.arg('-f');
             mvnRun.arg(mavenPOMFile);
             mvnRun.arg('help:effective-pom');
+            if(mavenOptions) {
+                mvnRun.line(mavenOptions);   
+            }
             return util.collectFeedRepositoriesFromEffectivePom(mvnRun.execSync()['stdout'])
             .then(function (repositories) {
                 if (!repositories || !repositories.length) {


### PR DESCRIPTION
When executing help:effective-pom, if pom files has some maven Options it fails because VSTS Task isn't add the new line with Maven options.