### PR TITLE
include extra help to deal with the special handling of the domain ov…

### DIFF
--- a/Tasks/PowerShellOnTargetMachines/task.json
+++ b/Tasks/PowerShellOnTargetMachines/task.json
@@ -44,7 +44,7 @@
             "label": "Admin Login",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Administrator login for the target machines."
+            "helpMarkDown": "Administrator login for the target machines. <br> Eg: Format: Domain\\Admin User, Admin User@Domain, .\\Admin User"
         },
         {
             "name": "AdminPassword",


### PR DESCRIPTION
…erride of the login

As I think the way this PowershellOnTargetMachines deals with the domain attribute of the login, it would be good to include it explicitly in the short help text.

(Special in the sense that if you 'normally' start a new remote Powershell Session the fact that the machine is running on a domain pretty much ensures that the user you are using is a domain user. This task *specifically* overrides this default behavior.)