### PR TITLE
correcting deletion path of vsts-task-lib from built common modueles.

### DIFF
--- a/Tasks/AzureVmssDeployment/make.json
+++ b/Tasks/AzureVmssDeployment/make.json
@@ -24,7 +24,7 @@
             "items": [
                 "node_modules/azure-arm-rest/node_modules/vsts-task-lib",
                 "node_modules/utility-common/node_modules/vsts-task-lib",
-                "node_modules/azure-blobstorage-artifactProvider/vsts-task-lib"
+                "node_modules/azure-blobstorage-artifactProvider/node_modules/vsts-task-lib"
             ],
             "options": "-Rf"
         }


### PR DESCRIPTION
Correcting error in path for vsts-task-lib in azure-blobstorage-provider common module while being used in AzureVmssDeployment task.