### PR TITLE
Publish Code Coverage task - Additional Files field Input validation for proper file path regex

### DIFF
--- a/Tasks/PublishCodeCoverageResults/publishcodecoverageresults.ts
+++ b/Tasks/PublishCodeCoverageResults/publishcodecoverageresults.ts
@@ -104,6 +104,7 @@ function pathExistsAsFile(path: string) {
         return tl.stats(path).isFile();
     }
     catch (error) {
+        tl.debug(error);
         return false;
     }
 }

--- a/Tasks/PublishCodeCoverageResults/publishcodecoverageresults.ts
+++ b/Tasks/PublishCodeCoverageResults/publishcodecoverageresults.ts
@@ -40,12 +40,13 @@ async function run() {
                         additionalFiles,
                         { followSymbolicLinks: false, followSpecifiedSymbolicLink: false },
                         { matchBase: true });
-                    tl.debug(tl.loc('FoundNMatchesForPattern', additionalFileMatches.length, additionalFiles));
                 }
                 else {
                     // Use the specific additional file (no wildcards)
                     var additionalFileMatches: string[] = [additionalFiles];
                 }
+                additionalFileMatches = additionalFileMatches.filter(file => pathExistsAsFile(file));
+                tl.debug(tl.loc('FoundNMatchesForPattern', additionalFileMatches.length, additionalFiles));
             }
 
             // Publish code coverage data
@@ -95,6 +96,16 @@ function resolvePathToSingleItem(workingDirectory:string, pathInput: string) : s
 function containsWildcard(inputValue: string) : boolean {
     return inputValue.indexOf('*') >= 0 ||
            inputValue.indexOf('?') >= 0;
+}
+
+// Gets whether the specified path exists as file.
+function pathExistsAsFile(path: string) {
+    try {
+        return tl.stats(path).isFile();
+    }
+    catch (error) {
+        return false;
+    }
 }
 
 run();

--- a/Tasks/PublishCodeCoverageResults/task.json
+++ b/Tasks/PublishCodeCoverageResults/task.json
@@ -15,7 +15,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 121,
+        "Minor": 122,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/PublishCodeCoverageResults/task.loc.json
+++ b/Tasks/PublishCodeCoverageResults/task.loc.json
@@ -15,7 +15,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 121,
+    "Minor": 122,
     "Patch": 0
   },
   "demands": [],

--- a/Tests-Legacy/L0/PublishCodeCoverageResults/_suite.ts
+++ b/Tests-Legacy/L0/PublishCodeCoverageResults/_suite.ts
@@ -136,6 +136,52 @@ describe('Publish Code Coverage Results Suite', function() {
             });
     })
 
+    it('Publish code coverage results when directory path matches the given additonal files input', (done) => {
+        setResponseFile('publishCCResponses.json');
+
+        var tr = new trm.TaskRunner('PublishCodeCoverageResults');
+
+        tr.setInput('codeCoverageTool', 'JaCoCo');
+        tr.setInput('summaryFileLocation', '/user/admin/summary.xml');
+        tr.setInput('reportDirectory', '/user/admin/report');
+        tr.setInput('additionalCodeCoverageFiles', "/some/*pattern/path");
+
+        tr.run()
+            .then(() => {
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.stdout.search(/##vso\[codecoverage.publish codecoveragetool=JaCoCo;summaryfile=\/user\/admin\/summary.xml;reportdirectory=\/user\/admin\/report;additionalcodecoveragefiles=;\]/) >= 0, 'should publish code coverage results.');
+
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
+    it('Publish code coverage results when file path matches the given additonal files input', (done) => {
+        setResponseFile('publishCCResponses.json');
+
+        var tr = new trm.TaskRunner('PublishCodeCoverageResults');
+
+        tr.setInput('codeCoverageTool', 'JaCoCo');
+        tr.setInput('summaryFileLocation', '/user/admin/summary.xml');
+        tr.setInput('reportDirectory', '/user/admin/report');
+        tr.setInput('additionalCodeCoverageFiles', "/some/*pattern/one");
+
+        tr.run()
+            .then(() => {
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.stdout.search(/##vso\[codecoverage.publish codecoveragetool=JaCoCo;summaryfile=\/user\/admin\/summary.xml;reportdirectory=\/user\/admin\/report;additionalcodecoveragefiles=some\/path\/one;\]/) >= 0, 'should publish code coverage results.');
+
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
     it('Publish code coverage results when code coverage tool is not provided', (done) => {
         setResponseFile('publishCCResponses.json');
 

--- a/Tests-Legacy/L0/PublishCodeCoverageResults/_suite.ts
+++ b/Tests-Legacy/L0/PublishCodeCoverageResults/_suite.ts
@@ -182,6 +182,29 @@ describe('Publish Code Coverage Results Suite', function() {
             });
     })
 
+    it('Publish code coverage results when both directory and file path matches the given additonal files input', (done) => {
+        setResponseFile('publishCCResponses.json');
+
+        var tr = new trm.TaskRunner('PublishCodeCoverageResults');
+
+        tr.setInput('codeCoverageTool', 'JaCoCo');
+        tr.setInput('summaryFileLocation', '/user/admin/summary.xml');
+        tr.setInput('reportDirectory', '/user/admin/report');
+        tr.setInput('additionalCodeCoverageFiles', "/some/*pattern");
+
+        tr.run()
+            .then(() => {
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.stdout.search(/##vso\[codecoverage.publish codecoveragetool=JaCoCo;summaryfile=\/user\/admin\/summary.xml;reportdirectory=\/user\/admin\/report;additionalcodecoveragefiles=some\/path\/one,some\/path\/two;\]/) >= 0, 'should publish code coverage results.');
+
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
     it('Publish code coverage results when code coverage tool is not provided', (done) => {
         setResponseFile('publishCCResponses.json');
 

--- a/Tests-Legacy/L0/PublishCodeCoverageResults/publishCCResponses.json
+++ b/Tests-Legacy/L0/PublishCodeCoverageResults/publishCCResponses.json
@@ -13,9 +13,27 @@
     },
     "findMatch": {
         "/some/*pattern": [
+            "some/path",
             "some/path/one",
             "some/path/two"
         ],
+        "/some/*pattern/path": [
+            "some/path"
+        ],
+        "/some/*pattern/one": [
+            "some/path/one"
+        ],
         "/other/*pattern": []
+    },
+    "stats": {
+        "some/path": {
+            "isFile": false
+        },
+        "some/path/one": {
+            "isFile": true
+        },
+        "some/path/two": {
+            "isFile": true
+        }
     }
 }


### PR DESCRIPTION
If user passes directory path instead of file path in additional files field, then directory path is ignored and not published to command.
Link to mseng [bug](https://mseng.visualstudio.com/VSOnline/_workitems/edit/1022209).