### PR TITLE
Fixing json parse failure while publish due to empty key

### DIFF
--- a/Tasks/PublishSymbols/task.loc.json
+++ b/Tasks/PublishSymbols/task.loc.json
@@ -61,10 +61,10 @@
       "type": "pickList",
       "label": "ms-resource:loc.input.label.SymbolServerType",
       "required": true,
-      "defaultValue": "",
+      "defaultValue": " ",
       "helpMarkDown": "ms-resource:loc.input.help.SymbolServerType",
       "options": {
-        "": "Select one",
+        " ": "Select one",
         "TeamServices": "Team Services",
         "FileShare": "File share"
       },


### PR DESCRIPTION
The combo box item requires a new entry "Select one" needs to be added,
The empty string "" fails parsing and making it something like 'select' will not trigger settings required error,
Having it a space " " satisfies both.