### PR TITLE
Marking RFT as deprecated

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/DeployTestAgent.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/DeployTestAgent.ps1
@@ -2,7 +2,7 @@
 param()
 
 Trace-VstsEnteringInvocation $MyInvocation
-Write-Warning "This task and it’s companion task (Run Functional Tests) are now deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests."
+Write-Warning "This task and it’s companion task (Run Functional Tests) are now deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests. Visit https://aka.ms/testingwithphases for more information."
 try {
     Import-VstsLocStrings "$PSScriptRoot\Task.json"
 

--- a/Tasks/DeployVisualStudioTestAgent/DeployTestAgent.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/DeployTestAgent.ps1
@@ -2,7 +2,7 @@
 param()
 
 Trace-VstsEnteringInvocation $MyInvocation
-Write-Warning "This task is now deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests."
+Write-Warning "This task and it’s companion task (Run Functional Tests) are now deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests."
 try {
     Import-VstsLocStrings "$PSScriptRoot\Task.json"
 

--- a/Tasks/DeployVisualStudioTestAgent/DeployTestAgent.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/DeployTestAgent.ps1
@@ -2,6 +2,7 @@
 param()
 
 Trace-VstsEnteringInvocation $MyInvocation
+Write-Warning "This task is now deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests."
 try {
     Import-VstsLocStrings "$PSScriptRoot\Task.json"
 

--- a/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/en-US/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Visual Studio Test Agent Deployment",
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=838890)",
-  "loc.description": "Deploy and configure Test Agent to run tests on a set of machines",
+  "loc.description": "Deprecated: This task and it’s companion task (Run Functional Tests) are deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
   "loc.instanceNameFormat": "Deploy TestAgent on $(testMachineGroup)",
   "loc.releaseNotes": "<ul><li>Support for Visual Studio Test Agent 2017: You can now deploy and run tests using multiple versions of Visual Studio Test Agent. Versions 2015 and 2017 are supported.</li><li>Machine groups created from the Test hub are no longer supported. You can continue to use a list of machines or Azure resource groups.</li></ul>",
   "loc.group.displayName.testMachineGroups": "Test Machines",

--- a/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/en-US/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Visual Studio Test Agent Deployment",
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=838890)",
-  "loc.description": "Deprecated: This task and it’s companion task (Run Functional Tests) are deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
+  "loc.description": "Deprecated: This task and it’s companion task (Run Functional Tests) are deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the 'Visual Studio Test Platform' task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
   "loc.instanceNameFormat": "Deploy TestAgent on $(testMachineGroup)",
   "loc.releaseNotes": "<ul><li>Support for Visual Studio Test Agent 2017: You can now deploy and run tests using multiple versions of Visual Studio Test Agent. Versions 2015 and 2017 are supported.</li><li>Machine groups created from the Test hub are no longer supported. You can continue to use a list of machines or Azure resource groups.</li></ul>",
   "loc.group.displayName.testMachineGroups": "Test Machines",

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -2,7 +2,7 @@
     "id": "52A38A6A-1517-41D7-96CC-73EE0C60D2B6",
     "name": "DeployVisualStudioTestAgent",
     "friendlyName": "Visual Studio Test Agent Deployment",
-    "description": "Deprecated: Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
+    "description": "Deprecated: This task and it’s companion task (Run Functional Tests) are deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the 'Visual Studio Test Platform' task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=838890)",
     "category": "Test",
     "visibility": [
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 34
+        "Patch": 35
     },
     "deprecated": true,
     "runsOn": [

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,8 +13,9 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 33
+        "Patch": 34
     },
+    "deprecated": true,
     "runsOn": [
         "Agent"
     ],

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -2,7 +2,7 @@
     "id": "52A38A6A-1517-41D7-96CC-73EE0C60D2B6",
     "name": "DeployVisualStudioTestAgent",
     "friendlyName": "Visual Studio Test Agent Deployment",
-    "description": "Deploy and configure Test Agent to run tests on a set of machines",
+    "description": "Deprecated: Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=838890)",
     "category": "Test",
     "visibility": [

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 34
+    "Patch": 35
   },
   "deprecated": true,
   "runsOn": [

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,8 +13,9 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 33
+    "Patch": 34
   },
+  "deprecated": true,
   "runsOn": [
     "Agent"
   ],

--- a/Tasks/RunDistributedTests/RunDistributedTests.ps1
+++ b/Tasks/RunDistributedTests/RunDistributedTests.ps1
@@ -148,7 +148,7 @@ Function Override-TestSettingProperties
     return $hasOverridenProperties
 }
 
