### PR TITLE
Remove AndroidSDK demand since Xamarin and the SDK are now installed …

### DIFF
--- a/Tasks/XamarinAndroid/task.json
+++ b/Tasks/XamarinAndroid/task.json
@@ -11,11 +11,10 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 128,
-        "Patch": 1
+        "Minor": 129,
+        "Patch": 0
     },
     "demands": [
-        "AndroidSDK",
         "MSBuild",
         "Xamarin.Android"
     ],

--- a/Tasks/XamarinAndroid/task.loc.json
+++ b/Tasks/XamarinAndroid/task.loc.json
@@ -11,11 +11,10 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 127,
-    "Patch": 1
+    "Minor": 129,
+    "Patch": 0
   },
   "demands": [
-    "AndroidSDK",
     "MSBuild",
     "Xamarin.Android"
   ],


### PR DESCRIPTION
…with VS

AndroidSDK capability detection is not working on some instances of VS, seems like partial install failures leading to some customers having issues: https://github.com/Microsoft/vsts-agent/issues/1043. Xamarin.Android and AndroidSDK are now installed as part of VS install, so Xamarin.Android demand is sufficient to cover both.  