### PR TITLE
Override Test Settings Properties in RFT

### DIFF
--- a/Tasks/RunDistributedTests/RunDistributedTests.ps1
+++ b/Tasks/RunDistributedTests/RunDistributedTests.ps1
@@ -24,94 +24,129 @@ Function CmdletHasMember($memberName) {
     return $cmdletParameter
 }
 
-#To parse the Overriding Parameters string provided by user
-Function GetPropertiesMapping {
-    param ( [String] $overridingParameters )
-    
-        $inputStr = $overridingParameters
-        $parameterStrings = New-Object System.Collections.Generic.List[String]
-        $startOfSegment = 0;
-        $index = 0;
-    
-        $separator = ";" 
-        $escapeCharacter = '\'
-    
-        while ($index -ilt $inputStr.Length)
+Function Split-Parameters
+{
+    param 
+    ( 
+        [String] 
+        $OverridingParameters,
+
+        [String] 
+        $Separator,
+
+        [Char]
+        $EscapeCharacter
+    )
+   
+    $inputStr = $OverridingParameters
+    $parameterStrings = New-Object System.Collections.Generic.List[String]
+    $startOfSegment = 0
+    $index = 0
+
+    while ($index -ilt $inputStr.Length)
+    {
+        $index = $inputStr.indexOf($Separator, $index)
+        if ($index -gt 0 -and $inputStr[$index - 1] -eq $EscapeCharacter)
         {
-            $index = $inputStr.indexOf($separator, $index);
-            if ($index -gt 0 -and $inputStr[$index - 1] -eq $escapeCharacter)
-            {
-                $index += $separator.Length;
-                continue; 
-            }
-            if ($index -eq -1)
-            {
-                break;
-            }
-            $parameterStrings.Add($inputStr.Substring($startOfSegment, $index - $startOfSegment).Replace($escapeCharacter + $separator, $separator));
-            $index += $separator.Length;
-            $startOfSegment = $index;
+            $index += $Separator.Length
+            continue
         }
-        $parameterStrings.Add($inputStr.Substring($startOfSegment).Replace($escapeCharacter + $separator, $separator));
+        if ($index -eq -1)
+        {
+            break
+        }
+        $parameterStrings.Add($inputStr.Substring($startOfSegment, $index - $startOfSegment).Replace($EscapeCharacter + $Separator, $Separator))
+        $index += $Separator.Length
+        $startOfSegment = $index
+    }
+    $parameterStrings.Add($inputStr.Substring($startOfSegment).Replace($EscapeCharacter + $Separator, $Separator))
+
+    return $parameterStrings
+}
+
+Function Get-PropertiesMapping 
+{
+    param 
+    ( 
+        [String] 
+        $OverridingParameters 
+    )
         
-        $properties = New-Object 'system.collections.generic.dictionary[string,string]'
-        foreach ($s in $parameterStrings)
+    $parameterStrings = Split-Parameters -OverridingParameters $OverridingParameters -Separator ";" -EscapeCharacter '\'
+    $properties = New-Object 'system.collections.generic.dictionary[string,string]'
+    
+    foreach ($s in $parameterStrings)
+    {
+        $pair = $s.Split('=', 2)
+        if ($pair.Length -eq 2)
         {
-            $pair = $s.Split('=', 2);
-            if ($pair.Length -eq 2)
+            if (!$properties.ContainsKey($pair[0]))
             {
-               if (!$properties.ContainsKey($pair[0]))
-               {
-                    $properties.Add($pair[0], $pair[1])
-               }
+                $properties.Add($pair[0], $pair[1])
             }
         }
-        return $properties;
     }
     
-Function OverrideTestSettingProperties {
-    param (
-    [String] $overridingParameters, 
-    [System.Xml.XmlDocument] $testSettings
+    return $properties
+}
+    
+Function Override-TestSettingProperties 
+{
+    param 
+    (
+        [String]
+        $OverridingParameters, 
+       
+        [System.Xml.XmlDocument] 
+        $TestSettingsXmlDoc
     )
     
-        if([String]::IsNullOrEmpty($overridingParameters) -or $testSettings -eq $null)
-        {
-            return $false
+    $properties = Get-PropertiesMapping -OverridingParameters $OverridingParameters
+    $propertyNodes = $TestSettingsXmlDoc.TestSettings.Properties.ChildNodes
+    $hasOverridenProperties  = $false
+    
+    foreach($property in $propertyNodes)
+    {       
+        if ([string]::CompareOrdinal($property.LocalName, "Property") -ne 0 ) 
+        { 
+            continue 
+        } 
+
+        $nameAttribute = $property.name
+        $valueAttribute = $property.value
+        
+        if(-not $nameAttribute) 
+        { 
+            $nameAttribute = $property.Name 
         }
-    
-        $properties = GetPropertiesMapping -overridingParameters $overridingParameters
-        $propertyNodes = $testSettings.TestSettings.Properties.ChildNodes
-    
-        $hasOverridenProperties  = $false;
-        foreach($property in $propertyNodes)
-        {       
-            if ([string]::CompareOrdinal($property.LocalName, "Property") -ne 0 ) { continue } 
-    
-            $nameAttribute = $property.name
-            $valueAttribute = $property.value
-    
-            if(-not $nameAttribute) { $nameAttribute = $property.Name }
-    
-            if(-not $valueAttribute) { $valueAttribute = $property.Value }
+
+        if(-not $valueAttribute) 
+        { 
+            $valueAttribute = $property.Value 
+        }
             
-            if (-not ($nameAttribute -and $valueAttribute)) { continue }
+        if (-not ($nameAttribute -and $valueAttribute))
+        { 
+            continue 
+        }
              
-            if ($properties.ContainsKey($nameAttribute))
+        if ($properties.ContainsKey($nameAttribute))
+        {
+            $hasOverridenProperties = $true
+            Write-Verbose "Overriding value for parameter : $nameAttribute" 
+            if($property.value)
             {
-                $hasOverridenProperties = $true
-                if($property.value)
-                {
-                    $property.value = $properties[$nameAttribute]
-                }
-                elseif($property.Value)
-                {
-                    $property.Value = $properties[$nameAttribute]
-                }
+                $property.value = $properties[$nameAttribute]
+            }
+            elseif($property.Value)
+            {
+                $property.Value = $properties[$nameAttribute]
             }
         }
-        return $hasOverridenProperties
     }
+    
+    return $hasOverridenProperties
+}
 
 Write-Verbose "Entering script RunDistributedTests.ps1"
 Write-Verbose "TestMachineGroup = $testMachineGroup"
@@ -149,18 +184,34 @@ $taskContextMemberExists  = CmdletHasMember "TaskContext"
 
 if($overrideRunParams -and $runSettingsFile -and (Test-Path $runSettingsFile))
 {
-    if (([string]::Compare([io.path]::GetExtension($runSettingsFile), ".testsettings", $True) -eq 0)) {
-        $xml = [xml](Get-Content $runSettingsFile)
-        $hasOverridenProperties = OverrideTestSettingProperties -overridingParameters $overrideRunParams -testSettings $xml
-        if($hasOverridenProperties)
+    if (([string]::Compare([io.path]::GetExtension($runSettingsFile), ".testsettings", $True) -eq 0)) 
+    {
+        $settingsXML = $null 
+        try
         {
-            $newTestSettingsFile = [io.path]::Combine($env:TEMP, ([GUID]::NewGuid()).toString() + ".testsettings" )
-            $xml.Save($newTestSettingsFile)
-            Write-Verbose "Task will be using new TestSettings file created after overriding properties : $newTestSettingsFile"
-            $runSettingsFile = $newTestSettingsFile
-            # Resetting run params as we have already overriden them in test settiings file
-            $overrideRunParams = $null
+            $settingsXML = [xml](Get-Content $runSettingsFile)
         }
+        catch 
+        {
+            Write-Verbose "Exception occurred reading provided testsettings $_.Exception.message "
+        }
+        if($settingsXML -eq $null -or (-not $settingsXML.TestSettings) )
+        {
+            Write-Warning "The specified testsettings file $runSettingsFile is invalid or does not exist. Provide a valid settings file or clear the field."
+        }
+        else
+        {
+            $hasOverridenProperties = Override-TestSettingProperties -OverridingParameters $overrideRunParams -TestSettingsXmlDoc $settingsXML
+            if($hasOverridenProperties)
+            {
+                $newTestSettingsFile = [io.path]::Combine($env:TEMP, ([GUID]::NewGuid()).toString() + ".testsettings" )
+                $settingsXML.Save($newTestSettingsFile)
+                Write-Verbose "Task will be using new TestSettings file created after overriding properties : $newTestSettingsFile"
+                $runSettingsFile = $newTestSettingsFile
+            }
+        }
+        # Resetting overrideRunParams as we have already overriden them. Also needed to avoid not supported error of cmdlet.
+        $overrideRunParams = $null
     }
 }
 

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/en-US/resources.resjson
@@ -25,7 +25,7 @@
   "loc.input.label.runSettingsFile": "Run Settings File",
   "loc.input.help.runSettingsFile": "Path to runsettings or testsettings file to use with the tests.",
   "loc.input.label.overrideRunParams": "Override Test Run Parameters",
-  "loc.input.help.overrideRunParams": "Override parameters defined in the `TestRunParameters` section of runsettings file or `Properties` section of testsettings file. For example: `AppURL=$(DeployURL);Port=8080`. Note: Properties specified in testsettings file can be accessed via TestContext using Visual Studio 2017 Update 4 or higher.",
+  "loc.input.help.overrideRunParams": "Override parameters defined in the `TestRunParameters` section of runsettings file or `Properties` section of testsettings file. For example: `AppURL=$(DeployURL);Port=8080`. Note: Properties specified in testsettings file can be accessed via the TestContext using Visual Studio 2017 Update 4 or higher.",
   "loc.input.label.codeCoverageEnabled": "Code Coverage Enabled",
   "loc.input.help.codeCoverageEnabled": "Whether code coverage needs to be enabled.",
   "loc.input.label.customSlicingEnabled": "Distribute tests by number of machines",

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/en-US/resources.resjson
@@ -25,7 +25,7 @@
   "loc.input.label.runSettingsFile": "Run Settings File",
   "loc.input.help.runSettingsFile": "Path to runsettings or testsettings file to use with the tests.",
   "loc.input.label.overrideRunParams": "Override Test Run Parameters",
-  "loc.input.help.overrideRunParams": "Override parameters defined in the TestRunParameters section of runsettings file. For example: `AppURL=$(DeployURL);Port=8080`",
+  "loc.input.help.overrideRunParams": "Override parameters defined in the `TestRunParameters` section of runsettings file or `Properties` section of testsettings file. For example: `AppURL=$(DeployURL);Port=8080`. Note: Properties specified in testsettings file can be accessed via TestContext using Visual Studio 2017 Update 4 or higher.",
   "loc.input.label.codeCoverageEnabled": "Code Coverage Enabled",
   "loc.input.help.codeCoverageEnabled": "Whether code coverage needs to be enabled.",
   "loc.input.label.customSlicingEnabled": "Distribute tests by number of machines",

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/en-US/resources.resjson
@@ -25,7 +25,7 @@
   "loc.input.label.runSettingsFile": "Run Settings File",
   "loc.input.help.runSettingsFile": "Path to runsettings or testsettings file to use with the tests.",
   "loc.input.label.overrideRunParams": "Override Test Run Parameters",
-  "loc.input.help.overrideRunParams": "Override parameters defined in the `TestRunParameters` section of runsettings file or `Properties` section of testsettings file. For example: `AppURL=$(DeployURL);Port=8080`. Note: Properties specified in testsettings file can be accessed via the TestContext using Visual Studio 2017 Update 4 or higher.",
+  "loc.input.help.overrideRunParams": "Override parameters defined in the `TestRunParameters` section of runsettings file or `Properties` section of testsettings file. For example: `AppURL=$(DeployURL);Port=8080`. Note: Properties specified in testsettings file can be accessed via the TestContext using Test Agent 2017 Update 4 or higher.",
   "loc.input.label.codeCoverageEnabled": "Code Coverage Enabled",
   "loc.input.help.codeCoverageEnabled": "Whether code coverage needs to be enabled.",
   "loc.input.label.customSlicingEnabled": "Distribute tests by number of machines",

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -144,7 +144,7 @@
             "label": "Override Test Run Parameters",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Override parameters defined in the `TestRunParameters` section of runsettings file or `Properties` section of testsettings file. For example: `AppURL=$(DeployURL);Port=8080`. Note: Properties specified in testsettings file can be accessed via the TestContext using Visual Studio 2017 Update 4 or higher.",
+            "helpMarkDown": "Override parameters defined in the `TestRunParameters` section of runsettings file or `Properties` section of testsettings file. For example: `AppURL=$(DeployURL);Port=8080`. Note: Properties specified in testsettings file can be accessed via the TestContext using Test Agent 2017 Update 4 or higher.",
             "groupName": "executionOptions"
         },
         {

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 53
+        "Patch": 54
     },
     "runsOn": [
         "Agent"
@@ -144,7 +144,7 @@
             "label": "Override Test Run Parameters",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Override parameters defined in the TestRunParameters section of runsettings file. For example: `AppURL=$(DeployURL);Port=8080`",
+            "helpMarkDown": "Override parameters defined in the `TestRunParameters` section of runsettings file or `Properties` section of testsettings file. For example: `AppURL=$(DeployURL);Port=8080`. Note: Properties specified in testsettings file can be accessed via the TestContext using Visual Studio 2017 Update 4 or higher.",
             "groupName": "executionOptions"
         },
         {

--- a/Tasks/RunDistributedTests/task.loc.json
+++ b/Tasks/RunDistributedTests/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 53
+    "Patch": 54
   },
   "runsOn": [
     "Agent"


### PR DESCRIPTION
Change in RFT task to override test settings properties in powershell before passing it to cmdlet. 
Note: As cmdlet in LegacySDK cannot be changed hence this logic is added in ps1. Creates the new test settings file in agent temp and deletes when run completes.  

Scenarios Tested. 
- Invalid XML (testSettings)
- Valid TestSettings withouit properties
- Multiple Properties tag
- for different case in attribute name/Name 