### PR TITLE
Users/ranjanar/emptylines in logs

### DIFF
--- a/Tasks/VsTest/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VsTest/Strings/resources.resjson/en-US/resources.resjson
@@ -22,7 +22,7 @@
   "loc.input.label.searchFolder": "Search folder",
   "loc.input.help.searchFolder": "Folder to search for the test assemblies. Defaults to $(System.DefaultWorkingDirectory).",
   "loc.input.label.testFiltercriteria": "Test filter criteria",
-  "loc.input.help.testFiltercriteria": "Additional criteria to filter tests from Test assemblies. For example: `Priority=1|Name=MyTestMethod`",
+  "loc.input.help.testFiltercriteria": "Additional criteria to filter tests from Test assemblies. For example: `Priority=1|Name=MyTestMethod`. [More information](https://msdn.microsoft.com/en-us/library/jj155796.aspx)",
   "loc.input.label.runOnlyImpactedTests": "Run only impacted tests",
   "loc.input.help.runOnlyImpactedTests": "Automatically select, and run only the tests needed to validate the code change. [More information](https://aka.ms/tialearnmore)",
   "loc.input.label.runAllTestsAfterXBuilds": "Number of builds after which all tests should be run",

--- a/Tasks/VsTest/distributedtest.ts
+++ b/Tasks/VsTest/distributedtest.ts
@@ -117,7 +117,7 @@ export class DistributedTest {
             // and writes info to stdout directly
             const lines = c.toString().split('\n');
             lines.forEach(function (line: string) {
-                if (line.length === 0) {
+                if (line.trim().length === 0) {
                     return;
                 }
                 if (line.startsWith('Web method')) {

--- a/Tasks/VsTest/helpers.ts
+++ b/Tasks/VsTest/helpers.ts
@@ -135,7 +135,7 @@ export class Helper {
     public static printMultiLineLog(multiLineString: string, logFunction: Function) {
         const lines = multiLineString.toString().split('\n');
         lines.forEach(function (line: string) {
-            if (line.length === 0) {
+            if (line.trim().length === 0) {
                 return;
             }
             logFunction(line);

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [
         "vstest"
@@ -139,7 +139,7 @@
             "label": "Test filter criteria",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional criteria to filter tests from Test assemblies. For example: `Priority=1|Name=MyTestMethod`",
+            "helpMarkDown": "Additional criteria to filter tests from Test assemblies. For example: `Priority=1|Name=MyTestMethod`. [More information](https://msdn.microsoft.com/en-us/library/jj155796.aspx)",
             "groupName": "testSelection",
             "visibleRule": "testSelector = testAssemblies"
         },

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/versionfinder.ts
+++ b/Tasks/VsTest/versionfinder.ts
@@ -17,8 +17,7 @@ export function getVsTestRunnerDetails(testConfig : models.TestConfigurations) {
     const wmicArgs = ['datafile', 'where', 'name=\''.concat(vstestLocationEscaped, '\''), 'get', 'Version', '/Value'];
     wmicTool.arg(wmicArgs);
     const output = wmicTool.execSync({ silent: true } as tr.IExecSyncOptions).stdout.trim();
-    tl.debug('VSTest Version information: ' + output);
-    //utils.Helper.printMultiLineLog(output.stdout, (logLine) => { console.log('##vso[task.debug]' + logLine); });
+    tl.debug('VSTest Version information: ' + output)
 
     const verSplitArray = output.split('=');
     if (verSplitArray.length !== 2) {

--- a/Tasks/VsTest/versionfinder.ts
+++ b/Tasks/VsTest/versionfinder.ts
@@ -16,9 +16,15 @@ export function getVsTestRunnerDetails(testConfig : models.TestConfigurations) {
     const wmicTool = tl.tool('wmic');
     const wmicArgs = ['datafile', 'where', 'name=\''.concat(vstestLocationEscaped, '\''), 'get', 'Version', '/Value'];
     wmicTool.arg(wmicArgs);
-    const output = wmicTool.execSync({ silent: true } as tr.IExecSyncOptions).stdout.trim();
-    tl.debug('VSTest Version information: ' + output)
+    let output = wmicTool.execSync({ silent: true } as tr.IExecSyncOptions).stdout;
 
+
+    if (utils.Helper.isNullOrWhitespace(output)) {
+        tl.error(tl.loc('ErrorReadingVstestVersion'));
+        throw new Error(tl.loc('ErrorReadingVstestVersion'));
+    }
+    output = output.trim();
+    tl.debug('VSTest Version information: ' + output);
     const verSplitArray = output.split('=');
     if (verSplitArray.length !== 2) {
         tl.error(tl.loc('ErrorReadingVstestVersion'));

--- a/Tasks/VsTest/versionfinder.ts
+++ b/Tasks/VsTest/versionfinder.ts
@@ -18,7 +18,6 @@ export function getVsTestRunnerDetails(testConfig : models.TestConfigurations) {
     wmicTool.arg(wmicArgs);
     let output = wmicTool.execSync({ silent: true } as tr.IExecSyncOptions).stdout;
 
-
     if (utils.Helper.isNullOrWhitespace(output)) {
         tl.error(tl.loc('ErrorReadingVstestVersion'));
         throw new Error(tl.loc('ErrorReadingVstestVersion'));

--- a/Tasks/VsTest/versionfinder.ts
+++ b/Tasks/VsTest/versionfinder.ts
@@ -1,4 +1,5 @@
 import * as tl from 'vsts-task-lib/task';
+import tr = require('vsts-task-lib/toolrunner');
 import * as path from 'path';
 import * as Q from 'q';
 import * as models from './models';
@@ -15,10 +16,11 @@ export function getVsTestRunnerDetails(testConfig : models.TestConfigurations) {
     const wmicTool = tl.tool('wmic');
     const wmicArgs = ['datafile', 'where', 'name=\''.concat(vstestLocationEscaped, '\''), 'get', 'Version', '/Value'];
     wmicTool.arg(wmicArgs);
-    const output = wmicTool.execSync();
-    tl.debug('VSTest Version information: ' + output.stdout);
+    const output = wmicTool.execSync({ silent: true } as tr.IExecSyncOptions).stdout.trim();
+    tl.debug('VSTest Version information: ' + output);
+    //utils.Helper.printMultiLineLog(output.stdout, (logLine) => { console.log('##vso[task.debug]' + logLine); });
 
-    const verSplitArray = output.stdout.split('=');
+    const verSplitArray = output.split('=');
     if (verSplitArray.length !== 2) {
         tl.error(tl.loc('ErrorReadingVstestVersion'));
         throw new Error(tl.loc('ErrorReadingVstestVersion'));
@@ -26,8 +28,8 @@ export function getVsTestRunnerDetails(testConfig : models.TestConfigurations) {
 
     const versionArray = verSplitArray[1].split('.');
     if (versionArray.length !== 4) {
-        tl.warning(tl.loc('UnexpectedVersionString', output.stdout));
-        throw new Error(tl.loc('UnexpectedVersionString', output.stdout));
+        tl.warning(tl.loc('UnexpectedVersionString', output));
+        throw new Error(tl.loc('UnexpectedVersionString', output));
     }
 
     const majorVersion = parseInt(versionArray[0]);
@@ -109,9 +111,9 @@ function locateTestWindow(testConfig: models.TestConfigurations): string {
 function getVSTestConsole15Path(): string {
     const vswhereTool = tl.tool(path.join(__dirname, 'vswhere.exe'));
     vswhereTool.line('-version [15.0,16.0) -latest -products * -requires Microsoft.VisualStudio.PackageGroup.TestTools.Core -property installationPath');
-    let vsPath = vswhereTool.execSync().stdout;
-    tl.debug('Visual Studio 15.0 or higher installed path: ' + vsPath);
+    let vsPath = vswhereTool.execSync({ silent: true } as tr.IExecSyncOptions).stdout;
     vsPath = utils.Helper.trimString(vsPath);
+    tl.debug('Visual Studio 15.0 or higher installed path: ' + vsPath);
     if (!utils.Helper.isNullOrWhitespace(vsPath)) {
         return path.join(vsPath, 'Common7', 'IDE', 'CommonExtensions', 'Microsoft', 'TestWindow');
     }


### PR DESCRIPTION
BUG 976508 : [Feedback] Test filter criteria is not documented very well in Test Assemblies build task
BUG 1018788 : vstestv2 : Lot of blank lines in the logs when we call wmic to get the version