### PR TITLE
Fix DotNetCoreCLI broken tests

### DIFF
--- a/Tasks/Common/nuget-task-common/NuGetConfigHelper2.ts
+++ b/Tasks/Common/nuget-task-common/NuGetConfigHelper2.ts
@@ -26,9 +26,10 @@ export class NuGetConfigHelper2 {
         private authInfo: auth.NuGetExtendedAuthInfo,
         private environmentSettings: ngToolRunner.NuGetEnvironmentSettings,
         private tempConfigPath: string /*optional*/,
-        private useNuGetToModifyConfigFile: boolean = true)
+        private useNuGetToModifyConfigFile: boolean /* optional */)
     {
         this.tempNugetConfigPath = tempConfigPath || this.getTempNuGetConfigPath();
+        this.useNuGetToModifyConfigFile = useNuGetToModifyConfigFile || true;
         this.nugetXmlHelper = useNuGetToModifyConfigFile ?
             new NuGetExeXmlHelper(this.nugetPath, this.tempNugetConfigPath, this.authInfo, this.environmentSettings) :
             new NuGetXmlHelper(this.tempNugetConfigPath);


### PR DESCRIPTION
Fixing broken DotNetCoreCLI tests. Default parameters not supported on node v5.