### PR TITLE
On Demand broken in RC2

### DIFF
--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 5
+        "Patch": 6
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 5
+    "Patch": 6
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/taskinputparser.ts
+++ b/Tasks/VsTest/taskinputparser.ts
@@ -250,6 +250,8 @@ function getTestSelectorBasedInputs(testConfiguration: models.TestConfigurations
                 throw new Error(tl.loc('testRunIdInvalid', testConfiguration.onDemandTestRunId));
             }
             console.log(tl.loc('testRunIdInput', testConfiguration.onDemandTestRunId));
+            testConfiguration.sourceFilter = ['**\\*', '!**\\obj\\*'];
+            tl.debug('Setting the test source filter for the TestRun : ' + testConfiguration.sourceFilter);
             break;
     }
 }


### PR DESCRIPTION
Validated in the RC2 box by replacing the js file

The Release that passed:
http://servermac-04:8080/tfs/DefaultCollection/TFS2018AgileProject/_apps%2Fhub%2Fms.vss-releaseManagement-web.hub-explorer?_a=release-logs&releaseId=9
