### PR TITLE
Android Signing: Default value of **/*.apk for APK files

### DIFF
--- a/Tasks/AndroidSigning/task.json
+++ b/Tasks/AndroidSigning/task.json
@@ -11,7 +11,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 126,
+        "Minor": 130,
         "Patch": 0
     },
     "demands": [
@@ -36,7 +36,7 @@
             "name": "files",
             "type": "filePath",
             "label": "APK Files",
-            "defaultValue": "",
+            "defaultValue": "**/*.apk",
             "required": true,
             "helpMarkDown": "Relative path from the repo root to the APK(s) you want to sign. You can use wildcards to specify multiple files. For example, `**/bin/*.apk` for all .APK files in the 'bin' subfolder."
         },

--- a/Tasks/AndroidSigning/task.json
+++ b/Tasks/AndroidSigning/task.json
@@ -34,6 +34,7 @@
     "inputs": [
         {
             "name": "files",
+            "aliases": ["apkFiles"],
             "type": "filePath",
             "label": "APK Files",
             "defaultValue": "**/*.apk",

--- a/Tasks/AndroidSigning/task.loc.json
+++ b/Tasks/AndroidSigning/task.loc.json
@@ -34,6 +34,9 @@
   "inputs": [
     {
       "name": "files",
+      "aliases": [
+        "apkFiles"
+      ],
       "type": "filePath",
       "label": "ms-resource:loc.input.label.files",
       "defaultValue": "**/*.apk",

--- a/Tasks/AndroidSigning/task.loc.json
+++ b/Tasks/AndroidSigning/task.loc.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 126,
+    "Minor": 130,
     "Patch": 0
   },
   "demands": [
@@ -36,7 +36,7 @@
       "name": "files",
       "type": "filePath",
       "label": "ms-resource:loc.input.label.files",
-      "defaultValue": "",
+      "defaultValue": "**/*.apk",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.files"
     },


### PR DESCRIPTION
The Android build template already defaults to this value.  This change adds the same default value to the Android Signing task.