### PR TITLE
Bump patch versions, remove id regex.

### DIFF
--- a/Tasks/InstallAppleCertificate/task.json
+++ b/Tasks/InstallAppleCertificate/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 126,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/InstallAppleCertificate/task.loc.json
+++ b/Tasks/InstallAppleCertificate/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 126,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/InstallAppleProvisioningProfile/task.json
+++ b/Tasks/InstallAppleProvisioningProfile/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 126,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",
@@ -92,4 +92,3 @@
         "InputProvisioningProfileNotFound": "Provisioning profile to be installed was not found at %s. Specify the full file path to a provisioning profile."
     }
 }
-    

--- a/Tasks/InstallAppleProvisioningProfile/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfile/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 126,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
@@ -54,7 +54,7 @@
   "loc.input.label.destinationSimulators": "Simulators",
   "loc.input.help.destinationSimulators": "An Xcode simulator name. Primarily used for UI testing. For example, `iPhone X` (iOS and watchOS) or `Apple TV 4K` (tvOS). A target OS version is optional and can be specified with OS=versionNumber (`iPhone X,OS=11.1`).",
   "loc.input.label.destinationDevices": "Devices",
-  "loc.input.help.destinationDevices": "A device name or UUID. Primarily used for UI testing. For example, `Chidi’s iPad` or ``.",
+  "loc.input.help.destinationDevices": "A device name. Primarily used for UI testing. For example, `Chidi’s iPad`.",
   "loc.input.label.args": "Arguments",
   "loc.input.help.args": "(Optional) Enter additional command line arguments with which to build. This is useful for specifying `-target` or `-project` arguments instead of specifying a workspace/project and scheme. See the [xcodebuild man page](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/xcodebuild.1.html).",
   "loc.input.label.cwd": "Working directory",

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 4,
         "Minor": 126,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [
         "xcode"
@@ -286,7 +286,7 @@
             "defaultValue": "",
             "required": false,
             "groupName": "devices",
-            "helpMarkDown": "A device name or UUID. Primarily used for UI testing. For example, `Chidi’s iPad` or ``.",
+            "helpMarkDown": "A device name. Primarily used for UI testing. For example, `Chidi’s iPad`.",
             "visibleRule": "destinationPlatformOption != default && destinationPlatformOption != macOS && destinationTypeOption == devices"
         },
         {

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 4,
     "Minor": 126,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [
     "xcode"

--- a/Tasks/Xcode/xcodeutils.ts
+++ b/Tasks/Xcode/xcodeutils.ts
@@ -61,13 +61,8 @@ export function buildDestinationArgs(platform: string, devices: string[], target
                 destination = `platform=${platform}`;
             }
 
-            let matches = device.match(/([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})/i);
-            if (matches) {
-                destination += `,id=${device}`;
-            }
-            else {
-                destination += `,name=${device}`;
-            }
+            // The device name may be followed by additional key-value pairs. Example: "iPhone X,OS=11.1"
+            destination += `,name=${device}`;
 
             tl.debug(`Constructed destination: ${destination}`);
             destinations.push(destination);


### PR DESCRIPTION
The regex only handled simulator ids, not device UDIDs. Removing for now, we can look at how to correctly support simulator ids and device UDIDs if we get requests for this functionality.