### PR TITLE
Revert "Use latest 0.12.0 of mobile-center-cli (#5775)"

### DIFF
--- a/Tasks/VSMobileCenterTest/package.json
+++ b/Tasks/VSMobileCenterTest/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/microsoft/vsts-tasks",
   "dependencies": {
     "glob": "^7.0.6",
-    "mobile-center-cli": "0.12.0",
+    "mobile-center-cli": "0.9.1",
     "vso-node-api": "^6.2.2-preview",
     "vsts-task-lib": "2.0.5"
   }

--- a/Tasks/VSMobileCenterTest/task.json
+++ b/Tasks/VSMobileCenterTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 126,
-        "Patch": 0
+        "Patch": 1
     },
     "groups": [
         {

--- a/Tasks/VSMobileCenterTest/task.loc.json
+++ b/Tasks/VSMobileCenterTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 126,
-    "Patch": 0
+    "Patch": 1
   },
   "groups": [
     {


### PR DESCRIPTION
This reverts commit fa5d8906443469cfba0fb44b29dffc680a296f71 since it broke out canary builds