### PR TITLE
[AppCenterDistribute] Limit release notes max length to 5000

### DIFF
--- a/Tasks/AppCenterDistribute/task.json
+++ b/Tasks/AppCenterDistribute/task.json
@@ -127,7 +127,12 @@
             "label": "Release Notes",
             "required": true,
             "helpMarkDown": "Release notes for this version.",
-            "visibleRule": "releaseNotesSelection = input"
+            "visibleRule": "releaseNotesSelection = input",
+            "properties": {
+                "resizable": "true",
+                "rows": "10",
+                "maxLength": "5000"	
+            }
         },
         {
             "name": "releaseNotesFile",

--- a/Tasks/AppCenterDistribute/task.loc.json
+++ b/Tasks/AppCenterDistribute/task.loc.json
@@ -141,7 +141,12 @@
       "label": "ms-resource:loc.input.label.releaseNotesInput",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.releaseNotesInput",
-      "visibleRule": "releaseNotesSelection = input"
+      "visibleRule": "releaseNotesSelection = input",
+      "properties": {
+        "resizable": "true",
+        "rows": "10",
+        "maxLength": "5000"	
+      }
     },
     {
       "name": "releaseNotesFile",


### PR DESCRIPTION
This PR contains fix for this issue:
https://msmobilecenter.visualstudio.com/Mobile-Center/Distribution/_workitems/edit/29625?triage=false
