### PR TITLE
Fix for Xml variable substitution

### DIFF
--- a/Tasks/AzureRmWebAppDeployment/task.json
+++ b/Tasks/AzureRmWebAppDeployment/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 3,
         "Minor": 3,
-        "Patch": 30
+        "Patch": 31
     },
     "releaseNotes": "What's new in Version 3.0: <br/>&nbsp;&nbsp;Supports File Transformations (XDT) <br/>&nbsp;&nbsp;Supports Variable Substitutions(XML, JSON) <br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more Information.",
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeployment/task.loc.json
+++ b/Tasks/AzureRmWebAppDeployment/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 3,
     "Minor": 3,
-    "Patch": 30
+    "Patch": 31
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/Common/webdeployment-common/Tests/L1XmlVarSub.ts
+++ b/Tasks/Common/webdeployment-common/Tests/L1XmlVarSub.ts
@@ -13,7 +13,8 @@ async function xmlVarSub() {
         'DefaultConnection': "Url=https://primary;Database=db1;ApiKey=11111111-1111-1111-1111-111111111111;Failover = {Url:'https://secondary', ApiKey:'11111111-1111-1111-1111-111111111111'}",
         'OtherDefaultConnection': 'connectionStringValue2',
         'ParameterConnection': 'New_Connection_String From xml var subs',
-        'connectionString': 'replaced_value'
+        'connectionString': 'replaced_value',
+        'invariantName': 'System.Data.SqlServer'
     }
 
     var parameterFilePath = path.join(__dirname, 'L1XmlVarSub/parameters_test.xml');

--- a/Tasks/Common/webdeployment-common/Tests/L1XmlVarSub/Web_Expected.config
+++ b/Tasks/Common/webdeployment-common/Tests/L1XmlVarSub/Web_Expected.config
@@ -95,7 +95,7 @@
       </parameters>
     </defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="System.Data.SqlServer" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
   <system.codedom>

--- a/Tasks/Common/webdeployment-common/ltxdomutility.ts
+++ b/Tasks/Common/webdeployment-common/ltxdomutility.ts
@@ -20,7 +20,7 @@ export class LtxDomUtility  {
         return this.xmlDom;
     }
 
