### PR TITLE
Add Java 9 option to drop downs in the Java tasks

### DIFF
--- a/Tasks/ANT/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ANT/Strings/resources.resjson/en-US/resources.resjson
@@ -39,7 +39,7 @@
   "loc.input.label.jdkArchitecture": "JDK Architecture",
   "loc.input.help.jdkArchitecture": "Optionally supply the architecture (x86, x64) of the JDK.",
   "loc.messages.LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please make sure environment variable '%s' exists and is set to the location of a corresponding JDK.",
+  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
   "loc.messages.DiscontinueAntCodeCoverage": "We are discontinuing the support of automated Code Coverage report generation for Ant projects. Please refer https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/ANT/README.md for more details.",
   "loc.messages.NoCodeCoverage": "No code coverage results were found to publish."
 }

--- a/Tasks/ANT/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ANT/Strings/resources.resjson/en-US/resources.resjson
@@ -39,7 +39,7 @@
   "loc.input.label.jdkArchitecture": "JDK Architecture",
   "loc.input.help.jdkArchitecture": "Optionally supply the architecture (x86, x64) of the JDK.",
   "loc.messages.LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
+  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find the specified JDK version. Please ensure the specified JDK version is installed on the agent and the environment variable '%s' exists and is set to the location of a corresponding JDK or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
   "loc.messages.DiscontinueAntCodeCoverage": "We are discontinuing the support of automated Code Coverage report generation for Ant projects. Please refer https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/ANT/README.md for more details.",
   "loc.messages.NoCodeCoverage": "No code coverage results were found to publish."
 }

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -232,7 +232,7 @@
     },
     "messages": {
         "LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please make sure environment variable '%s' exists and is set to the location of a corresponding JDK.",
+        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
         "DiscontinueAntCodeCoverage": "We are discontinuing the support of automated Code Coverage report generation for Ant projects. Please refer https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/ANT/README.md for more details.",
         "NoCodeCoverage": "No code coverage results were found to publish."
    }

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 127,
+        "Minor": 128,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 126,
+        "Minor": 127,
         "Patch": 0
     },
     "demands": [
@@ -232,7 +232,7 @@
     },
     "messages": {
         "LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
+        "FailedToLocateSpecifiedJVM": "Failed to find the specified JDK version. Please ensure the specified JDK version is installed on the agent and the environment variable '%s' exists and is set to the location of a corresponding JDK or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
         "DiscontinueAntCodeCoverage": "We are discontinuing the support of automated Code Coverage report generation for Ant projects. Please refer https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/ANT/README.md for more details.",
         "NoCodeCoverage": "No code coverage results were found to publish."
    }

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -191,6 +191,7 @@
             "visibleRule": "javaHomeSelection = JDKVersion",
             "options": {
                 "default": "default",
+                "1.9": "JDK 9",
                 "1.8": "JDK 8",
                 "1.7": "JDK 7",
                 "1.6": "JDK 6"

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 126,
+    "Minor": 127,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -209,6 +209,7 @@
       "visibleRule": "javaHomeSelection = JDKVersion",
       "options": {
         "default": "default",
+        "1.9": "JDK 9",
         "1.8": "JDK 8",
         "1.7": "JDK 7",
         "1.6": "JDK 6"

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 127,
+    "Minor": 128,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/Common/java-common/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Common/java-common/Strings/resources.resjson/en-US/resources.resjson
@@ -1,4 +1,4 @@
 {
   "loc.messages.LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK."
+  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find the specified JDK version. Please ensure the specified JDK version is installed on the agent and the environment variable '%s' exists and is set to the location of a corresponding JDK or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK."
 }

--- a/Tasks/Common/java-common/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Common/java-common/Strings/resources.resjson/en-US/resources.resjson
@@ -1,4 +1,4 @@
 {
   "loc.messages.LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please make sure environment variable '%s' exists and is set to the location of a corresponding JDK."
+  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details."
 }

--- a/Tasks/Common/java-common/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Common/java-common/Strings/resources.resjson/en-US/resources.resjson
@@ -1,4 +1,4 @@
 {
   "loc.messages.LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details."
+  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK."
 }

--- a/Tasks/Common/java-common/module.json
+++ b/Tasks/Common/java-common/module.json
@@ -1,6 +1,6 @@
 {
   "messages": {
     "LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-    "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please make sure environment variable '%s' exists and is set to the location of a corresponding JDK."
+    "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details."
   }
 }

--- a/Tasks/Common/java-common/module.json
+++ b/Tasks/Common/java-common/module.json
@@ -1,6 +1,6 @@
 {
   "messages": {
     "LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-    "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details."
+    "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK."
   }
 }

--- a/Tasks/Common/java-common/module.json
+++ b/Tasks/Common/java-common/module.json
@@ -1,6 +1,6 @@
 {
   "messages": {
     "LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-    "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK."
+    "FailedToLocateSpecifiedJVM": "Failed to find the specified JDK version. Please ensure the specified JDK version is installed on the agent and the environment variable '%s' exists and is set to the location of a corresponding JDK or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK."
   }
 }

--- a/Tasks/Gradle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Gradle/Strings/resources.resjson/en-US/resources.resjson
@@ -96,6 +96,6 @@
   "loc.messages.codeAnalysisArtifactSummaryTitle": "Code Analysis Results",
   "loc.messages.codeAnalysisDisabled": "Code analysis is disabled outside of the build environment. Could not find a value for: %s",
   "loc.messages.LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please make sure environment variable '%s' exists and is set to the location of a corresponding JDK.",
+  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details.",
   "loc.messages.NoCodeCoverage": "No code coverage results were found to publish."
 }

--- a/Tasks/Gradle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Gradle/Strings/resources.resjson/en-US/resources.resjson
@@ -96,6 +96,6 @@
   "loc.messages.codeAnalysisArtifactSummaryTitle": "Code Analysis Results",
   "loc.messages.codeAnalysisDisabled": "Code analysis is disabled outside of the build environment. Could not find a value for: %s",
   "loc.messages.LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
+  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find the specified JDK version. Please ensure the specified JDK version is installed on the agent and the environment variable '%s' exists and is set to the location of a corresponding JDK or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
   "loc.messages.NoCodeCoverage": "No code coverage results were found to publish."
 }

