### PR TITLE
Add lock file to VSMobileCenterTasks

### DIFF
--- a/Tasks/VSMobileCenterUpload/Tests/npm-shrinkwrap.json
+++ b/Tasks/VSMobileCenterUpload/Tests/npm-shrinkwrap.json
@@ -1,0 +1,65 @@
+{
+  "name": "vsts-tasks-vsmobilecenterupload",
+  "version": "1.0.0",
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.0.1",
+      "from": "assertion-error@1.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz"
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz"
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+        }
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+    },
+    "lodash": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.9.0.tgz"
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+    },
+    "propagate": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz"
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz"
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+    }
+  }
+}


### PR DESCRIPTION
A few days ago, the publisher of the assertion-error NPM package published a new package version including .d.ts type files.  Because the release branch is still on TypeScript v1, this broke us.

The fix is to add a package lock file for every task that is breaking so that we do not pull the latest package version.

See also https://github.com/Microsoft/vsts-tasks/commit/aa0c08f29066367205135c304b774eecaaa7613c 