### PR TITLE
Remove preview flag in InstallAppleProvisioningProfile and InstallAppleCertificate tasks

### DIFF
--- a/Tasks/InstallAppleCertificate/task.json
+++ b/Tasks/InstallAppleCertificate/task.json
@@ -5,7 +5,6 @@
     "description": "Install an Apple certificate required to build on a macOS agent",
     "helpMarkDown": "",
     "category": "Utility",
-    "preview": true,
     "visibility": [
         "Build",
         "Release"
@@ -13,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 122,
+        "Minor": 124,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallAppleCertificate/task.loc.json
+++ b/Tasks/InstallAppleCertificate/task.loc.json
@@ -5,7 +5,6 @@
   "description": "ms-resource:loc.description",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Utility",
-  "preview": true,
   "visibility": [
     "Build",
     "Release"
@@ -13,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 122,
+    "Minor": 124,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfile/task.json
+++ b/Tasks/InstallAppleProvisioningProfile/task.json
@@ -5,7 +5,6 @@
     "description": "Install an Apple provisioning profile required to build on a macOS agent",
     "helpMarkDown": "",
     "category": "Utility",
-    "preview": true,
     "visibility": [
         "Build",
         "Release"
@@ -13,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 119,
+        "Minor": 124,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfile/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfile/task.loc.json
@@ -5,7 +5,6 @@
   "description": "ms-resource:loc.description",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Utility",
-  "preview": true,
   "visibility": [
     "Build",
     "Release"
@@ -13,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 119,
+    "Minor": 124,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
Removed the preview flag and bumped the minor version in InstallAppleProvisioningProfile and InstallAppleCertificate tasks.