### PR TITLE
PublishSymbols: Excluding directory matches returned Find-VstsMatch, during publish

### DIFF
--- a/Tasks/PublishSymbols/PublishSymbols.ps1
+++ b/Tasks/PublishSymbols/PublishSymbols.ps1
@@ -69,6 +69,9 @@ try {
     if ( ($SymbolServerType -eq "FileShare") -or ($SymbolServerType -eq "TeamServices") -or (-not $SkipIndexing) ) {
         # Get the PDB file paths.
         [string]$SearchPattern = Get-VstsInput -Name 'SearchPattern' -Default "**\*.pdb"
+        if ($SearchPattern.Contains("`n")) {
+            [string[]]$SearchPattern = $SearchPattern -split "`n"
+        }
         $matches = @(Find-VstsMatch -DefaultRoot $SymbolsFolder -Pattern $SearchPattern)
         $pdbFiles = $matches | Where-Object { -not ( Test-Path -LiteralPath $_ -PathType Container ) }
 

--- a/Tasks/PublishSymbols/PublishSymbols.ps1
+++ b/Tasks/PublishSymbols/PublishSymbols.ps1
@@ -68,12 +68,12 @@ try {
 
     if ( ($SymbolServerType -eq "FileShare") -or ($SymbolServerType -eq "TeamServices") -or (-not $SkipIndexing) ) {
         # Get the PDB file paths.
-        [string]$SearchPattern = Get-VstsInput -Name 'SearchPattern' -Default "**\*.pdb"
+        [string]$SearchPattern = Get-VstsInput -Name 'SearchPattern' -Default "**\bin\**\*.pdb"
         if ($SearchPattern.Contains("`n")) {
             [string[]]$SearchPattern = $SearchPattern -split "`n"
         }
         $matches = @(Find-VstsMatch -DefaultRoot $SymbolsFolder -Pattern $SearchPattern)
-        $pdbFiles = $matches | Where-Object { -not ( Test-Path -LiteralPath $_ -PathType Container ) }
+        $pdbFiles = $matches | Where-Object { -not ( Test-Path -LiteralPath $_ -PathType Container ) }  # Filter out directories
 
         Write-Host (Get-VstsLocString -Key Found0Files -ArgumentList $pdbFiles.Count)
         

--- a/Tasks/PublishSymbols/Tests/PassesArguments.ps1
+++ b/Tasks/PublishSymbols/Tests/PassesArguments.ps1
@@ -22,6 +22,7 @@ foreach ($treatNotIndexedAsWarning in @($true, $false)) {
     Register-Mock Get-VstsInput { 'Some input symbols path' } -- -Name 'SymbolsPath'
     Register-Mock Get-VstsInput { 'FileShare' } -ParametersEvaluator { $Name -eq 'SymbolServerType' }
     Register-Mock Get-VstsInput { $true } -ParametersEvaluator { $Name -eq 'IndexSources' }
+    Register-Mock Get-VstsInput { $true } -ParametersEvaluator { $Name -eq 'PublishSymbols' }
     Register-Mock Get-VstsInput { 'Some input search pattern' } -ParametersEvaluator { $Name -eq 'SearchPattern' }
     Register-Mock Get-VstsInput { 'Some input symbols product' } -ParametersEvaluator { $Name -eq 'SymbolsProduct' }
     Register-Mock Get-VstsInput { 'Some input symbols version' } -ParametersEvaluator { $Name -eq 'SymbolsVersion' }

--- a/Tasks/PublishSymbols/Tests/SetsFallbackMaxWaitTime.ps1
+++ b/Tasks/PublishSymbols/Tests/SetsFallbackMaxWaitTime.ps1
@@ -11,6 +11,7 @@ Register-Mock Invoke-PublishSymbols
 Register-Mock Get-VstsTaskVariable
 Register-Mock Get-VstsInput { 'FileShare' } -ParametersEvaluator { $Name -eq 'SymbolServerType' }
 Register-Mock Get-VstsInput { $true } -ParametersEvaluator { $Name -eq 'IndexSources' }
+Register-Mock Get-VstsInput { $true } -ParametersEvaluator { $Name -eq 'PublishSymbols' }
 Register-Mock Get-VstsInput { '-1' } -- -Name 'SymbolsMaximumWaitTime' -Default '0' -AsInt
 Register-Mock Get-VstsInput { 'Some input symbols path' } -- -Name 'SymbolsPath'
 Register-Mock Get-VstsInput { 'Some input search pattern' } -ParametersEvaluator { $Name -eq 'SearchPattern' }

--- a/Tasks/PublishSymbols/Tests/SkipsIndexing.ps1
+++ b/Tasks/PublishSymbols/Tests/SkipsIndexing.ps1
@@ -27,6 +27,7 @@ foreach ($treatNotIndexedAsWarning in @($true, $false)) {
     Register-Mock Get-VstsInput { 'Some symbols artifact name' } -- -Name 'SymbolsArtifactName'
     Register-Mock Get-VstsInput { $treatNotIndexedAsWarning } -ParametersEvaluator { $Name -eq 'TreatNotIndexedAsWarning' }
     Register-Mock Get-VstsInput { $false } -- -Name 'IndexSources' -AsBool
+    Register-Mock Get-VstsInput { $true } -ParametersEvaluator { $Name -eq 'PublishSymbols' }
     $env:PublishSymbols_Debug = $null
 
     # Act.

--- a/Tasks/PublishSymbols/task.json
+++ b/Tasks/PublishSymbols/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [

--- a/Tasks/PublishSymbols/task.loc.json
+++ b/Tasks/PublishSymbols/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "1.95.0",
   "groups": [


### PR DESCRIPTION
The api `Find-VstsMatch(*)` returns directories as well, and  trying to open the directory like a file causes the task to fail.
Typically users use `*.*`, which often skips directory as long as it does not contain a `.`,
In our builds we have `.` in directories (like `App.L0.Tests`)