--- a/Tasks/Gradle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Gradle/Strings/resources.resjson/en-US/resources.resjson
@@ -96,6 +96,6 @@
   "loc.messages.codeAnalysisArtifactSummaryTitle": "Code Analysis Results",
   "loc.messages.codeAnalysisDisabled": "Code analysis is disabled outside of the build environment. Could not find a value for: %s",
   "loc.messages.LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details.",
+  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
   "loc.messages.NoCodeCoverage": "No code coverage results were found to publish."
 }

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -181,6 +181,7 @@
             "visibleRule": "javaHomeSelection = JDKVersion",
             "options": {
                 "default": "default",
+                "1.9": "JDK 9",
                 "1.8": "JDK 8",
                 "1.7": "JDK 7",
                 "1.6": "JDK 6"

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -415,7 +415,7 @@
         "codeAnalysisArtifactSummaryTitle": "Code Analysis Results",
         "codeAnalysisDisabled": "Code analysis is disabled outside of the build environment. Could not find a value for: %s",
         "LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please make sure environment variable '%s' exists and is set to the location of a corresponding JDK.",
+        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details.",
         "NoCodeCoverage": "No code coverage results were found to publish."
     }
 }

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -15,7 +15,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 126,
+        "Minor": 127,
         "Patch": 0
     },
     "demands": [
@@ -415,7 +415,7 @@
         "codeAnalysisArtifactSummaryTitle": "Code Analysis Results",
         "codeAnalysisDisabled": "Code analysis is disabled outside of the build environment. Could not find a value for: %s",
         "LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
+        "FailedToLocateSpecifiedJVM": "Failed to find the specified JDK version. Please ensure the specified JDK version is installed on the agent and the environment variable '%s' exists and is set to the location of a corresponding JDK or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
         "NoCodeCoverage": "No code coverage results were found to publish."
     }
 }

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -15,7 +15,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 127,
+        "Minor": 128,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -415,7 +415,7 @@
         "codeAnalysisArtifactSummaryTitle": "Code Analysis Results",
         "codeAnalysisDisabled": "Code analysis is disabled outside of the build environment. Could not find a value for: %s",
         "LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details.",
