### PR TITLE
Make the build output directory optional to support Xcode's new build system

### DIFF
--- a/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
@@ -60,7 +60,7 @@
   "loc.input.label.cwd": "Working directory",
   "loc.input.help.cwd": "(Optional) Enter the working directory in which to run the build. If no value is entered, the root of the repository will be used.",
   "loc.input.label.outputPattern": "Output directory",
-  "loc.input.help.outputPattern": "Enter a path relative to the working directory where build output (binaries) will be placed. The default value includes variables. When are used, make sure to specify values on the **Variables** tab.",
+  "loc.input.help.outputPattern": "(Optional) Enter a path relative to the working directory where build output (binaries) will be placed. Examples: `output/$(SDK)/$(Configuration)` or `output/$(TestSDK)/$(TestConfiguration)`. Archive and export paths are configured separately.",
   "loc.input.label.useXcpretty": "Use xcpretty",
   "loc.input.help.useXcpretty": "Specify whether to use xcpretty to format xcodebuild output and generate JUnit test results. Enabling this requires xcpretty to be installed on the agent machine. It is preinstalled on VSTS hosted build agents. See [xcpretty](https://github.com/supermarin/xcpretty) on GitHub.",
   "loc.input.label.publishJUnitResults": "Publish to VSTS/TFS",
@@ -87,5 +87,6 @@
   "loc.messages.MultipleSchemesFound": "The workspace contains multiple schemes. No scheme selected. Use `Scheme` to specify a target scheme.",
   "loc.messages.NoSchemeFound": "No shared scheme found in the workspace. Use \"Manage Schemes\" in Xcode to share a scheme.",
   "loc.messages.SchemeSelected": "The workspace contains a single shared scheme. '%s' will be used.",
-  "loc.messages.FailedToFindScheme": "Failed to find a scheme in the workspace. Use `Scheme` to specify a target scheme."
+  "loc.messages.FailedToFindScheme": "Failed to find a scheme in the workspace. Use `Scheme` to specify a target scheme.",
+  "loc.messages.OutputDirectoryIgnored": "Output directory for build output (binaries) ignored. Specifying an output directory is incompatible with the '%s' action."
 }

