### PR TITLE
Updated help msg to add generic connection endpoint

### DIFF
--- a/Tasks/cURLUploader/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/cURLUploader/Strings/resources.resjson/en-US/resources.resjson
@@ -8,7 +8,7 @@
   "loc.input.help.files": "File(s) to be uploaded. Wildcards can be used. For example, `**\\*.zip` for all ZIP files in all subfolders.",
   "loc.input.label.authType": "Authentication Method",
   "loc.input.label.serviceEndpoint": "Service Endpoint",
-  "loc.input.help.serviceEndpoint": "The service endpoint with the credentials for the server authentication.",
+  "loc.input.help.serviceEndpoint": "The service endpoint with the credentials for the server authentication. Use the Generic connection type for the service endpoint.",
   "loc.input.label.username": "Username",
   "loc.input.help.username": "Specify the username for server authentication.",
   "loc.input.label.password": "Password",


### PR DESCRIPTION
The help message in the cURLUploader task regarding the service endpoint can be confusing, Suggesting to add an indication pointing at generic endpoint.
