### PR TITLE
Fix .NET Core restore default to include NuGet.org

### DIFF
--- a/Tasks/Common/nuget-task-common/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Common/nuget-task-common/Strings/resources.resjson/en-US/resources.resjson
@@ -12,5 +12,6 @@
   "loc.messages.Error_NoVersionWasFoundWhichMatches": "No version was found which matches the input %s",
   "loc.messages.Error_NoUrlWasFoundWhichMatches": "No download URL was found for %s",
   "loc.messages.Error_NuGetToolInstallerFailer": "Tool install failed: %s",
-  "loc.messages.Warning_UpdatingNuGetVersion": "Updating version of NuGet.exe to %s from %s. Behavior changes or breaking changes might occur as NuGet updates to a new version. If this is not desired, uncheck the 'Check for Latest Version' option in the task."
+  "loc.messages.Warning_UpdatingNuGetVersion": "Updating version of NuGet.exe to %s from %s. Behavior changes or breaking changes might occur as NuGet updates to a new version. If this is not desired, uncheck the 'Check for Latest Version' option in the task.",
+  "loc.messages.Error_NoMatchingFilesFoundForPattern": "No matching files were found with search pattern: %s"
 }

--- a/Tasks/Common/nuget-task-common/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Common/nuget-task-common/Strings/resources.resjson/en-US/resources.resjson
@@ -12,6 +12,5 @@
   "loc.messages.Error_NoVersionWasFoundWhichMatches": "No version was found which matches the input %s",
   "loc.messages.Error_NoUrlWasFoundWhichMatches": "No download URL was found for %s",
   "loc.messages.Error_NuGetToolInstallerFailer": "Tool install failed: %s",
-  "loc.messages.Warning_UpdatingNuGetVersion": "Updating version of NuGet.exe to %s from %s. Behavior changes or breaking changes might occur as NuGet updates to a new version. If this is not desired, uncheck the 'Check for Latest Version' option in the task.",
-  "loc.messages.Error_NoMatchingFilesFoundForPattern": "No matching files were found with search pattern: %s"
+  "loc.messages.Warning_UpdatingNuGetVersion": "Updating version of NuGet.exe to %s from %s. Behavior changes or breaking changes might occur as NuGet updates to a new version. If this is not desired, uncheck the 'Check for Latest Version' option in the task."
 }

--- a/Tasks/DotNetCoreCLI/package.json
+++ b/Tasks/DotNetCoreCLI/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vsts-tasks-dotnetcoreexe",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "description": "Dotnet core exe",
     "main": "dotnetcore.js",
     "scripts": {

--- a/Tasks/DotNetCoreCLI/package.json
+++ b/Tasks/DotNetCoreCLI/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vsts-tasks-dotnetcoreexe",
-    "version": "2.2.0",
+    "version": "2.1.3",
     "description": "Dotnet core exe",
     "main": "dotnetcore.js",
     "scripts": {

--- a/Tasks/DotNetCoreCLI/task.json
+++ b/Tasks/DotNetCoreCLI/task.json
@@ -140,7 +140,7 @@
             "name": "selectOrConfig",
             "type": "radio",
             "label": "Feeds to use",
-            "defaultValue": "config",
+            "defaultValue": "select",
             "helpMarkDown": "You can either select a feed from VSTS and/or NuGet.org here, or commit a nuget.config file to your source code repository and set its path here.",
             "required": "true",
             "options": {

--- a/Tasks/DotNetCoreCLI/task.json
+++ b/Tasks/DotNetCoreCLI/task.json
@@ -17,8 +17,8 @@
     "preview": true,
     "version": {
         "Major": 2,
-        "Minor": 2,
-        "Patch": 0
+        "Minor": 1,
+        "Patch": 3
     },
     "minimumAgentVersion": "2.0.0",
     "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DotNetCoreCLI/task.json
+++ b/Tasks/DotNetCoreCLI/task.json
@@ -17,8 +17,8 @@
     "preview": true,
     "version": {
         "Major": 2,
-        "Minor": 1,
-        "Patch": 2
+        "Minor": 2,
+        "Patch": 0
     },
     "minimumAgentVersion": "2.0.0",
     "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DotNetCoreCLI/task.loc.json
+++ b/Tasks/DotNetCoreCLI/task.loc.json
@@ -140,7 +140,7 @@
       "name": "selectOrConfig",
       "type": "radio",
       "label": "ms-resource:loc.input.label.selectOrConfig",
-      "defaultValue": "config",
+      "defaultValue": "select",
       "helpMarkDown": "ms-resource:loc.input.help.selectOrConfig",
       "required": "true",
       "options": {


### PR DESCRIPTION
dotnet changed (from NuGet.exe) the way multiple NuGet.config files are found and combined. This change means that the machine-wide NuGet.config is no longer picked up when a custom NuGet.config is provided. To unblock the majority scenario (packages coming solely from NuGet.org - no private registries), I've changed the task default to the options that generate a NuGet.config that contains NuGet.org.