-Write-Warning "This task and it’s companion task (Visual Studio Test Agent Deployment) are now deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests."
+Write-Warning "This task and it’s companion task (Visual Studio Test Agent Deployment) are now deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests. Visit https://aka.ms/testingwithphases for more information."
 Write-Verbose "Entering script RunDistributedTests.ps1"
 Write-Verbose "TestMachineGroup = $testMachineGroup"
 Write-Verbose "Test Drop Location = $dropLocation"

--- a/Tasks/RunDistributedTests/RunDistributedTests.ps1
+++ b/Tasks/RunDistributedTests/RunDistributedTests.ps1
@@ -148,7 +148,7 @@ Function Override-TestSettingProperties
     return $hasOverridenProperties
 }
 
-Write-Warning "This task is now deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests."
+Write-Warning "This task and it’s companion task (Visual Studio Test Agent Deployment) are now deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests."
 Write-Verbose "Entering script RunDistributedTests.ps1"
 Write-Verbose "TestMachineGroup = $testMachineGroup"
 Write-Verbose "Test Drop Location = $dropLocation"

--- a/Tasks/RunDistributedTests/RunDistributedTests.ps1
+++ b/Tasks/RunDistributedTests/RunDistributedTests.ps1
@@ -148,6 +148,7 @@ Function Override-TestSettingProperties
     return $hasOverridenProperties
 }
 
+Write-Warning "This task is now deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests."
 Write-Verbose "Entering script RunDistributedTests.ps1"
 Write-Verbose "TestMachineGroup = $testMachineGroup"
 Write-Verbose "Test Drop Location = $dropLocation"

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/en-US/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Run Functional Tests",
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=624389)",
-  "loc.description": "Run Coded UI/Selenium/Functional tests on a set of machines (using Test Agent)",
+  "loc.description": "Deprecated: This task and it’s companion task (Visual Studio Test Agent Deployment) are deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
   "loc.instanceNameFormat": "Run Tests $(sourcefilters) on $(testMachineGroup)",
   "loc.group.displayName.setupOptions": "Setup Options",
   "loc.group.displayName.executionOptions": "Execution Options",

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/en-US/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Run Functional Tests",
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=624389)",
-  "loc.description": "Deprecated: This task and it’s companion task (Visual Studio Test Agent Deployment) are deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
+  "loc.description": "Deprecated: This task and it’s companion task (Visual Studio Test Agent Deployment) are deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the 'Visual Studio Test Platform' task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
   "loc.instanceNameFormat": "Run Tests $(sourcefilters) on $(testMachineGroup)",
   "loc.group.displayName.setupOptions": "Setup Options",
   "loc.group.displayName.executionOptions": "Execution Options",

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -2,7 +2,7 @@
     "id": "D353D6A2-E361-4A8F-8D8C-123BEBB71028",
     "name": "RunVisualStudioTestsusingTestAgent",
     "friendlyName": "Run Functional Tests",
-    "description": "Deprecated: Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
+    "description": "Deprecated: This task and it’s companion task (Visual Studio Test Agent Deployment) are deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the 'Visual Studio Test Platform' task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=624389)",
     "category": "Test",
     "visibility": [
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 55
+        "Patch": 56
     },
     "deprecated": true,
     "runsOn": [

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -2,7 +2,7 @@
     "id": "D353D6A2-E361-4A8F-8D8C-123BEBB71028",
     "name": "RunVisualStudioTestsusingTestAgent",
     "friendlyName": "Run Functional Tests",
-    "description": "Run Coded UI/Selenium/Functional tests on a set of machines (using Test Agent)",
+    "description": "Deprecated: Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent phase setting. Use the ‘Visual Studio Test Platform’ task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=624389)",
     "category": "Test",
     "visibility": [

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -13,8 +13,9 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 54
+        "Patch": 55
     },
+    "deprecated": true,
     "runsOn": [
         "Agent"
     ],

--- a/Tasks/RunDistributedTests/task.loc.json
+++ b/Tasks/RunDistributedTests/task.loc.json
@@ -13,8 +13,9 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 54
+    "Patch": 55
   },
+  "deprecated": true,
   "runsOn": [
     "Agent"
   ],

--- a/Tasks/RunDistributedTests/task.loc.json
+++ b/Tasks/RunDistributedTests/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 55
+    "Patch": 56
   },
   "deprecated": true,
   "runsOn": [


### PR DESCRIPTION
Moving forward, Deploy Test Agent Task and Run Distributed Tests task will not be supported in VSTS. Marking the tests as deprecated.