### PR TITLE
Updated task.json. A potential fix of #5548

### DIFF
--- a/Tasks/Kubernetes/task.json
+++ b/Tasks/Kubernetes/task.json
@@ -169,7 +169,10 @@
                 "yaml": "yaml"
             },
             "helpMarkDown": "Output format.",
-            "groupName": "output"
+            "groupName": "output",
+            "properties": {
+                "EditableOptions": "True"
+            }
         },
         {
             "name": "kubectlOutput",


### PR DESCRIPTION
Marked output field as editable so that if someone enters:
              jsonpath='{$.status.loadBalancer.ingress[0].ip}'
it will be converted into a valid output command line option:
              -o jsonpath='{$.status.loadBalancer.ingress[0].ip}'
and will enable json path as output filters.