### PR TITLE
force merge to publish results against a single run

### DIFF
--- a/Tasks/PublishTestResults/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishTestResults/Strings/resources.resjson/en-US/resources.resjson
@@ -12,7 +12,7 @@
   "loc.input.label.searchFolder": "Search folder",
   "loc.input.help.searchFolder": "Folder to search for the test result files. Defaults to $(System.DefaultWorkingDirectory).",
   "loc.input.label.mergeTestResults": "Merge test results",
-  "loc.input.help.mergeTestResults": "To merge results from all test results files to one test run in VSTS/TFS, check this option. To create a test run for each test results file, uncheck this option.",
+  "loc.input.help.mergeTestResults": "A test run is created for each results file. Check this option to merge results into a single test run. To optimize for better performance, results will be merged into a single run if there are more than 100 result files, irrespective of this option.",
   "loc.input.label.testRunTitle": "Test run title",
   "loc.input.help.testRunTitle": "Provide a name for the Test Run.",
   "loc.input.label.platform": "Platform",
@@ -20,5 +20,6 @@
   "loc.input.label.configuration": "Configuration",
   "loc.input.help.configuration": "Configuration for which the tests were run.",
   "loc.input.label.publishRunAttachments": "Upload test results files",
-  "loc.input.help.publishRunAttachments": "Opt in/out of publishing test run level attachments. If selected, test result files will be uploaded and attached to test run"
+  "loc.input.help.publishRunAttachments": "Opt in/out of publishing test run level attachments. If selected, test result files will be uploaded and attached to test run",
+  "loc.messages.mergeFiles": "Number of results files is greater than %d. Therefore merging all files to publish results against a single test run."
 }

--- a/Tasks/PublishTestResults/publishtestresults.ts
+++ b/Tasks/PublishTestResults/publishtestresults.ts
@@ -1,6 +1,8 @@
+import * as path from 'path';
 import * as tl from 'vsts-task-lib/task';
 
 const MERGE_THRESHOLD = 100;
+tl.setResourcePath(path.join(__dirname, 'task.json'));
 
 const testRunner = tl.getInput('testRunner', true);
 const testResultsFiles: string[] = tl.getDelimitedInput('testResultsFiles', '\n', true);
@@ -25,7 +27,9 @@ if (isNullOrWhitespace(searchFolder)) {
 
 const matchingTestResultsFiles: string[] = tl.findMatch(searchFolder, testResultsFiles);
 const forceMerge = matchingTestResultsFiles && matchingTestResultsFiles.length > MERGE_THRESHOLD;
-tl.debug(`forceMerge is set to ${forceMerge} based on the the number of Test Results files.`);
+if (forceMerge) {
+    tl.warning(tl.loc('mergeFiles', MERGE_THRESHOLD));
+}
 
 if (!matchingTestResultsFiles || matchingTestResultsFiles.length === 0) {
     tl.warning('No test result files matching ' + testResultsFiles + ' were found.');

--- a/Tasks/PublishTestResults/task.json
+++ b/Tasks/PublishTestResults/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "releaseNotes": "<ul><li>NUnit3 support</li><li>Support for Minimatch files pattern</li></ul>",

--- a/Tasks/PublishTestResults/task.json
+++ b/Tasks/PublishTestResults/task.json
@@ -66,7 +66,7 @@
             "label": "Merge test results",
             "defaultValue": "false",
             "required": false,
-            "helpMarkDown": "To merge results from all test results files to one test run in VSTS/TFS, check this option. To create a test run for each test results file, uncheck this option."
+            "helpMarkDown": "A test run is created for each results file. Check this option to merge results into a single test run. To optimize for better performance, results will be merged into a single run if there are more than 100 result files, irrespective of this option."
         },
         {
             "name": "testRunTitle",
@@ -110,5 +110,8 @@
             "target": "publishtestresults.js",
             "argumentFormat": ""
         }
+    },
+    "messages": {
+        "mergeFiles": "Number of results files is greater than %d. Therefore merging all files to publish results against a single test run."
     }
 }

--- a/Tasks/PublishTestResults/task.loc.json
+++ b/Tasks/PublishTestResults/task.loc.json
@@ -110,5 +110,8 @@
       "target": "publishtestresults.js",
       "argumentFormat": ""
     }
+  },
+  "messages": {
+    "mergeFiles": "ms-resource:loc.messages.mergeFiles"
   }
 }

