### PR TITLE
Fix L0 tests failing in VSTS.Tasks.Publish

### DIFF
--- a/Tasks/AzureRmWebAppDeployment/Tests/L0WindowsXdtTransformationFail.ts
+++ b/Tasks/AzureRmWebAppDeployment/Tests/L0WindowsXdtTransformationFail.ts
@@ -31,6 +31,7 @@ process.env["SYSTEM_TEAMPROJECT"] = "MyFirstProject";
 process.env["BUILD_SOURCEVERISONAUTHOR"] = "author";
 process.env["RELEASE_RELEASEURI"] = "vstfs:///ReleaseManagement/Release/1";
 process.env["AGENT_NAME"] = "author";
+process.env['SYSTEM_DEBUG'] = false;
 
 // provide answers for task mock
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/IISWebAppDeploymentOnMachineGroup/Tests/L0.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroup/Tests/L0.ts
@@ -122,8 +122,6 @@ describe('IISWebsiteDeploymentOnMachineGroup test suite', function() {
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
-        console.log(tr);
-        console.log(tr.stdout);
         assert(tr.invokedToolCount == 2, 'should have invoked tool twice');
         let expectedErr = "loc_mock_XDTTransformationsappliedsuccessfully";
         assert(tr.stdout.search(expectedErr) >= 0);
@@ -137,8 +135,6 @@ describe('IISWebsiteDeploymentOnMachineGroup test suite', function() {
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
-        console.log(tr);
-        console.log(tr.stdout);
         var expectedErr = 'Error: loc_mock_XdtTransformationErrorWhileTransforming C:\\tempFolder\\web.config C:\\tempFolder\\web.Release.config';
         assert(tr.invokedToolCount == 1, 'should have invoked tool only once');
         assert(tr.stderr.length > 0 || tr.errorIssues.length > 0, 'should have written to stderr');

--- a/Tasks/IISWebAppDeploymentOnMachineGroup/Tests/L0.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroup/Tests/L0.ts
@@ -122,6 +122,8 @@ describe('IISWebsiteDeploymentOnMachineGroup test suite', function() {
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
+        console.log(tr);
+        console.log(tr.stdout);
         assert(tr.invokedToolCount == 2, 'should have invoked tool twice');
         let expectedErr = "loc_mock_XDTTransformationsappliedsuccessfully";
         assert(tr.stdout.search(expectedErr) >= 0);
@@ -135,6 +137,8 @@ describe('IISWebsiteDeploymentOnMachineGroup test suite', function() {
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
+        console.log(tr);
+        console.log(tr.stdout);
         var expectedErr = 'Error: loc_mock_XdtTransformationErrorWhileTransforming C:\\tempFolder\\web.config C:\\tempFolder\\web.Release.config';
         assert(tr.invokedToolCount == 1, 'should have invoked tool only once');
         assert(tr.stderr.length > 0 || tr.errorIssues.length > 0, 'should have written to stderr');

--- a/Tasks/IISWebAppDeploymentOnMachineGroup/Tests/L0WindowsXdtTransformation.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroup/Tests/L0WindowsXdtTransformation.ts
@@ -10,6 +10,7 @@ tr.setInput('XmlTransformation', 'true');
 
 process.env['TASK_TEST_TRACE'] = 1;
 process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] =  "DefaultWorkingDirectory";
+process.env['SYSTEM_DEBUG'] = false;
 
 // provide answers for task mock
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/IISWebAppDeploymentOnMachineGroup/Tests/L0WindowsXdtTransformationFail.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroup/Tests/L0WindowsXdtTransformationFail.ts
@@ -10,6 +10,7 @@ tr.setInput('XmlTransformation', 'true');
 
 process.env['TASK_TEST_TRACE'] = 1;
 process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] =  "DefaultWorkingDirectory";
+process.env['SYSTEM_DEBUG'] = false;
 
 // provide answers for task mock
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{


### PR DESCRIPTION
VSTS.Tasks.Publish fails for below three cases:
1) IISWebsiteDeploymentOnMachineGroup test suite Fails if XDT Transformation throws error (Mock):

2) IISWebsiteDeploymentOnMachineGroup test suite Runs Successfully with XDT Transformation (Mock):

3) AzureRmWebAppDeployment Suite Fails if XML Transformation throws error (Mock):

**Cause:**
Recently, we added verbose flag for ctt, when system.debug is true.
But for tests, the above variable is set by default. which makes the ctt command mismatch with mocked command and fails.

**FIX:**
set system.debug=false explicitly.
