### PR TITLE
Bumping up task lib version

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/make.json
+++ b/Tasks/DeployVisualStudioTestAgent/make.json
@@ -15,7 +15,7 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.7.1",
+                "version": "0.8.2",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 22
+        "Patch": 23
     },
     "runsOn": [
         "Agent"

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 22
+    "Patch": 23
   },
   "runsOn": [
     "Agent"


### PR DESCRIPTION
This bumps up the task lib version for DTA task as requested by Eric and requested for 64k environment variable limit fix