-    public readHeader(xmlContent) {
+    private readHeader(xmlContent) {
         var index = xmlContent.indexOf('\n');
         if(index > -1) {
             var firstLine = xmlContent.substring(0,index).trim();
@@ -37,7 +37,7 @@ export class LtxDomUtility  {
     /**
      * Define method to create a lookup for DOM 
      */
-    public buildLookUpTable(node) {
+    private buildLookUpTable(node) {
         if(node){
             var nodeName = node.name;
             if(nodeName){

--- a/Tasks/Common/webdeployment-common/ltxdomutility.ts
+++ b/Tasks/Common/webdeployment-common/ltxdomutility.ts
@@ -2,89 +2,96 @@ var ltx = require("ltx");
 var varUtility = require("./variableutility.js");
 var Q = require('q');
 
-var xmlDomLookUpTable = {};
-var headerContent;
+export class LtxDomUtility  {
 
-export function initializeDOM(xmlContent) {
-    xmlDomLookUpTable = {};
-    headerContent = null;
-    var xmlDom = ltx.parse(xmlContent);
-    readHeader(xmlContent);
-    buildLookUpTable(xmlDom);
-    return xmlDom;
-}
+    private xmlDomLookUpTable = {};
+    private headerContent;
+    private xmlDom;
 
-function readHeader(xmlContent) {
-    var index = xmlContent.indexOf('\n');
-    if(index > -1) {
-        var firstLine = xmlContent.substring(0,index).trim();
-        if(firstLine.startsWith("<?") && firstLine.endsWith("?>")) {
-            headerContent = firstLine;
+    public constructor(xmlContent) {
+        this.xmlDomLookUpTable = {};
+        this.headerContent = null;
+        this.xmlDom = ltx.parse(xmlContent);
+        this.readHeader(xmlContent);
+        this.buildLookUpTable(this.xmlDom);
+    }
+
+    public getXmlDom() {
+        return this.xmlDom;
+    }
+
+    public readHeader(xmlContent) {
+        var index = xmlContent.indexOf('\n');
+        if(index > -1) {
+            var firstLine = xmlContent.substring(0,index).trim();
+            if(firstLine.startsWith("<?") && firstLine.endsWith("?>")) {
+                this.headerContent = firstLine;
+            }
         }
     }
-}
 
-export function getContentWithHeader(xmlDom) {
-    return xmlDom ? (headerContent ? headerContent + "\n" : "") + xmlDom.root().toString() : "";
-}
+    public getContentWithHeader(xmlDom) {
+        return xmlDom ? (this.headerContent ? this.headerContent + "\n" : "") + xmlDom.root().toString() : "";
+    }
 
-/**
- * Define method to create a lookup for DOM 
- */
-function buildLookUpTable(node) {
-    if(node){
-        var nodeName = node.name;
-        if(nodeName){
-            nodeName = nodeName.toLowerCase();
-            var listOfNodes = xmlDomLookUpTable[nodeName];
-            if(listOfNodes == null || !(Array.isArray(listOfNodes))) {
-                listOfNodes = [];
-                xmlDomLookUpTable[nodeName] = listOfNodes;
-            }
-            listOfNodes.push(node);
-            var childNodes = node.children;
-            for(var i=0 ; i < childNodes.length; i++){
-                var childNodeName = childNodes[i].name;
-                if(childNodeName) {
-                    buildLookUpTable(childNodes[i]);
+    /**
+     * Define method to create a lookup for DOM 
+     */
+    public buildLookUpTable(node) {
+        if(node){
+            var nodeName = node.name;
+            if(nodeName){
+                nodeName = nodeName.toLowerCase();
+                var listOfNodes = this.xmlDomLookUpTable[nodeName];
+                if(listOfNodes == null || !(Array.isArray(listOfNodes))) {
+                    listOfNodes = [];
+                    this.xmlDomLookUpTable[nodeName] = listOfNodes;
+                }
+                listOfNodes.push(node);
+                var childNodes = node.children;
+                for(var i=0 ; i < childNodes.length; i++){
+                    var childNodeName = childNodes[i].name;
+                    if(childNodeName) {
+                        this.buildLookUpTable(childNodes[i]);
+                    }
                 }
             }
         }
     }
-}
 
-/**
- *  Returns array of nodes which match with the tag name.
- */
-export function getElementsByTagName(nodeName) {
-    if(varUtility.isEmpty(nodeName))
-        return [];
-    var selectedElements = xmlDomLookUpTable[nodeName.toLowerCase()];
-    if(!selectedElements){
-        selectedElements = [];
+    /**
+     *  Returns array of nodes which match with the tag name.
+     */
+    public getElementsByTagName(nodeName) {
+        if(varUtility.isEmpty(nodeName))
+            return [];
+        var selectedElements = this.xmlDomLookUpTable[nodeName.toLowerCase()];
+        if(!selectedElements){
+            selectedElements = [];
+        }
+        return selectedElements;
     }
-    return selectedElements;
-}
 
-/**
- *  Search in subtree with provided node name
- */
-export function getChildElementsByTagName(node, tagName) {
-    if(!varUtility.isObject(node) )
-        return [];
-    var children = node.children;
-    var liveNodes = [];
-    if(children){
-        for( var i=0; i < children.length; i++ ){
-            var childName = children[i].name;
-            if( !varUtility.isEmpty(childName) && tagName == childName){
-                liveNodes.push(children[i]);
-            }
-            var liveChildNodes = getChildElementsByTagName(children[i], tagName);
-            if(liveChildNodes && liveChildNodes.length > 0){
-            	liveNodes = liveNodes.concat(liveChildNodes);
+    /**
+     *  Search in subtree with provided node name
+     */
+    public getChildElementsByTagName(node, tagName) {
+        if(!varUtility.isObject(node) )
+            return [];
+        var children = node.children;
+        var liveNodes = [];
+        if(children){
+            for( var i=0; i < children.length; i++ ){
+                var childName = children[i].name;
+                if( !varUtility.isEmpty(childName) && tagName == childName){
+                    liveNodes.push(children[i]);
+                }
+                var liveChildNodes = this.getChildElementsByTagName(children[i], tagName);
+                if(liveChildNodes && liveChildNodes.length > 0){
+                    liveNodes = liveNodes.concat(liveChildNodes);
+                }
             }
         }
+        return liveNodes;
     }
-    return liveNodes;
 }

--- a/Tasks/Common/webdeployment-common/xmlvariablesubstitutionutility.ts
+++ b/Tasks/Common/webdeployment-common/xmlvariablesubstitutionutility.ts
@@ -45,7 +45,8 @@ function substituteValueinParameterFile(parameterFilePath, parameterSubValue) {
     const paramFileReplacableToken = 'PARAM_FILE_REPLACE_TOKEN';
     var paramFileReplacableValues = {};
     try {
-        xmlDocument = ltxdomutility.initializeDOM(webConfigContent);
+        var ltxDomUtiltiyInstance = new ltxdomutility.LtxDomUtility(webConfigContent);
+        xmlDocument = ltxDomUtiltiyInstance.getXmlDom();
         for(var xmlChildNode of xmlDocument.children) {
             if(!varUtility.isObject(xmlChildNode)) {
                 continue;
@@ -62,7 +63,7 @@ function substituteValueinParameterFile(parameterFilePath, parameterSubValue) {
         tl.debug("Unable to parse parameter file : " + parameterFilePath + ' Error: ' + error);
         return;
     }
-    var domContent = (fileEncodeType[1] ? '\uFEFF' : '') + ltxdomutility.getContentWithHeader(xmlDocument);
+    var domContent = (fileEncodeType[1] ? '\uFEFF' : '') + ltxDomUtiltiyInstance.getContentWithHeader(xmlDocument);
     for(var paramFileReplacableValue in paramFileReplacableValues) {
         tl.debug('Parameters file - Replacing value for temp_name: ' + paramFileReplacableValue);
         domContent = domContent.replace(paramFileReplacableValue, paramFileReplacableValues[paramFileReplacableValue]);
@@ -103,7 +104,8 @@ export function substituteXmlVariables(configFile, tags, variableMap, parameterF
     }
     var xmlDocument;
     try{
-        xmlDocument = ltxdomutility.initializeDOM(webConfigContent);
+        var ltxDomUtiltiyInstance = new ltxdomutility.LtxDomUtility(webConfigContent);
+        xmlDocument = ltxDomUtiltiyInstance.getXmlDom();
     } 
     catch(error) {
         tl.debug("Unable to parse file : " + configFile);
@@ -113,7 +115,7 @@ export function substituteXmlVariables(configFile, tags, variableMap, parameterF
     var replacableTokenValues = {};
     var isSubstitutionApplied: boolean = false;
     for(var tag of tags) {
-        var nodes = ltxdomutility.getElementsByTagName(tag); 
+        var nodes = ltxDomUtiltiyInstance.getElementsByTagName(tag); 
         if(nodes.length == 0) {
             tl.debug("Unable to find node with tag '" + tag + "' in provided xml file.");
             continue;
@@ -123,7 +125,7 @@ export function substituteXmlVariables(configFile, tags, variableMap, parameterF
                 tl.debug("Processing substitution for xml node : " + xmlNode.name);
                 try {
                     if(xmlNode.name == "configSections") {
-                        isSubstitutionApplied = updateXmlConfigNodeAttribute(xmlDocument, xmlNode, variableMap, replacableTokenValues) || isSubstitutionApplied;
+                        isSubstitutionApplied = updateXmlConfigNodeAttribute(xmlDocument, xmlNode, variableMap, replacableTokenValues, ltxDomUtiltiyInstance) || isSubstitutionApplied;
                     }
                     else if(xmlNode.name == "connectionStrings") {
                         if(parameterFilePath) {
@@ -144,7 +146,7 @@ export function substituteXmlVariables(configFile, tags, variableMap, parameterF
     }
 
     if(isSubstitutionApplied) {
-        var domContent = ( fileEncodeType[1]? '\uFEFF' : '' ) + ltxdomutility.getContentWithHeader(xmlDocument);
+        var domContent = ( fileEncodeType[1]? '\uFEFF' : '' ) + ltxDomUtiltiyInstance.getContentWithHeader(xmlDocument);
         for(var replacableTokenValue in replacableTokenValues) {
             tl.debug('Substituting original value in place of temp_name: ' + replacableTokenValue);
             domContent = domContent.split(replacableTokenValue).join(replacableTokenValues[replacableTokenValue]);
@@ -157,14 +159,14 @@ export function substituteXmlVariables(configFile, tags, variableMap, parameterF
     }
 }
 
-function updateXmlConfigNodeAttribute(xmlDocument, xmlNode, variableMap, replacableTokenValues): boolean {
+function updateXmlConfigNodeAttribute(xmlDocument, xmlNode, variableMap, replacableTokenValues, ltxDomUtiltiyInstance): boolean {
     var isSubstitutionApplied: boolean = false;
-    var sections = ltxdomutility.getChildElementsByTagName(xmlNode, "section");
+    var sections = ltxDomUtiltiyInstance.getChildElementsByTagName(xmlNode, "section");
     for(var section of sections) {
         if(varUtility.isObject(section)) {
             var sectionName = section.attr('name');
             if(!varUtility.isEmpty(sectionName)) {
-                var customSectionNodes = ltxdomutility.getElementsByTagName(sectionName);
+                var customSectionNodes = ltxDomUtiltiyInstance.getElementsByTagName(sectionName);
                 if( customSectionNodes.length != 0) {
                     var customNode = customSectionNodes[0];
                     isSubstitutionApplied = updateXmlNodeAttribute(customNode, variableMap, replacableTokenValues) || isSubstitutionApplied;

--- a/Tasks/IISWebAppDeploymentOnMachineGroup/task.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroup/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 28
+        "Patch": 29
     },
     "demands": [],
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/IISWebAppDeploymentOnMachineGroup/task.loc.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroup/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 28
+    "Patch": 29
   },
   "demands": [],
   "minimumAgentVersion": "2.104.1",


### PR DESCRIPTION
**Scenario**
Web App package contains web.config and parameters.xml and then xml variable substitution on config section will fail. 

**Cause**
LtxDomUtility class had xmlDomLookUpTable  as global variable and when  initializing  xmlDom for parameters.xml it's overriding lookupUpTable for web.config.

**Fix**
Changed LtxDomUtility to a class. So each instance of class will have it's own lookup table. 