### PR TITLE
Releases/m129 - Make XamarinTestCloud task depreciated

### DIFF
--- a/Tasks/XamarinTestCloud/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/XamarinTestCloud/Strings/resources.resjson/en-US/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Xamarin Test Cloud",
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613744)",
-  "loc.description": "Test mobile apps with Xamarin Test Cloud using Xamarin.UITest",
+  "loc.description": "[Depreciated] Testing mobile apps with Xamarin Test Cloud using Xamarin.UITest - recommended task is now AppCenterTest",
   "loc.instanceNameFormat": "Test $(app) with Xamarin.UITest in Xamarin Test Cloud",
   "loc.group.displayName.advanced": "Advanced",
   "loc.input.label.app": "App File",

--- a/Tasks/XamarinTestCloud/task.json
+++ b/Tasks/XamarinTestCloud/task.json
@@ -2,7 +2,7 @@
     "id": "049918CB-1488-48EB-85E8-C318ECCAAA74",
     "name": "XamarinTestCloud",
     "friendlyName": "Xamarin Test Cloud",
-    "description": "Test mobile apps with Xamarin Test Cloud using Xamarin.UITest",
+    "description": "[Depreciated] Testing mobile apps with Xamarin Test Cloud using Xamarin.UITest - recommended task is now AppCenterTest",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613744)",
     "category": "Test",
     "visibility": [

--- a/Tasks/XamarinTestCloud/task.json
+++ b/Tasks/XamarinTestCloud/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 127,
+        "Minor": 129,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/XamarinTestCloud/task.json
+++ b/Tasks/XamarinTestCloud/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 126,
+        "Minor": 127,
         "Patch": 0
     },
     "demands": [],
@@ -24,6 +24,7 @@
             "isExpanded": true
         }
     ],
+    "deprecated": true,
     "inputs": [
         {
             "name": "app",

--- a/Tasks/XamarinTestCloud/task.loc.json
+++ b/Tasks/XamarinTestCloud/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 126,
+    "Minor": 129,
     "Patch": 0
   },
   "demands": [],
@@ -24,6 +24,7 @@
       "isExpanded": true
     }
   ],
+  "deprecated": true,
   "inputs": [
     {
       "name": "app",


### PR DESCRIPTION
### Motivation
Depreciated in favour of AppCenterTest task.