### PR TITLE
fix proper name of app setting

### DIFF
--- a/Tasks/AzureRmWebAppDeployment/task.json
+++ b/Tasks/AzureRmWebAppDeployment/task.json
@@ -308,7 +308,7 @@
             "required": false,
             "visibleRule": "UseWebDeploy == true",
             "groupName": "AdditionalDeploymentOptions",
-            "helpMarkDown": "Select the option to enable msdeploy flag MSDEPLOY_RENAME_FILES_FLAG in Azure App Service application settings. The option if set enables msdeploy to rename locked files that are locked during app deployment"
+            "helpMarkDown": "Select the option to enable msdeploy flag MSDEPLOY_RENAME_LOCKED_FILES=1 in Azure App Service application settings. The option if set enables msdeploy to rename locked files that are locked during app deployment"
         },
         {
             "name": "XmlTransformation",


### PR DESCRIPTION
Looks like the wrong app setting name was in the help text here,  just changed it to reflect the actual app setting that this enabled. MSDEPLOY_RENAME_LOCKED_FILES=1