--- a/Tasks/PublishTestResults/task.loc.json
+++ b/Tasks/PublishTestResults/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tests-Legacy/L0/PublishTestResults/_suite.ts
+++ b/Tests-Legacy/L0/PublishTestResults/_suite.ts
@@ -129,4 +129,46 @@ describe('Publish Test Results Suite', function () {
                 done(err);
             });
     });
+
+    it('Publish test results when number of Test Results files is greater than threshold', (done) => {
+        setResponseFile('response.json');
+
+        const tr = new trm.TaskRunner('PublishTestResults');
+        tr.setInput('testResultsFiles', '**\\n-files*.xml');
+        tr.setInput('testRunner', 'Junit');
+        tr.setInput('mergeTestResults', 'false');
+
+        tr.run()
+            .then(() => {
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.stdout.search(/##vso\[results.publish type=Junit;mergeResults=true/) >= 0, 'mergeResults should be set to true');
+                done();
+            })
+            .fail((err) => {
+                console.log(tr.stdout);
+                done(err);
+            });
+    });
+
+    it('Publish test results when number of Test Results files is less than threshold', (done) => {
+        setResponseFile('response.json');
+
+        const tr = new trm.TaskRunner('PublishTestResults');
+        tr.setInput('testResultsFiles', '**\\TEST-*.xml');
+        tr.setInput('testRunner', 'Junit');
+        tr.setInput('mergeTestResults', 'false');
+
+        tr.run()
+            .then(() => {
+                assert(tr.stderr.length == 0, 'should not have written to stderr. error: ' + tr.stderr);
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.stdout.search(/##vso\[results.publish type=Junit;mergeResults=false/) >= 0, 'should not override mergeResults');
+                done();
+            })
+            .fail((err) => {
+                console.log(tr.stdout);
+                done(err);
+            });
+    });
 });

--- a/Tests-Legacy/L0/PublishTestResults/response.json
+++ b/Tests-Legacy/L0/PublishTestResults/response.json
@@ -4,10 +4,12 @@
             "jUnit1TEST.xml",
             "jUnit2TEST.xml"
         ],
-        "/invalid/*pattern": [
-        ],
+        "/invalid/*pattern": [],
         "TEST.xml": [
             "jUnit1TEST.xml"
+        ],
+        "**\\n-files*.xml": [
+            "n-files0.xml", "n-files1.xml", "n-files2.xml", "n-files3.xml", "n-files4.xml", "n-files5.xml", "n-files6.xml", "n-files7.xml", "n-files8.xml", "n-files9.xml", "n-files10.xml", "n-files11.xml", "n-files12.xml", "n-files13.xml", "n-files14.xml", "n-files15.xml", "n-files16.xml", "n-files17.xml", "n-files18.xml", "n-files19.xml", "n-files20.xml", "n-files21.xml", "n-files22.xml", "n-files23.xml", "n-files24.xml", "n-files25.xml", "n-files26.xml", "n-files27.xml", "n-files28.xml", "n-files29.xml", "n-files30.xml", "n-files31.xml", "n-files32.xml", "n-files33.xml", "n-files34.xml", "n-files35.xml", "n-files36.xml", "n-files37.xml", "n-files38.xml", "n-files39.xml", "n-files40.xml", "n-files41.xml", "n-files42.xml", "n-files43.xml", "n-files44.xml", "n-files45.xml", "n-files46.xml", "n-files47.xml", "n-files48.xml", "n-files49.xml", "n-files50.xml", "n-files51.xml", "n-files52.xml", "n-files53.xml", "n-files54.xml", "n-files55.xml", "n-files56.xml", "n-files57.xml", "n-files58.xml", "n-files59.xml", "n-files60.xml", "n-files61.xml", "n-files62.xml", "n-files63.xml", "n-files64.xml", "n-files65.xml", "n-files66.xml", "n-files67.xml", "n-files68.xml", "n-files69.xml", "n-files70.xml", "n-files71.xml", "n-files72.xml", "n-files73.xml", "n-files74.xml", "n-files75.xml", "n-files76.xml", "n-files77.xml", "n-files78.xml", "n-files79.xml", "n-files80.xml", "n-files81.xml", "n-files82.xml", "n-files83.xml", "n-files84.xml", "n-files85.xml", "n-files86.xml", "n-files87.xml", "n-files88.xml", "n-files89.xml", "n-files90.xml", "n-files91.xml", "n-files92.xml", "n-files93.xml", "n-files94.xml", "n-files95.xml", "n-files96.xml", "n-files97.xml", "n-files98.xml", "n-files99.xml", "n-files100.xml"
         ]
     }
 }


### PR DESCRIPTION
- Results are publish against a single run when number of result files is greater than 100. This overrides the options provided by the user in the task.