### PR TITLE
Add retry logic to options call in Nuget and NPM tasks

### DIFF
--- a/Tasks/Common/nuget-task-common/Utility.ts
+++ b/Tasks/Common/nuget-task-common/Utility.ts
@@ -218,10 +218,11 @@ export async function getNuGetFeedRegistryUrl(accessToken:string, feedId: string
 
     let vssConnection = new vsts.WebApi(packagingCollectionUrl, credentialHandler);
     let coreApi = vssConnection.getCoreApi();
-    return await Retry<string>(async () => {
-        let data = await coreApi.vsoClient.getVersioningData(ApiVersion, PackagingAreaName, PackageAreaId, { feedId: feedId });
-        return data.requestUrl;
-    });    
+
+    let data = await Retry(async () => {
+        return await coreApi.vsoClient.getVersioningData(ApiVersion, PackagingAreaName, PackageAreaId, { feedId: feedId });
+    });
+    return data.requestUrl;
 }
 
 // This should be replaced when retry is implemented in vso client.

--- a/Tasks/Common/nuget-task-common/Utility.ts
+++ b/Tasks/Common/nuget-task-common/Utility.ts
@@ -218,8 +218,31 @@ export async function getNuGetFeedRegistryUrl(accessToken:string, feedId: string
 
     let vssConnection = new vsts.WebApi(packagingCollectionUrl, credentialHandler);
     let coreApi = vssConnection.getCoreApi();
-
-    let data = await coreApi.vsoClient.getVersioningData(ApiVersion, PackagingAreaName, PackageAreaId, { feedId: feedId });
-
-    return data.requestUrl;
+    return await Retry<string>(async () => {
+        let data = await coreApi.vsoClient.getVersioningData(ApiVersion, PackagingAreaName, PackageAreaId, { feedId: feedId });
+        return data.requestUrl;
+    });    
 }
+
+// This should be replaced when retry is implemented in vso client.
+async function Retry<T>(cb : () => Promise<T>, max_retry: number = 4, retry_delay: number = 100) : Promise<T> {
+    try {
+        return await cb();
+    } catch(exception) {
+        tl.debug(JSON.stringify(exception));
+        if(max_retry > 0)
+        {
+            tl.debug("Waiting " + retry_delay + "ms...");
+            await delay(retry_delay);
+            tl.debug("Retrying...");
+            return await Retry<T>(cb, max_retry-1, retry_delay*2);
+        } else {
+            throw exception;
+        }
+    }
+}
+function delay(delayMs:number) {
+    return new Promise(function(resolve) { 
+        setTimeout(resolve, delayMs);
+    });
+ }


### PR DESCRIPTION
This options call is unexpectedly failing on occasion - subsequent builds pass, so go ahead and retry the call a couple of times before failing.