--- a/Tasks/Xcode/Tests/L0.ts
+++ b/Tasks/Xcode/Tests/L0.ts
@@ -416,7 +416,7 @@ describe('Xcode L0 Suite', function () {
             'PlistBuddy add method should have run.');
 
         //export
-        assert(tr.ran('/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive ' + 
+        assert(tr.ran('/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive ' +
             '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run with -allowProvisioningUpdates to export the IPA from the .xcarchive');
 
@@ -452,15 +452,44 @@ describe('Xcode L0 Suite', function () {
 
         assert(tr.ran("/usr/libexec/PlistBuddy -c Add provisioningProfiles:com.vsts.test.myApp string Bob _XcodeTaskExportOptions.plist"),
             'PlistBuddy add provisioningProfiles:com.vsts.test.myApp should have run.');
-    
+
         //export
-        assert(tr.ran('/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive ' + 
+        assert(tr.ran('/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive ' +
             '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run with -allowProvisioningUpdates to export the IPA from the .xcarchive');
 
         assert(tr.stderr.length == 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.invokedToolCount == 18, 'Should have run \"PlistBuddy -c Add...\" four times, and 14 other command lines.');
+
+        done();
+    });
+
+    it('Task defaults - v4.127.0', (done: MochaDone) => {
+        this.timeout(1000);
+
+        let tp = path.join(__dirname, 'L0TaskDefaults_4.127.0.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        //scheme
+        assert(tr.ran('/home/bin/xcodebuild -workspace /user/build/fun.xcodeproj/project.xcworkspace -list'),
+            'xcodebuild for listing schemes should have been run.');
+
+        //version
+        assert(tr.ran('/home/bin/xcodebuild -version'),
+            'xcodebuild for version should have been run.');
+
+        //build
+        assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
+            '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme funScheme build ' +
+            'CODE_SIGNING_ALLOWED=NO'),
+            'xcodebuild for building the ios project/workspace should have been run.');
+
+        assert(tr.invokedToolCount == 3, 'should have run xcodebuild for scheme list, version and build.');
+        assert(tr.stderr.length == 0, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
 
         done();
     });

--- a/Tasks/Xcode/Tests/L0TaskDefaults_4.127.0.ts
+++ b/Tasks/Xcode/Tests/L0TaskDefaults_4.127.0.ts
@@ -1,0 +1,87 @@
+
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'xcode.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+process.env['HOME'] = '/users/test'; //replace with mock of setVariable when task-lib has the support
+
+// Xcode task defaults used for version 4.127.0.
+tr.setInput('actions', 'build');
+tr.setInput('configuration', '$(Configuration)');
+tr.setInput('sdk', '$(SDK)');
+tr.setInput('xcWorkspacePath', '**/*.xcodeproj/project.xcworkspace');
+tr.setInput('scheme', '');
+tr.setInput('xcodeVersion', 'default');
+tr.setInput('xcodeDeveloperDir', '');
+tr.setInput('packageApp', 'false');
+tr.setInput('archivePath', '');
+tr.setInput('exportPath', 'output/$(SDK)/$(Configuration)');
+tr.setInput('exportOptions', 'auto');
+tr.setInput('exportMethod', 'development');
+tr.setInput('exportTeamId', '');
+tr.setInput('exportOptionsPlist', '');
+tr.setInput('exportArgs', '');
+tr.setInput('signingOption', 'nosign');
+tr.setInput('signingIdentity', '');
+tr.setInput('provisioningProfileUuid', '');
+tr.setInput('teamId', '');
+tr.setInput('destinationPlatformOption', 'default');
+tr.setInput('destinationPlatform', '');
+tr.setInput('destinationTypeOption', 'simulators');
+tr.setInput('destinationSimulators', 'iPhone 7');
+tr.setInput('destinationDevices', '');
+tr.setInput('args', '');
+tr.setInput('cwd', '');
+tr.setInput('outputPattern', '');
+tr.setInput('useXcpretty', 'false');
+tr.setInput('publishJUnitResults', 'false');
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "xcodebuild": "/home/bin/xcodebuild"
+    },
+    "checkPath": {
+        "/home/bin/xcodebuild": true
+    },
+    "filePathSupplied": {
+        "archivePath": false
+    },
+    "getVariable": {
+        "HOME": "/users/test"
+    },
+    "exist": {
+        "/user/build/_XcodeTaskExport_testScheme": false
+    },
+    "stats": {
+        "/user/build": {
+            "isFile": false
+        }
+    },
+    "findMatch": {
+        "**/*.xcodeproj/project.xcworkspace": [
+            "/user/build/fun.xcodeproj/project.xcworkspace"
+        ]
+    },
+    "exec": {
+        "/home/bin/xcodebuild -workspace /user/build/fun.xcodeproj/project.xcworkspace -list": {
+            "code": 0,
+            "stdout": 'Information about workspace "Fun":\n    Schemes:\n        funScheme\n\n'
+        },
+        "/home/bin/xcodebuild -version": {
+            "code": 0,
+            "stdout": "Xcode 7.3.1"
+        },
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme funScheme build CODE_SIGNING_ALLOWED=NO": {
+            "code": 0,
+            "stdout": "xcodebuild output here"
+        }
+    }
+};
+tr.setAnswers(a);
+
+tr.run();
+

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -11,8 +11,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 4,
-        "Minor": 126,
-        "Patch": 7
+        "Minor": 127,
+        "Patch": 0
     },
     "demands": [
         "xcode"
@@ -310,9 +310,8 @@
             "name": "outputPattern",
             "type": "string",
             "label": "Output directory",
-            "defaultValue": "output/$(SDK)/$(Configuration)",
-            "required": true,
-            "helpMarkDown": "Enter a path relative to the working directory where build output (binaries) will be placed. The default value includes variables. When are used, make sure to specify values on the **Variables** tab.",
+            "required": false,
+            "helpMarkDown": "(Optional) Enter a path relative to the working directory where build output (binaries) will be placed. Examples: `output/$(SDK)/$(Configuration)` or `output/$(TestSDK)/$(TestConfiguration)`. Archive and export paths are configured separately.",
             "groupName": "advanced"
         },
         {
@@ -369,6 +368,7 @@
         "MultipleSchemesFound": "The workspace contains multiple schemes. No scheme selected. Use `Scheme` to specify a target scheme.",
         "NoSchemeFound": "No shared scheme found in the workspace. Use \"Manage Schemes\" in Xcode to share a scheme.",
         "SchemeSelected": "The workspace contains a single shared scheme. '%s' will be used.",
-        "FailedToFindScheme": "Failed to find a scheme in the workspace. Use `Scheme` to specify a target scheme."
+        "FailedToFindScheme": "Failed to find a scheme in the workspace. Use `Scheme` to specify a target scheme.",
+        "OutputDirectoryIgnored": "Output directory for build output (binaries) ignored. Specifying an output directory is incompatible with the '%s' action."
     }
 }

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -11,8 +11,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 126,
-    "Patch": 7
+    "Minor": 127,
+    "Patch": 0
   },
   "demands": [
     "xcode"
@@ -310,8 +310,7 @@
       "name": "outputPattern",
       "type": "string",
       "label": "ms-resource:loc.input.label.outputPattern",
-      "defaultValue": "output/$(SDK)/$(Configuration)",
-      "required": true,
+      "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.outputPattern",
       "groupName": "advanced"
     },
@@ -369,6 +368,7 @@
     "MultipleSchemesFound": "ms-resource:loc.messages.MultipleSchemesFound",
     "NoSchemeFound": "ms-resource:loc.messages.NoSchemeFound",
     "SchemeSelected": "ms-resource:loc.messages.SchemeSelected",
-    "FailedToFindScheme": "ms-resource:loc.messages.FailedToFindScheme"
+    "FailedToFindScheme": "ms-resource:loc.messages.FailedToFindScheme",
+    "OutputDirectoryIgnored": "ms-resource:loc.messages.OutputDirectoryIgnored"
   }
 }

