### PR TITLE
Commenting out the warning code

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/SetupTestMachineForUITests.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/SetupTestMachineForUITests.ps1
@@ -795,7 +795,7 @@ function SetupTestMachine($TestUserName, $TestUserPassword, $EnvironmentURL) {
 
     Set-DisableScreenSaverReg | Out-Null
     ConfigurePowerOptions | Out-Null
-    IsWindowsErrorReportingDontShowUISet -TestUserDomain $Domain -TestUserName $TestUser
+    #IsWindowsErrorReportingDontShowUISet -TestUserDomain $Domain -TestUserName $TestUser
 
     $isTestUserLogged = IsTestUserCurrentlyLoggedIn -TestUserDomain $Domain -TestUserName $TestUser
     if(-not $isTestUserLogged)

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 18
+        "Patch": 19
     },
     "runsOn": [
         "Agent"

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 18
+    "Patch": 19
   },
   "runsOn": [
     "Agent"


### PR DESCRIPTION
After commenting out validated the reboot is happening.
Haven't found the original reason yet.