### PR TITLE
Adding env variable to support old vstest flow for RFT task

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/make.json
+++ b/Tasks/DeployVisualStudioTestAgent/make.json
@@ -8,7 +8,7 @@
         ],
         "files": [
             {          
-                "url": "https://testexecution.blob.core.windows.net/testexecution/3840309/TestExecution.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/4058849/TestExecution.zip",
                 "dest": "./TestExecution.zip"
             }
         ],

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 14
+        "Patch": 15
     },
     "runsOn": [
         "Agent"

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 14
+    "Patch": 15
   },
   "runsOn": [
     "Agent"

--- a/Tasks/VsTest/distributedtest.ts
+++ b/Tasks/VsTest/distributedtest.ts
@@ -72,6 +72,7 @@ export class DistributedTest {
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.EnableConsoleLogs', 'true');
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.UseVsTestConsole', this.dtaTestConfig.useVsTestConsole);
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.TestPlatformVersion', this.dtaTestConfig.vsTestVersion);
+        utils.Helper.addToProcessEnvVars(envVars, 'DTA.IsVsTestTask', 'true');  // Adding this to support old flow for RFT
         if (this.dtaTestConfig.pathtoCustomTestAdapters) {
             const testAdapters = tl.findMatch(this.dtaTestConfig.pathtoCustomTestAdapters, '**\\*TestAdapter.dll');
             if (!testAdapters || (testAdapters && testAdapters.length === 0)) {

--- a/Tasks/VsTest/distributedtest.ts
+++ b/Tasks/VsTest/distributedtest.ts
@@ -72,7 +72,6 @@ export class DistributedTest {
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.EnableConsoleLogs', 'true');
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.UseVsTestConsole', this.dtaTestConfig.useVsTestConsole);
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.TestPlatformVersion', this.dtaTestConfig.vsTestVersion);
-        utils.Helper.addToProcessEnvVars(envVars, 'DTA.IsVsTestTask', 'true');  // Adding this to support old flow for RFT
         if (this.dtaTestConfig.pathtoCustomTestAdapters) {
             const testAdapters = tl.findMatch(this.dtaTestConfig.pathtoCustomTestAdapters, '**\\*TestAdapter.dll');
             if (!testAdapters || (testAdapters && testAdapters.length === 0)) {

--- a/Tasks/VsTest/make.json
+++ b/Tasks/VsTest/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/4037926/TestExecution.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/4058849/TestExecution.zip",
                 "dest": "./Modules"
             }
         ],

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -403,6 +403,7 @@
         "testPlanSelector": "Test plan",
         "testRunSelector": "Test run",
         "testRunIdInvalid": "The test selection is 'Test run', but the test run id '%s' given is invalid",
-        "testRunIdInput": "Test run Id : '%s'"
+        "testRunIdInput": "Test run Id : '%s'",
+        "noVstestConsole": "Tests will not be executed with vstest console. Install Visual Studio 2017 RC or above to run tests via vstest console."
     }
 }

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 65
+        "Patch": 66
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 65
+    "Patch": 66
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/taskinputparser.ts
+++ b/Tasks/VsTest/taskinputparser.ts
@@ -34,9 +34,16 @@ export function getDistributedTestConfigurations() {
     }
     console.log(tl.loc('dtaNumberOfAgents', dtaConfiguration.numberOfAgentsInPhase));
 
-    const useVsTestConsole = tl.getVariable('UseVsTestConsole');
-    if (useVsTestConsole) {
+    let useVsTestConsole = tl.getVariable('UseVsTestConsole');
+    if (useVsTestConsole) {        
         dtaConfiguration.useVsTestConsole = useVsTestConsole;
+    }
+
+    // VsTest Console cannot be used for Dev14
+    if (dtaConfiguration.useVsTestConsole.toUpperCase() === 'TRUE' && dtaConfiguration.vsTestVersion === '14.0')
+    {
+        console.log(tl.loc('noVstestConsole'));
+        dtaConfiguration.useVsTestConsole = 'false';
     }
 
     dtaConfiguration.dtaEnvironment = initDtaEnvironment();

--- a/Tasks/VsTest/taskinputparser.ts
+++ b/Tasks/VsTest/taskinputparser.ts
@@ -40,7 +40,7 @@ export function getDistributedTestConfigurations() {
     }
 
     // VsTest Console cannot be used for Dev14
-    if (dtaConfiguration.useVsTestConsole.toUpperCase() === 'TRUE' && dtaConfiguration.vsTestVersion === '14.0')
+    if (dtaConfiguration.useVsTestConsole.toUpperCase() === 'TRUE' && dtaConfiguration.vsTestVersion !== '15.0')
     {
         console.log(tl.loc('noVstestConsole'));
         dtaConfiguration.useVsTestConsole = 'false';

--- a/Tasks/VsTest/taskinputparser.ts
+++ b/Tasks/VsTest/taskinputparser.ts
@@ -11,7 +11,7 @@ const uuid = require('uuid');
 export function getDistributedTestConfigurations() {
     const dtaConfiguration = {} as models.DtaTestConfigurations;
     initTestConfigurations(dtaConfiguration);
-    dtaConfiguration.useVsTestConsole = 'true';
+    dtaConfiguration.useVsTestConsole = 'false';
 
     if (dtaConfiguration.vsTestLocationMethod === utils.Constants.vsTestVersionString && dtaConfiguration.vsTestVersion === '12.0') {
         throw (tl.loc('vs2013NotSupportedInDta'));


### PR DESCRIPTION
Description: Currently there is no way to turn off the new vstest console way for RFT task. This fix adds an environment variable which helps identify vstest multiagent flow from RFT task.

https://mseng.visualstudio.com/VSOnline/Automated%20Testing/_git/VSO/pullrequest/241683?_a=files