--- a/Tests-Legacy/L0/Xcode/_suite.ts
+++ b/Tests-Legacy/L0/Xcode/_suite.ts
@@ -356,7 +356,7 @@ describe('Xcode Suite', function() {
             })
     })
 
-    it('run Xcode with required args not specified', (done) => {
+    it('run Xcode with required arg not specified', (done) => {
      setResponseFile('responseErrorArgs.json');
 
      var tr = new trm.TaskRunner('Xcode', true, true);
@@ -377,29 +377,21 @@ describe('Xcode Suite', function() {
      tr.setInput('publishJUnitResults', 'false');
 
      tr.run()
-         .then(() => {
-             assert(tr.stdout.search(/Input required: outputPattern/) > 0, 'Error should be shown if outputPath is not specified.');
-             tr.setInput('outputPattern', 'output/$(SDK)/$(Configuration)');
-             tr.run()
-                 .then(() => {
-                     assert(tr.stdout.search(/Input required: actions/) > 0, 'Error should be shown if actions are not specified.');
-                     tr.setInput('actions', 'build');
-                     tr.run()
-                        .then(() => {
-                             assert(tr.succeeded, 'Task should have run successfully with required inputs');
-                             done();
-                         })
-                        .fail((err) => {
-                             done(err);
-                         })
-                 })
-                 .fail((err) => {
-                     done(err);
-                 })
-         })
-         .fail((err) => {
-             done(err);
-         })
+        .then(() => {
+            assert(tr.stdout.search(/Input required: actions/) > 0, 'Error should be shown if actions are not specified.');
+            tr.setInput('actions', 'build');
+            tr.run()
+            .then(() => {
+                    assert(tr.succeeded, 'Task should have run successfully with required inputs');
+                    done();
+                })
+            .fail((err) => {
+                    done(err);
+                })
+        })
+        .fail((err) => {
+            done(err);
+        })
     })
 
     it('run Xcode with optional args specified', (done) => {

--- a/Tests-Legacy/L0/Xcode/responseErrorArgs.json
+++ b/Tests-Legacy/L0/Xcode/responseErrorArgs.json
@@ -19,7 +19,7 @@
       "code": 0,
       "stdout": "Xcode 7.3.1"
     },
-    "/home/bin/xcodebuild build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+    "/home/bin/xcodebuild build": {
       "code": 0,
       "stdout": "xcodebuild output here"
     }


### PR DESCRIPTION
In Xcode's current build system, you can't specify OBJROOT, SYMROOT etc with build action `archive`. In the new Swift-based build system preview, the same is also true for build action `clean`. I think most people only want to publish their ipa and possibly their xcarchive, and don't need to define where build intermediates are placed.

When outputPattern is not supplied, ~/Library/Developer/Xcode/DerivedData is used for more intermediates and caches. (It was already referenced some when outputPattern was mandatory.) This means Get source's clean will remove less than it used to. If a user is using an on-prem build agent and wants a completely clean build, they can add `clean` to Xcode actions.

Compatibility:
Because outputPattern was always required before, this change should be backward compatible. Pre-existing build definitions that supply outputPattern will execute the same xcodebuild command lines. `exportPath` still has a default value (`output/$(SDK)/$(Configuration)`).