### PR TITLE
[WIP] MultiLine minimatch support in DotNetCoreCLI preview.

### DIFF
--- a/Tasks/DotNetCoreCLI/packcommand.ts
+++ b/Tasks/DotNetCoreCLI/packcommand.ts
@@ -9,7 +9,7 @@ import { IExecOptions } from "vsts-task-lib/toolrunner";
 
 export async function run(): Promise<void> {
 
-    let searchPattern = tl.getPathInput("searchPatternPack", true);
+    let searchPattern = tl.getDelimitedInput("searchPatternPack", '\n', true);
     let configuration = tl.getInput("configurationToPack");
     let versioningScheme = tl.getInput("versioningScheme");
     let versionEnvVar = tl.getInput("versionEnvVar");
@@ -94,7 +94,8 @@ export async function run(): Promise<void> {
                 filesList = tl.findMatch(undefined, searchPattern, findOptions, matchOptions);
             }
             else {
-                filesList = nutil.resolveFilterSpec(searchPattern);
+                // TODO: See what we need to do in legacy scenarios.
+                filesList = nutil.resolveFilterSpec(searchPattern[0]);
             }
         }
 

--- a/Tasks/DotNetCoreCLI/task.json
+++ b/Tasks/DotNetCoreCLI/task.json
@@ -270,7 +270,7 @@
         },
         {
             "name": "searchPatternPack",
-            "type": "filePath",
+            "type": "multiLine",
             "label": "Path to csproj or nuspec file(s) to pack",
             "defaultValue": "**/*.csproj",
             "helpMarkDown": "Pattern to search for csproj or nuspec files to pack.\n\nYou can separate multiple patterns with a semicolon, and you can make a pattern negative by prefixing it with '-:'. Example: `**\\*.csproj;-:**\\*.Tests.csproj`",


### PR DESCRIPTION
We tried to update DotNetCoreCLI task to the last version in TFS 2017 update 2 for a scenario that combines .NET Core projects with a VS Web Performance test.

We need to exclude this performance test in the dotnet pack command. We looked at the code and saw that the search of files uses an array, and the matching is minimatch (like in VSTest task).

I changed the task parameter to multiLine and parsed correctly in packCommand.ts, we tested it and it works.

Is this change acceptable in the main code base? Any input on how to continue (there is help and so on missing from this change)? 