### PR TITLE
Allow copy single file as indicated by tooltip

### DIFF
--- a/Tasks/PublishBuildArtifacts/publishbuildartifacts.ts
+++ b/Tasks/PublishBuildArtifacts/publishbuildartifacts.ts
@@ -1,5 +1,4 @@
 import os = require('os');
-import fs = require('fs');
 import path = require('path');
 var process = require('process');
 import tl = require('vsts-task-lib/task');
@@ -97,10 +96,10 @@ async function run() {
                 // copy the files
                 let script: string = path.join(__dirname, 'Invoke-Robocopy.ps1');
                 let command: string = `& ${pathToScriptPSString(script)} -Source ${pathToRobocopyPSString(pathtoPublish)} -Target ${pathToRobocopyPSString(artifactPath)} -ParallelCount ${parallelCount}`
-                if (fs.statSync(pathtoPublish).isFile()) {
+                if (tl.stats(pathtoPublish).isFile()) {
                     let parentFolder = path.dirname(pathtoPublish);
                     let file = path.basename(pathtoPublish);
-                    command = `& ${pathToScriptPSString(script)} -Source ${pathToRobocopyPSString(parentFolder)} -Target ${pathToRobocopyPSString(artifactPath)} -ParallelCount ${parallelCount} -File "${file}"`
+                    command = `& ${pathToScriptPSString(script)} -Source ${pathToRobocopyPSString(parentFolder)} -Target ${pathToRobocopyPSString(artifactPath)} -ParallelCount ${parallelCount} -File '${file}'`
                 }
 
                 let powershell = new tr.ToolRunner('powershell.exe');

--- a/Tasks/PublishBuildArtifacts/publishbuildartifacts.ts
+++ b/Tasks/PublishBuildArtifacts/publishbuildartifacts.ts
@@ -1,4 +1,5 @@
 import os = require('os');
+import fs = require('fs');
 import path = require('path');
 var process = require('process');
 import tl = require('vsts-task-lib/task');
@@ -52,14 +53,14 @@ async function run() {
         let artifactName: string = tl.getInput('ArtifactName', true);
         let artifactType: string = tl.getInput('ArtifactType', true);
 
-       
+
         let hostType = tl.getVariable('system.hostType');
         if ((hostType && hostType.toUpperCase() != 'BUILD') && (artifactType.toUpperCase() !== "FILEPATH")) {
             tl.setResult(tl.TaskResult.Failed, tl.loc('ErrorHostTypeNotSupported'));
             return;
         }
 
-        
+
         artifactType = artifactType.toLowerCase();
         let data = {
             artifacttype: artifactType,
@@ -96,6 +97,11 @@ async function run() {
                 // copy the files
                 let script: string = path.join(__dirname, 'Invoke-Robocopy.ps1');
                 let command: string = `& ${pathToScriptPSString(script)} -Source ${pathToRobocopyPSString(pathtoPublish)} -Target ${pathToRobocopyPSString(artifactPath)} -ParallelCount ${parallelCount}`
+                if (fs.statSync(pathtoPublish).isFile()) {
+                    let parentFolder = path.dirname(pathtoPublish);
+                    let file = path.basename(pathtoPublish);
+                    command = `& ${pathToScriptPSString(script)} -Source ${pathToRobocopyPSString(parentFolder)} -Target ${pathToRobocopyPSString(artifactPath)} -ParallelCount ${parallelCount} -File "${file}"`
+                }
 
                 let powershell = new tr.ToolRunner('powershell.exe');
                 powershell.arg('-NoLogo');

--- a/Tasks/PublishBuildArtifacts/task.json
+++ b/Tasks/PublishBuildArtifacts/task.json
@@ -11,8 +11,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 124,
-    "Patch": 1
+    "Minor": 126,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.91.0",

--- a/Tasks/PublishBuildArtifacts/task.loc.json
+++ b/Tasks/PublishBuildArtifacts/task.loc.json
@@ -11,8 +11,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 124,
-    "Patch": 1
+    "Minor": 126,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.91.0",

--- a/Tests-Legacy/L0/PublishBuildArtifacts/_suite.ts
+++ b/Tests-Legacy/L0/PublishBuildArtifacts/_suite.ts
@@ -12,7 +12,7 @@ function setResponseFile(name: string) {
 
 describe('Publish Build Artifacts Suite', function () {
     this.timeout(10000);
-	
+
 	before((done: MochaDone) => {
 		// init here
 		done();
@@ -20,15 +20,15 @@ describe('Publish Build Artifacts Suite', function () {
 
 	after(() => {
 	});
-	
+
 	it('Publish to container', (done: MochaDone) => {
 		setResponseFile('publishBuildArtifactsGood.json');
-		
+
 		let tr = new trm.TaskRunner('PublishBuildArtifacts');
 		tr.setInput('PathtoPublish', '/bin/release');
 		tr.setInput('ArtifactName', 'drop');
 		tr.setInput('ArtifactType', 'Container');
-		
+
 		tr.run()
 		.then(() => {
 			assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
@@ -39,7 +39,7 @@ describe('Publish Build Artifacts Suite', function () {
 		.fail((err) => {
 			done(err);
 		});
-	})	
+	})
 
 	if (os.platform() == 'win32') {
 		it('Publish to UNC', (done: MochaDone) => {
@@ -108,15 +108,37 @@ describe('Publish Build Artifacts Suite', function () {
 			});
 		})
 
+		it('Copy single file with robocopy', (done: MochaDone) => {
+			setResponseFile('publishBuildArtifactsGood.json');
+
+			let tr = new trm.TaskRunner('PublishBuildArtifacts', false, true);
+			tr.setInput('PathtoPublish', 'C:\\bin\\release\\file.exe');
+			tr.setInput('ArtifactName', 'drop');
+			tr.setInput('ArtifactType', 'FilePath');
+			tr.setInput('TargetPath', '\\\\UNCShare');
+
+			tr.run()
+			.then(() => {
+				assert(!tr.stderr, 'should not have written to stderr. error: ' + tr.stderr);
+				assert(tr.succeeded, 'task should have succeeded');
+				assert(tr.stdout.indexOf('test stdout from robocopy (copy a single file)') >= 0, 'should copy files.');
+				assert(tr.stdout.search(/artifact.associate/gi) >= 0, 'should associate artifact.');
+				done();
+			})
+			.fail((err) => {
+				done(err);
+			});
+		})
+
 		it('fails if robocopy fails', (done: MochaDone) => {
 			setResponseFile('publishBuildArtifactsBad.json');
-			
+
 			let tr = new trm.TaskRunner('PublishBuildArtifacts', false, true);
 			tr.setInput('PathtoPublish', 'C:\\bin\\release');
 			tr.setInput('ArtifactName', 'drop');
 			tr.setInput('ArtifactType', 'FilePath');
 			tr.setInput('TargetPath', '\\\\UNCShare\\subdir');
-			
+
 			tr.run()
 			.then(() => {
 				assert(tr.failed, 'task should have failed');
@@ -175,8 +197,8 @@ describe('Publish Build Artifacts Suite', function () {
 
 	it('fails if PathtoPublish not set', (done: MochaDone) => {
 		setResponseFile('publishBuildArtifactsGood.json');
-		
-		let tr = new trm.TaskRunner('PublishBuildArtifacts');		
+
+		let tr = new trm.TaskRunner('PublishBuildArtifacts');
 		tr.setInput('ArtifactName', 'drop');
 		tr.setInput('ArtifactType', 'Container');
 		tr.run()
@@ -192,10 +214,10 @@ describe('Publish Build Artifacts Suite', function () {
 			done(err);
 		});
 	})
-	
+
 	it('fails if ArtifactName not set', (done: MochaDone) => {
 		setResponseFile('publishBuildArtifactsGood.json');
-		
+
 		let tr = new trm.TaskRunner('PublishBuildArtifacts');
 		tr.setInput('PathtoPublish', '/bin/release');
 		tr.setInput('ArtifactType', 'Container');
@@ -212,10 +234,10 @@ describe('Publish Build Artifacts Suite', function () {
 			done(err);
 		});
 	})
-	
+
 	it('fails if ArtifactType not set', (done: MochaDone) => {
 		setResponseFile('publishBuildArtifactsGood.json');
-		
+
 		let tr = new trm.TaskRunner('PublishBuildArtifacts');
 		tr.setInput('PathtoPublish', '/bin/release');
 		tr.setInput('ArtifactName', 'drop');
@@ -232,11 +254,11 @@ describe('Publish Build Artifacts Suite', function () {
 			done(err);
 		});
 	})
-	
-	
+
+
 	it('fails if PathtoPublish not found', (done: MochaDone) => {
 		setResponseFile('publishBuildArtifactsGood.json');
-		
+
 		let tr = new trm.TaskRunner('PublishBuildArtifacts');
 		tr.setInput('PathtoPublish', '/bin/notexist');
 		tr.setInput('ArtifactName', 'drop');

--- a/Tests-Legacy/L0/PublishBuildArtifacts/publishBuildArtifactsGood.json
+++ b/Tests-Legacy/L0/PublishBuildArtifacts/publishBuildArtifactsGood.json
@@ -2,7 +2,8 @@
     "checkPath": {
         "/bin/release": true,
         "C:\\bin\\release\\": true,
-        "C:\\bin\\release": true
+        "C:\\bin\\release": true,
+        "C:\\bin\\release\\file.exe": true
     },
   "exec": {
     "powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command & '\\PublishBuildArtifacts\\Invoke-Robocopy.ps1' -Source 'C:\\bin\\release' -Target '\\\\UNCShare\\subdir\\drop' -ParallelCount 1": {
@@ -19,6 +20,25 @@
       "stdout": "test stdout from robocopy (target with trailing slash)",
       "stderr": "",
       "code": 0
+    },
+    "powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command & '\\PublishBuildArtifacts\\Invoke-Robocopy.ps1' -Source 'C:\\bin\\release' -Target '\\\\UNCShare\\drop\\.' -ParallelCount 1 -File 'file.exe'": {
+      "stdout": "test stdout from robocopy (copy a single file)",
+      "stderr": "",
+      "code": 0
+    }
+  },
+  "stats": {
+    "/bin/release": {
+      "isFile": false
+    },
+    "C:\\bin\\release\\": {
+      "isFile": false
+    },
+    "C:\\bin\\release": {
+      "isFile": false
+    },
+    "C:\\bin\\release\\file.exe": {
+      "isFile": true
     }
   }
 }


### PR DESCRIPTION
When selecting "Artifact publish location: A file share", we do not support publish a file, even though the tooltip mentions "The folder or **file** path to publish".

Tested:
1. Path to publish set to a folder -- all files under this folder are copied
2. Path to publish set to a file with and without spaces -- the single file is copied in both cases. 
