### PR TITLE
Makes the XamarinTestCloud task depreciated

### DIFF
--- a/Tasks/XamarinTestCloud/task.json
+++ b/Tasks/XamarinTestCloud/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 127,
+        "Minor": 129,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/XamarinTestCloud/task.json
+++ b/Tasks/XamarinTestCloud/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 126,
+        "Minor": 127,
         "Patch": 0
     },
     "demands": [],
@@ -24,6 +24,7 @@
             "isExpanded": true
         }
     ],
+    "deprecated": true,
     "inputs": [
         {
             "name": "app",

--- a/Tasks/XamarinTestCloud/task.loc.json
+++ b/Tasks/XamarinTestCloud/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 126,
+    "Minor": 129,
     "Patch": 0
   },
   "demands": [],
@@ -24,6 +24,7 @@
       "isExpanded": true
     }
   ],
+  "deprecated": true,
   "inputs": [
     {
       "name": "app",


### PR DESCRIPTION
### Motivation
To encourage users to start switching over to the new AppCenterTest task.