### PR TITLE
VsTest task hotfix for vstest console changes

### DIFF
--- a/Tasks/VsTest/distributedtest.ts
+++ b/Tasks/VsTest/distributedtest.ts
@@ -65,6 +65,8 @@ export class DistributedTest {
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.MiniMatchSourceFilter', 'true');
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.LocalTestDropPath', this.dtaTestConfig.testDropLocation);
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.EnableConsoleLogs', 'true');
+        utils.Helper.addToProcessEnvVars(envVars, 'DTA.UseVsTestConsole', this.dtaTestConfig.useVsTestConsole);
+        utils.Helper.addToProcessEnvVars(envVars, 'DTA.TestPlatformVersion', this.dtaTestConfig.vsTestVersion);
         if (this.dtaTestConfig.pathtoCustomTestAdapters) {
             const testAdapters = tl.findMatch(this.dtaTestConfig.pathtoCustomTestAdapters, '**\\*TestAdapter.dll');
             if (!testAdapters || (testAdapters && testAdapters.length === 0)) {

--- a/Tasks/VsTest/models.ts
+++ b/Tasks/VsTest/models.ts
@@ -41,6 +41,7 @@ export interface DtaTestConfigurations extends TestConfigurations {
     customSlicingenabled: boolean;
     dtaEnvironment: DtaEnvironment;
     numberOfAgentsInPhase: number;
+    useVsTestConsole: string;
 }
 
 export interface DtaEnvironment {

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 61
+        "Patch": 62
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 61
+    "Patch": 62
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/taskinputparser.ts
+++ b/Tasks/VsTest/taskinputparser.ts
@@ -11,6 +11,7 @@ const uuid = require('node-uuid');
 export function getDistributedTestConfigurations() {
     const dtaConfiguration = {} as models.DtaTestConfigurations;
     initTestConfigurations(dtaConfiguration);
+    dtaConfiguration.useVsTestConsole = 'true';
 
     if (dtaConfiguration.vsTestLocationMethod === utils.Constants.vsTestVersionString && dtaConfiguration.vsTestVersion === '12.0') {
         throw (tl.loc('vs2013NotSupportedInDta'));
@@ -33,6 +34,11 @@ export function getDistributedTestConfigurations() {
     }
     tl._writeLine(tl.loc('dtaNumberOfAgents', dtaConfiguration.numberOfAgentsInPhase));
 
+    const useVsTestConsole = tl.getVariable('UseVsTestConsole');
+    if (useVsTestConsole) {
+        dtaConfiguration.useVsTestConsole = useVsTestConsole;
+    }  
+    
     dtaConfiguration.dtaEnvironment = initDtaEnvironment();
     return dtaConfiguration;
 }

--- a/Tasks/VsTest/taskinputparser.ts
+++ b/Tasks/VsTest/taskinputparser.ts
@@ -11,7 +11,7 @@ const uuid = require('node-uuid');
 export function getDistributedTestConfigurations() {
     const dtaConfiguration = {} as models.DtaTestConfigurations;
     initTestConfigurations(dtaConfiguration);
-    dtaConfiguration.useVsTestConsole = 'true';
+    dtaConfiguration.useVsTestConsole = 'false';
 
     if (dtaConfiguration.vsTestLocationMethod === utils.Constants.vsTestVersionString && dtaConfiguration.vsTestVersion === '12.0') {
         throw (tl.loc('vs2013NotSupportedInDta'));

--- a/Tasks/VsTest/versionfinder.ts
+++ b/Tasks/VsTest/versionfinder.ts
@@ -78,12 +78,14 @@ function locateTestWindow(testConfig: models.TestConfigurations): string {
         tl.debug('Searching for latest Visual Studio');
         const vstestconsole15Path = getVSTestConsole15Path();
         if (vstestconsole15Path) {
+            testConfig.vsTestVersion = "15.0";
             return vstestconsole15Path;
         }
 
         // fallback
         tl.debug('Unable to find an instance of Visual Studio 2017..');
         tl.debug('Searching for Visual Studio 2015..');
+        testConfig.vsTestVersion = "14.0";
         return getVSTestLocation(14);
     }
 


### PR DESCRIPTION
Description: VsTest V2 task was modified to run with the new flow starting with m120 deployment. The task side changes were not ported to m120 which have caused users with Old version of VS (dev14) to hit issues.

Fix: Ported the changes to m120 branch now with default flow as the old route of running via test platform.