### PR TITLE
Use Path::GetTempFileName() instead of creating random filename

### DIFF
--- a/Tasks/PublishSymbols/PublishSymbols.ps1
+++ b/Tasks/PublishSymbols/PublishSymbols.ps1
@@ -121,7 +121,7 @@ try {
             throw "Unable to generate Personal Access Token for the user. Contact Project Collection Administrator"
         }
 
-        [string]$tmpFileName = Join-Path $env:TEMP ("SymbolFileList-" + [random]::new().Next(100) + ".txt")
+        [string]$tmpFileName = [IO.Path]::GetTempFileName()
         [string]$SourcePath = Resolve-Path -LiteralPath $SymbolsFolder
         
         [IO.File]::WriteAllLines($tmpFileName, [string[]]@("# FileList under $SymbolsFolder with pattern $SearchPattern", "")) # Also Truncates any existing files


### PR DESCRIPTION
The [random]::new() is not supported and causing failure in PS4 (like in Windows Server 2012)