### PR TITLE
Fix regex for parsing apple cert common name field

### DIFF
--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -442,10 +442,10 @@ export async function getP12CommonName(p12Path: string, p12Pwd: string) {
         if (data) {
             // find the subject
             data = data.toString().trim();
-            let subject: string[] = data.match(/subject=.+\/CN=.+\(.+\).+/g);
+            let subject: string[] = data.match(/subject=.+\/CN=.+\(?.+\)?.+/g);
             if (subject && subject[0]) {
                 // find the CN from the subject
-                let cn: string[] = subject[0].trim().match(/\/CN=.+\(.+\)/g);
+                let cn: string[] = subject[0].trim().match(/\/CN=.+\(?.+\)?/g);
                 if (cn && cn[0]) {
                     commonName = cn[0].replace('/CN=', '').trim();
                 }

--- a/Tasks/InstallAppleCertificate/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/InstallAppleCertificate/Strings/resources.resjson/en-US/resources.resjson
@@ -18,5 +18,7 @@
   "loc.input.help.deleteCert": "Select to delete the certificate from the keychain after the build or release is complete.",
   "loc.input.label.deleteCustomKeychain": "Delete Custom Keychain",
   "loc.input.help.deleteCustomKeychain": "Select to delete the custom keychain from the agent after the build or release is complete.",
+  "loc.input.label.signingIdentity": "Certificate Signing Identity",
+  "loc.input.help.signingIdentity": "The Common Name of the subject in the signing certificate.  Will attempt to parse the Common Name if this is left empty.",
   "loc.messages.INVALID_P12": "Unable to find the certificate SHA1 hash and common name (CN). Verify that the certificate is a valid P12."
 }

--- a/Tasks/InstallAppleCertificate/Tests/L0.ts
+++ b/Tasks/InstallAppleCertificate/Tests/L0.ts
@@ -79,4 +79,22 @@ describe('InstallAppleCertificate Suite', function () {
 
         done();
     });
+
+    it('Defaults: with user input CN do not parse for it', (done: MochaDone) => {
+        // there is no way to verify the variable value as it is a 'side effect'
+        // this test just verifies that with user set CN, the task still works
+        this.timeout(1000);
+
+        let tp: string = path.join(__dirname, 'L0UserSupplyCN.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.ran('/usr/bin/security import /build/temp/mySecureFileId.filename -P mycertPwd -A -t cert -f pkcs12 -k /usr/lib/login.keychain'),
+            'certificate should have been installed in the default keychain');
+        assert(!tr.ran('/usr/bin/security create-keychain -p mykeychainPwd /usr/lib/login.keychain'), 'login keychain should not be created')
+        assert(tr.stderr.length === 0, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        done();
+    });
 });

--- a/Tasks/InstallAppleCertificate/Tests/L0UserSupplyCN.ts
+++ b/Tasks/InstallAppleCertificate/Tests/L0UserSupplyCN.ts
@@ -1,0 +1,76 @@
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+
+let taskPath = path.join(__dirname, '..', 'preinstallcert.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('certSecureFile', 'mySecureFileId');
+tr.setInput('certSigningIdentity', 'Testing Signing');
+tr.setInput('certPwd', 'mycertPwd');
+tr.setInput('keychain', 'default');
+tr.setInput('keychainPassword', 'mykeychainPwd');
+
+process.env['AGENT_VERSION'] = '2.116.0';
+process.env['AGENT_TEMPDIRECTORY'] = '/build/temp';
+process.env['HOME'] = '/users/test';
+
+let secureFileHelperMock = require('securefiles-common/securefiles-common-mock');
+tr.registerMock('securefiles-common/securefiles-common', secureFileHelperMock);
+
+tr.registerMock('fs', {
+    existsSync: function (filePath) {
+        if (filePath === '/usr/lib/login.keychain') {
+            return true;
+        }
+    },
+    writeFileSync: function (filePath, contents) {
+    }
+});
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "openssl": "/usr/bin/openssl",
+        "security": "/usr/bin/security"
+    },
+    "checkPath": {
+        "/usr/bin/openssl": true,
+        "/usr/bin/security": true
+    },
+    "exist": {
+        "/build/temp/mySecureFileId.filename": true,
+        "/usr/lib/login.keychain": true
+    },
+    "exec": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -subject": {
+            "code": 0,
+            "stdout": "MAC verified OK\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US"
+        },
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint": {
+            "code": 0,
+            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C"
+        },
+        "/usr/bin/security default-keychain": {
+            "code": 0,
+            "stdout": "/usr/lib/login.keychain"
+        },
+        "/usr/bin/security unlock-keychain -p mykeychainPwd /usr/lib/login.keychain": {
+            "code": 0,
+            "stdout": "keychain unlocked"
+        },
+        "/usr/bin/security import /build/temp/mySecureFileId.filename -P mycertPwd -A -t cert -f pkcs12 -k /usr/lib/login.keychain": {
+            "code": 0,
+            "stdout": "cert installed"
+        },
+        "/usr/bin/security list-keychain -d user": {
+            "code": 0,
+            "stdout": "/usr/lib/login.keychain"
+        }
+    }
+};
+tr.setAnswers(a);
+
+tr.run();
+

--- a/Tasks/InstallAppleCertificate/preinstallcert.ts
+++ b/Tasks/InstallAppleCertificate/preinstallcert.ts
@@ -21,7 +21,12 @@ async function run() {
 
         // get the P12 details - SHA1 hash and common name (CN)
         let p12Hash: string = await sign.getP12SHA1Hash(certPath, certPwd);
-        let p12CN: string = await sign.getP12CommonName(certPath, certPwd);
+        // give user an option to override the CN as a workaround if we can't parse the certificate
+        let p12CN: string = tl.getInput('certSigningIdentity', false);
+        if (!p12CN) {
+            p12CN = await sign.getP12CommonName(certPath, certPwd);
+        }
+
         if (!p12Hash || !p12CN) {
             throw tl.loc('INVALID_P12');
         }

--- a/Tasks/InstallAppleCertificate/task.json
+++ b/Tasks/InstallAppleCertificate/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 119,
+        "Minor": 121,
         "Patch": 0
     },
     "runsOn": [
@@ -95,6 +95,14 @@
             "required": false,
             "helpMarkDown": "Select to delete the custom keychain from the agent after the build or release is complete.",
             "visibleRule": "keychain = custom",
+            "groupName": "advanced"
+        },
+        {
+            "name": "signingIdentity",
+            "type": "string",
+            "label": "Certificate Signing Identity",
+            "required": false,
+            "helpMarkDown": "The Common Name of the subject in the signing certificate.  Will attempt to parse the Common Name if this is left empty.",
             "groupName": "advanced"
         }
     ],

--- a/Tasks/InstallAppleCertificate/task.loc.json
+++ b/Tasks/InstallAppleCertificate/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 119,
+    "Minor": 121,
     "Patch": 0
   },
   "runsOn": [
@@ -95,6 +95,14 @@
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.deleteCustomKeychain",
       "visibleRule": "keychain = custom",
+      "groupName": "advanced"
+    },
+    {
+      "name": "signingIdentity",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.signingIdentity",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.signingIdentity",
       "groupName": "advanced"
     }
   ],


### PR DESCRIPTION
The `()` is optional in the CN, make them optional.  Also add an advanced field in the task so user can override this in case we fail to parse the CN in the future. 

![image](https://user-images.githubusercontent.com/10119737/28697567-db190d2e-730a-11e7-9a47-7f822db338ad.png)
