### PR TITLE
Remove default parameters

### DIFF
--- a/Tasks/Common/nuget-task-common/Utility.ts
+++ b/Tasks/Common/nuget-task-common/Utility.ts
@@ -221,12 +221,12 @@ export async function getNuGetFeedRegistryUrl(accessToken:string, feedId: string
 
     let data = await Retry(async () => {
         return await coreApi.vsoClient.getVersioningData(ApiVersion, PackagingAreaName, PackageAreaId, { feedId: feedId });
-    });
+    }, 4, 100);
     return data.requestUrl;
 }
 
 // This should be replaced when retry is implemented in vso client.
-async function Retry<T>(cb : () => Promise<T>, max_retry: number = 4, retry_delay: number = 100) : Promise<T> {
+async function Retry<T>(cb : () => Promise<T>, max_retry: number, retry_delay: number) : Promise<T> {
     try {
         return await cb();
     } catch(exception) {

--- a/Tasks/Npm/util.ts
+++ b/Tasks/Npm/util.ts
@@ -160,13 +160,14 @@ export async function getFeedRegistryUrl(feedId: string): Promise<string> {
     let coreApi = vssConnection.getCoreApi();
 
     let data = await Retry(async () => {
-         return await coreApi.vsoClient.getVersioningData(apiVersion, area, locationId, { feedId: feedId });
-    });
+        return await coreApi.vsoClient.getVersioningData(apiVersion, area, locationId, { feedId: feedId });
+    }, 4, 100);
+
     return data.requestUrl;
 }
 
 // This should be replaced when retry is implemented in vso client.
-async function Retry<T>(cb : () => Promise<T>, max_retry: number = 4, retry_delay: number = 100) : Promise<T> {
+async function Retry<T>(cb : () => Promise<T>, max_retry: number, retry_delay: number) : Promise<T> {
     try {
         return await cb();
     } catch(exception) {
@@ -187,3 +188,4 @@ function delay(delayMs:number) {
         setTimeout(resolve, delayMs);
     });
  }
+ 


### PR DESCRIPTION
Tracked L0 failures in node v5 to usage of default parameters.  Installed v5.10 and verified fix.