### PR TITLE
Add back the legacy variables as output variables aren't enabled yet.

### DIFF
--- a/Tasks/InstallAppleCertificate/preinstallcert.ts
+++ b/Tasks/InstallAppleCertificate/preinstallcert.ts
@@ -56,6 +56,11 @@ async function run() {
 
         // set the keychain output variable.
         tl.setVariable('keychainPath', keychainPath);
+
+        // Set the legacy variables that doesn't use the task's refName, unlike our output variables.
+        // If there are multiple InstallAppleCertificate tasks, the last one wins.
+        tl.setVariable('APPLE_CERTIFICATE_SIGNING_IDENTITY', p12CN);
+        tl.setVariable('APPLE_CERTIFICATE_KEYCHAIN', keychainPath);
     } catch (err) {
         tl.setResult(tl.TaskResult.Failed, err);
     } finally {

--- a/Tasks/InstallAppleProvisioningProfile/installprovprofile.ts
+++ b/Tasks/InstallAppleProvisioningProfile/installprovprofile.ts
@@ -20,7 +20,11 @@ async function run() {
                 tl.setTaskVariable('APPLE_PROV_PROFILE_UUID', UUID);
 
                 // set the provisioning profile output variable.
-                tl.setVariable('provProfileUuid', UUID);
+                tl.setVariable('provisioningProfileUuid', UUID);
+
+                // Set the legacy variable that doesn't use the task's refName, unlike our output variables.
+                // If there are multiple InstallAppleCertificate tasks, the last one wins.
+                tl.setVariable('APPLE_PROV_PROFILE_UUID', UUID);                
             } else {
                 throw tl.loc('InputProvisioningProfileNotFound', provProfilePath);
             }

--- a/Tasks/InstallAppleProvisioningProfile/preinstallprovprofile.ts
+++ b/Tasks/InstallAppleProvisioningProfile/preinstallprovprofile.ts
@@ -23,7 +23,11 @@ async function run() {
                 tl.setTaskVariable('APPLE_PROV_PROFILE_UUID', UUID);
 
                 // set the provisioning profile output variable.
-                tl.setVariable('provProfileUuid', UUID);
+                tl.setVariable('provisioningProfileUuid', UUID);
+
+                // Set the legacy variable that doesn't use the task's refName, unlike our output variables.
+                // If there are multiple InstallAppleCertificate tasks, the last one wins.
+                tl.setVariable('APPLE_PROV_PROFILE_UUID', UUID);
             }
         }
 

--- a/Tasks/InstallAppleProvisioningProfile/task.json
+++ b/Tasks/InstallAppleProvisioningProfile/task.json
@@ -66,7 +66,7 @@
     ],
     "outputVariables": [
         {
-            "name": "provProfileUuid",
+            "name": "provisioningProfileUuid",
             "description": "The resolved UUID for the selected provisioning profile."
         }
     ],

--- a/Tasks/InstallAppleProvisioningProfile/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfile/task.loc.json
@@ -66,7 +66,7 @@
   ],
   "outputVariables": [
     {
-      "name": "provProfileUuid",
+      "name": "provisioningProfileUuid",
       "description": "The resolved UUID for the selected provisioning profile."
     }
   ],


### PR DESCRIPTION
Also remove abbreviation from new variable name to match yaml convention.