### PR TITLE
configSections were not being processed

### DIFF
--- a/Tasks/Common/webdeployment-common/Tests/L1XmlVarSub.ts
+++ b/Tasks/Common/webdeployment-common/Tests/L1XmlVarSub.ts
@@ -13,7 +13,8 @@ async function xmlVarSub() {
         'DefaultConnection': "Url=https://primary;Database=db1;ApiKey=11111111-1111-1111-1111-111111111111;Failover = {Url:'https://secondary', ApiKey:'11111111-1111-1111-1111-111111111111'}",
         'OtherDefaultConnection': 'connectionStringValue2',
         'ParameterConnection': 'New_Connection_String From xml var subs',
-        'connectionString': 'replaced_value'
+        'connectionString': 'replaced_value',
+        'NVSReplacementTest': 'replaced_config_value'
     }
 
     var parameterFilePath = path.join(__dirname, 'L1XmlVarSub/parameters_test.xml');

--- a/Tasks/Common/webdeployment-common/Tests/L1XmlVarSub/Web.config
+++ b/Tasks/Common/webdeployment-common/Tests/L1XmlVarSub/Web.config
@@ -13,6 +13,7 @@
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <section name="nameValueSection" requirePermission="false" type="System.Configuration.NameValueSectionHandler,System,Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   </configSections>
   <connectionStrings>
     <add name="DefaultConnection"  conntype="conntype" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\aspnet-AzureWebApp1-20160810012740.mdf;Initial Catalog=aspnet-AzureWebApp1-20160810012740;Integrated Security=True" providerName="System.Data.SqlClient" />
@@ -104,4 +105,7 @@
       <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
+  <nameValueSection>
+		<add key="NVSReplacementTest" value="original_value" />
+	</nameValueSection>
 </configuration>

--- a/Tasks/Common/webdeployment-common/Tests/L1XmlVarSub/Web_Expected.config
+++ b/Tasks/Common/webdeployment-common/Tests/L1XmlVarSub/Web_Expected.config
@@ -13,6 +13,7 @@
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <section name="nameValueSection" requirePermission="false" type="System.Configuration.NameValueSectionHandler,System,Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   </configSections>
   <connectionStrings>
     <add name="DefaultConnection"  conntype="conntype" connectionString="Url=https://primary;Database=db1;ApiKey=11111111-1111-1111-1111-111111111111;Failover = {Url:'https://secondary', ApiKey:'11111111-1111-1111-1111-111111111111'}" providerName="System.Data.SqlClient" />
@@ -104,4 +105,7 @@
       <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
+  <nameValueSection>
+		<add key="NVSReplacementTest" value="replaced_config_value" />
+	</nameValueSection>
 </configuration>

--- a/Tasks/Common/webdeployment-common/xmlvariablesubstitutionutility.ts
+++ b/Tasks/Common/webdeployment-common/xmlvariablesubstitutionutility.ts
@@ -113,7 +113,7 @@ export function substituteXmlVariables(configFile, tags, variableMap, parameterF
     var replacableTokenValues = {};
     var isSubstitutionApplied: boolean = false;
     for(var tag of tags) {
-        var nodes = ltxdomutility.getElementsByTagName(tag); 
+        var nodes = xmlDocument.getChildren(tag); 
         if(nodes.length == 0) {
             tl.debug("Unable to find node with tag '" + tag + "' in provided xml file.");
             continue;
@@ -159,12 +159,13 @@ export function substituteXmlVariables(configFile, tags, variableMap, parameterF
 
 function updateXmlConfigNodeAttribute(xmlDocument, xmlNode, variableMap, replacableTokenValues): boolean {
     var isSubstitutionApplied: boolean = false;
-    var sections = ltxdomutility.getChildElementsByTagName(xmlNode, "section");
-    for(var section of sections) {
+    var sections = xmlNode.getChildren("section");
+    for(var section of sections) {        
         if(varUtility.isObject(section)) {
             var sectionName = section.attr('name');
             if(!varUtility.isEmpty(sectionName)) {
-                var customSectionNodes = ltxdomutility.getElementsByTagName(sectionName);
+                tl.debug("Processing substitution for xml section node : " + sectionName);
+                var customSectionNodes = xmlDocument.getChildren(sectionName);
                 if( customSectionNodes.length != 0) {
                     var customNode = customSectionNodes[0];
                     isSubstitutionApplied = updateXmlNodeAttribute(customNode, variableMap, replacableTokenValues) || isSubstitutionApplied;
@@ -189,11 +190,11 @@ function updateXmlNodeAttribute(xmlDomNode, variableMap, replacableTokenValues):
         var attributeName = (attributeName === "key") ? "value" : attributeName;
         if(variableMap[attributeNameValue]) {
             var ConfigFileAppSettingsTokenName = ConfigFileAppSettingsToken + '(' + attributeNameValue + ')';
-            tl.debug('Updating value for key=' + attributeNameValue + 'with token_value: ' + ConfigFileAppSettingsTokenName);
+            tl.debug('Updating value for key=' + attributeNameValue + ' with token_value: ' + ConfigFileAppSettingsTokenName);
             xmlDomNode.attr(attributeName, ConfigFileAppSettingsTokenName);
             replacableTokenValues[ConfigFileAppSettingsTokenName] =  variableMap[attributeNameValue].replace(/"/g, "'");
             isSubstitutionApplied = true;
-        }
+        }        
     }
     var children = xmlDomNode.children;
     for(var childNode of children) {


### PR DESCRIPTION
configSections were not being processed.  ltxdomutility is a singleton and was being initialized twice.  xmlDocument provides the getChildren facility so ltxdomutility.getElementsByTagName should not be necessary.

#5892