### PR TITLE
Fix for secret contains '$'

### DIFF
--- a/Tasks/AzureKeyVault/operations/KeyVault.ts
+++ b/Tasks/AzureKeyVault/operations/KeyVault.ts
@@ -141,7 +141,7 @@ export class KeyVault {
                     secretsToErrorsMap.addError(secretName, errorMessage);
                 }
                 else {
-                    console.log("##vso[task.setvariable variable=" + secretName + ";issecret=true;]" + secretValue);
+                    console.log("##vso[task.setvariable variable=" + secretName + ";issecret=true;]'" + secretValue + "'");
                 }
                 
                 return resolve();


### PR DESCRIPTION
When secret contains '$', the set variable command will try to get the variable value