### PR TITLE
Use latest 0.12.0 of mobile-center-cli

### DIFF
--- a/Tasks/VSMobileCenterTest/package.json
+++ b/Tasks/VSMobileCenterTest/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/microsoft/vsts-tasks",
   "dependencies": {
     "glob": "^7.0.6",
-    "mobile-center-cli": "0.9.1",
+    "mobile-center-cli": "0.12.0",
     "vso-node-api": "^6.2.2-preview",
     "vsts-task-lib": "2.0.5"
   }


### PR DESCRIPTION
Update to the latest version of mobile-center-cli which among other things fixes this issue:

https://github.com/Microsoft/mobile-center-cli/pull/290 

Tests are passing locally

```
➜  vsts-tasks git:(feature/update-vsmc-cli) ✗ node make.js test --task VSMobileCenterTest --suite L0
tsc tool:
Version 1.8.7
/Users/krukow/code/vsts-tasks/node_modules/.bin/tsc
mocha tool:
2.3.3
/Users/krukow/code/vsts-tasks/node_modules/.bin/mocha

> tsc --rootDir /Users/krukow/code/vsts-tasks/Tests --outDir /Users/krukow/code/vsts-tasks/_build/Tests

> copying ps test lib resources
copying **/@(*.ps1|*.psm1)

> mocha /Users/krukow/code/vsts-tasks/_build/Tasks/VSMobileCenterTest/Tests/L0.js /Users/krukow/code/vsts-tasks/_build/Tests/L0.js


  VSMobileCenterTest L0 Suite
    ✓ Positive path: upload Appium test with service endpoint (285ms)
    ✓ Positive path: upload Espresso test with service endpoint (284ms)
    ✓ Positive path: upload Calabash test with service endpoint (279ms)
    ✓ Positive path: upload XCUITest test with service endpoint (280ms)
    ✓ Positive path: upload UITest with username and password (284ms)
    ✓ Negative path: with username and password, should always logout even when test run failed (286ms)
    ✓ Favor system mobile-center cli over bundled cli (279ms)

  General Suite
    ✓ Find invalid task.json
    ✓ Find nested task.json (126ms)
    ✓ Find .js with uppercase
    ✓ Find unsupported demands
    ✓ Find unsupported runsOn
    ✓ Find invalid server Task
    ✓ Find invalid message key in task.json
    ✓ Find missing string in .ts
    ✓ Find missing string in .ps1/.psm1


  16 passing (2s)
```