+        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
         "NoCodeCoverage": "No code coverage results were found to publish."
     }
 }

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -15,7 +15,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 127,
+    "Minor": 128,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -197,6 +197,7 @@
       "visibleRule": "javaHomeSelection = JDKVersion",
       "options": {
         "default": "default",
+        "1.9": "JDK 9",
         "1.8": "JDK 8",
         "1.7": "JDK 7",
         "1.6": "JDK 6"

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -15,7 +15,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 126,
+    "Minor": 127,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/Maven/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Maven/Strings/resources.resjson/en-US/resources.resjson
@@ -102,7 +102,7 @@
   "loc.messages.codeAnalysisArtifactSummaryTitle": "Code Analysis Results",
   "loc.messages.codeAnalysisDisabled": "Code analysis is disabled outside of the build environment. Could not find a value for: %s",
   "loc.messages.LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details.",
+  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
   "loc.messages.NoCodeCoverage": "No code coverage results were found to publish.",
   "loc.messages.EntryAlreadyExists": "The settings for the feed or repository already exists in the xml file.",
   "loc.messages.EffectivePomInvalid": "Could not parse the effective POM.",

--- a/Tasks/Maven/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Maven/Strings/resources.resjson/en-US/resources.resjson
@@ -102,7 +102,7 @@
   "loc.messages.codeAnalysisArtifactSummaryTitle": "Code Analysis Results",
   "loc.messages.codeAnalysisDisabled": "Code analysis is disabled outside of the build environment. Could not find a value for: %s",
   "loc.messages.LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
+  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find the specified JDK version. Please ensure the specified JDK version is installed on the agent and the environment variable '%s' exists and is set to the location of a corresponding JDK or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
   "loc.messages.NoCodeCoverage": "No code coverage results were found to publish.",
   "loc.messages.EntryAlreadyExists": "The settings for the feed or repository already exists in the xml file.",
   "loc.messages.EffectivePomInvalid": "Could not parse the effective POM.",

--- a/Tasks/Maven/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Maven/Strings/resources.resjson/en-US/resources.resjson
@@ -102,7 +102,7 @@
   "loc.messages.codeAnalysisArtifactSummaryTitle": "Code Analysis Results",
   "loc.messages.codeAnalysisDisabled": "Code analysis is disabled outside of the build environment. Could not find a value for: %s",
   "loc.messages.LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please make sure environment variable '%s' exists and is set to the location of a corresponding JDK.",
+  "loc.messages.FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details.",
   "loc.messages.NoCodeCoverage": "No code coverage results were found to publish.",
   "loc.messages.EntryAlreadyExists": "The settings for the feed or repository already exists in the xml file.",
   "loc.messages.EffectivePomInvalid": "Could not parse the effective POM.",

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -450,7 +450,7 @@
         "codeAnalysisArtifactSummaryTitle": "Code Analysis Results",
         "codeAnalysisDisabled": "Code analysis is disabled outside of the build environment. Could not find a value for: %s",
         "LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
+        "FailedToLocateSpecifiedJVM": "Failed to find the specified JDK version. Please ensure the specified JDK version is installed on the agent and the environment variable '%s' exists and is set to the location of a corresponding JDK or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
         "NoCodeCoverage": "No code coverage results were found to publish.",
         "EntryAlreadyExists": "The settings for the feed or repository already exists in the xml file.",
         "EffectivePomInvalid": "Could not parse the effective POM.",

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -450,7 +450,7 @@
         "codeAnalysisArtifactSummaryTitle": "Code Analysis Results",
         "codeAnalysisDisabled": "Code analysis is disabled outside of the build environment. Could not find a value for: %s",
         "LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please make sure environment variable '%s' exists and is set to the location of a corresponding JDK.",
+        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details.",
         "NoCodeCoverage": "No code coverage results were found to publish.",
         "EntryAlreadyExists": "The settings for the feed or repository already exists in the xml file.",
         "EffectivePomInvalid": "Could not parse the effective POM.",

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 127,
+        "Minor": 128,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -183,6 +183,7 @@
             "visibleRule": "javaHomeSelection = JDKVersion",
             "options": {
                 "default": "default",
+                "1.9": "JDK 9",
                 "1.8": "JDK 8",
                 "1.7": "JDK 7",
                 "1.6": "JDK 6"

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -450,7 +450,7 @@
         "codeAnalysisArtifactSummaryTitle": "Code Analysis Results",
         "codeAnalysisDisabled": "Code analysis is disabled outside of the build environment. Could not find a value for: %s",
         "LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
-        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details.",
+        "FailedToLocateSpecifiedJVM": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
         "NoCodeCoverage": "No code coverage results were found to publish.",
         "EntryAlreadyExists": "The settings for the feed or repository already exists in the xml file.",
         "EffectivePomInvalid": "Could not parse the effective POM.",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -199,6 +199,7 @@
       "visibleRule": "javaHomeSelection = JDKVersion",
       "options": {
         "default": "default",
+        "1.9": "JDK 9",
         "1.8": "JDK 8",
         "1.7": "JDK 7",
         "1.6": "JDK 6"

--- a/Tasks/XamarinAndroid/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/en-US/resources.resjson
@@ -33,7 +33,7 @@
   "loc.input.help.jdkUserInputPath": "Use the JDK version at specified path during build.",
   "loc.input.label.jdkArchitecture": "JDK Architecture",
   "loc.input.help.jdkArchitecture": "Optionally supply the architecture (x86, x64) of JDK.",
-  "loc.messages.JDKNotFound": "Failed to find specified JDK version. Please make sure environment variable %s exists and is set to the location of a corresponding JDK.",
+  "loc.messages.JDKNotFound": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details.",
   "loc.messages.NoMatchingProjects": "No files were found matching: %s.",
   "loc.messages.XamarinAndroidBuildFailed": "%s\nSee https://go.microsoft.com/fwlink/?LinkId=760847.",
   "loc.messages.XamarinAndroidSucceeded": "Xamarin.Android task execution completed with no errors.",

--- a/Tasks/XamarinAndroid/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/en-US/resources.resjson
@@ -33,7 +33,7 @@
   "loc.input.help.jdkUserInputPath": "Use the JDK version at specified path during build.",
   "loc.input.label.jdkArchitecture": "JDK Architecture",
   "loc.input.help.jdkArchitecture": "Optionally supply the architecture (x86, x64) of JDK.",
-  "loc.messages.JDKNotFound": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details.",
+  "loc.messages.JDKNotFound": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
   "loc.messages.NoMatchingProjects": "No files were found matching: %s.",
   "loc.messages.XamarinAndroidBuildFailed": "%s\nSee https://go.microsoft.com/fwlink/?LinkId=760847.",
   "loc.messages.XamarinAndroidSucceeded": "Xamarin.Android task execution completed with no errors.",

--- a/Tasks/XamarinAndroid/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/en-US/resources.resjson
@@ -33,7 +33,7 @@
   "loc.input.help.jdkUserInputPath": "Use the JDK version at specified path during build.",
   "loc.input.label.jdkArchitecture": "JDK Architecture",
   "loc.input.help.jdkArchitecture": "Optionally supply the architecture (x86, x64) of JDK.",
-  "loc.messages.JDKNotFound": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
+  "loc.messages.JDKNotFound": "Failed to find the specified JDK version. Please ensure the specified JDK version is installed on the agent and the environment variable '%s' exists and is set to the location of a corresponding JDK or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
   "loc.messages.NoMatchingProjects": "No files were found matching: %s.",
   "loc.messages.XamarinAndroidBuildFailed": "%s\nSee https://go.microsoft.com/fwlink/?LinkId=760847.",
   "loc.messages.XamarinAndroidSucceeded": "Xamarin.Android task execution completed with no errors.",

--- a/Tasks/XamarinAndroid/task.json
+++ b/Tasks/XamarinAndroid/task.json
@@ -221,7 +221,7 @@
         }
     },
     "messages": {
-        "JDKNotFound": "Failed to find specified JDK version. Please make sure environment variable %s exists and is set to the location of a corresponding JDK.",
+        "JDKNotFound": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details.",
         "NoMatchingProjects": "No files were found matching: %s.",
         "XamarinAndroidBuildFailed": "%s\nSee https://go.microsoft.com/fwlink/?LinkId=760847.",
         "XamarinAndroidSucceeded": "Xamarin.Android task execution completed with no errors.",

--- a/Tasks/XamarinAndroid/task.json
+++ b/Tasks/XamarinAndroid/task.json
@@ -11,7 +11,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 126,
+        "Minor": 127,
         "Patch": 1
     },
     "demands": [
@@ -221,7 +221,7 @@
         }
     },
     "messages": {
-        "JDKNotFound": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
+        "JDKNotFound": "Failed to find the specified JDK version. Please ensure the specified JDK version is installed on the agent and the environment variable '%s' exists and is set to the location of a corresponding JDK or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
         "NoMatchingProjects": "No files were found matching: %s.",
         "XamarinAndroidBuildFailed": "%s\nSee https://go.microsoft.com/fwlink/?LinkId=760847.",
         "XamarinAndroidSucceeded": "Xamarin.Android task execution completed with no errors.",

--- a/Tasks/XamarinAndroid/task.json
+++ b/Tasks/XamarinAndroid/task.json
@@ -221,7 +221,7 @@
         }
     },
     "messages": {
-        "JDKNotFound": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the JavaToolInstaller task to install the desired JDK. Refer to https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer for more details.",
+        "JDKNotFound": "Failed to find specified JDK version. Please ensure specified JDK version is installed on the agent or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK.",
         "NoMatchingProjects": "No files were found matching: %s.",
         "XamarinAndroidBuildFailed": "%s\nSee https://go.microsoft.com/fwlink/?LinkId=760847.",
         "XamarinAndroidSucceeded": "Xamarin.Android task execution completed with no errors.",

--- a/Tasks/XamarinAndroid/task.json
+++ b/Tasks/XamarinAndroid/task.json
@@ -11,7 +11,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 127,
+        "Minor": 128,
         "Patch": 1
     },
     "demands": [

--- a/Tasks/XamarinAndroid/task.json
+++ b/Tasks/XamarinAndroid/task.json
@@ -174,6 +174,7 @@
             "visibleRule": "jdkSelection = JDKVersion",
             "options": {
                 "default": "default",
+                "1.9": "JDK 9",
                 "1.8": "JDK 8",
                 "1.7": "JDK 7",
                 "1.6": "JDK 6"

--- a/Tasks/XamarinAndroid/task.loc.json
+++ b/Tasks/XamarinAndroid/task.loc.json
@@ -190,6 +190,7 @@
       "visibleRule": "jdkSelection = JDKVersion",
       "options": {
         "default": "default",
+        "1.9": "JDK 9",
         "1.8": "JDK 8",
         "1.7": "JDK 7",
         "1.6": "JDK 6"

--- a/Tasks/XamarinAndroid/task.loc.json
+++ b/Tasks/XamarinAndroid/task.loc.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 126,
+    "Minor": 127,
     "Patch": 1
   },
   "demands": [

--- a/Tests-Legacy/L0/ANT/_suite.ts
+++ b/Tests-Legacy/L0/ANT/_suite.ts
@@ -236,7 +236,7 @@ describe('ANT Suite', function() {
                 assert(tr.resultWasSet, 'task should have set a result');
                 assert(tr.stderr.length > 0, 'should have written to stderr');
                 assert(tr.failed, 'task should have failed');
-                assert(tr.stdout.indexOf('Failed to find specified JDK version') >= 0, 'JAVA_HOME set?');
+                assert(tr.stdout.indexOf('Failed to find the specified JDK version') >= 0, 'JAVA_HOME set?');
                 done();
             })
             .fail((err) => {

--- a/Tests-Legacy/L0/Maven/_suite.ts
+++ b/Tests-Legacy/L0/Maven/_suite.ts
@@ -1021,7 +1021,7 @@ describe('Maven Suite', function () {
                 assert(tr.resultWasSet, 'task should have set a result');
                 assert(tr.stderr.length > 0, 'should have written to stderr');
                 assert(tr.failed, 'task should have failed');
-                assert(tr.stdout.indexOf('Failed to find specified JDK version') >= 0, 'JAVA_HOME set?');
+                assert(tr.stdout.indexOf('Failed to find the specified JDK version') >= 0, 'JAVA_HOME set?');
                 done();
             })
             .fail((err) => {

--- a/Tests-Legacy/L0/XamarinAndroid/_suite.ts
+++ b/Tests-Legacy/L0/XamarinAndroid/_suite.ts
@@ -249,7 +249,7 @@ describe('XamarinAndroid Suite', function () {
 				assert(tr.resultWasSet, 'task should have set a result');
 				assert(tr.stderr.length > 0, 'should have written to stderr');
 				assert(tr.failed, 'task should have failed');
-				assert(tr.stdout.indexOf('Failed to find specified JDK version') >= 0, 'JAVA_HOME set?');
+				assert(tr.stdout.indexOf('Failed to find the specified JDK version') >= 0, 'JAVA_HOME set?');
 				done();
 			})
 			.fail((err) => {


### PR DESCRIPTION
Add Java 9 option to drop downs in the Java tasks and update the error message thrown when the requested Java version is not present so that it suggests using the JavaToolInstaller task.