### PR TITLE
Fixing Test Execution package version for prod

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/make.json
+++ b/Tasks/DeployVisualStudioTestAgent/make.json
@@ -8,7 +8,7 @@
         ],
         "files": [
             {          
-                "url": "https://testexecution.blob.core.windows.net/testexecution/4071087/TestExecution.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/3840309/TestExecution.zip",
                 "dest": "./TestExecution.zip"
             }
         ],

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 17
+        "Patch": 18
     },
     "runsOn": [
         "Agent"

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 17
+    "Patch": 18
   },
   "runsOn": [
     "Agent"


### PR DESCRIPTION
Description: With the current package version of Test Exeution, RFT task is failing because the new flow is getting invoked. Reducing the task version to the older version to enable the task.