### PR TITLE
Fix IndexHelpers in PublishSymbols

### DIFF
--- a/Tasks/PublishSymbols/IndexHelpers/SrcSrvIniContentFunctions.ps1
+++ b/Tasks/PublishSymbols/IndexHelpers/SrcSrvIniContentFunctions.ps1
@@ -116,7 +116,7 @@ function New-TfvcSrcSrvIniContent {
             (Get-Date))
         'INDEXER=TFSTB'
         'SRCSRV: variables ------------------------------------------'
-        'TFS_EXTRACT_CMD=tf.exe view /version:%var4% /noprompt "$%var3%" /server:%fnvar%(%var2%) /console > %SRCSRVTRG%'
+        'TFS_EXTRACT_CMD=tf.exe view /version:%var4% /noprompt "$%var3%" /server:%fnvar%(%var2%) /output:%SRCSRVTRG%'
         'TFS_EXTRACT_TARGET=%targ%\%var2%%fnbksl%(%var3%)\%var4%\%fnfile%(%var5%)'
         'SRCSRVVERCTRL=tfs'
         'SRCSRVERRDESC=access'


### PR DESCRIPTION
Fix in "New-TfvcSrcSrvIniContent":
The TFS_EXTRACT_CMD used ">" to create the local source code file. This could fail on Windows if the local file destination directory does not exist.
Changed the TFS_EXTRACT_CMD to use the /output switch for specifying the local file. This switch is already used in "New-TfsGitSrcSrvIniContent"