### PR TITLE
Fix/appcenter spacing issue latest cli

### DIFF
--- a/Tasks/AppCenterTest/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AppCenterTest/Strings/resources.resjson/en-US/resources.resjson
@@ -2,7 +2,7 @@
   "loc.friendlyName": "App Center Test",
   "loc.helpMarkDown": "For help with this task, visit the Visual Studio App Center [support site](https://aka.ms/appcentersupport).",
   "loc.description": "Test app packages with Visual Studio App Center.",
-  "loc.instanceNameFormat": "Test $(app) with Visual Studio App Center",
+  "loc.instanceNameFormat": "Test with Visual Studio App Center",
   "loc.group.displayName.prepare": "Prepare Tests",
   "loc.group.displayName.run": "Run Tests",
   "loc.group.displayName.advanced": "Advanced",

--- a/Tasks/AppCenterTest/appcentertest.ts
+++ b/Tasks/AppCenterTest/appcentertest.ts
@@ -156,12 +156,6 @@ function getLoginRunner(cliPath: string, debug: boolean, credsType: string): Too
     return loginRunner;
 }
 
-function getVersionRunner(cliPath: string): ToolRunner {
-    let versionRunner = tl.tool(cliPath);
-    versionRunner.arg('-v');
-    return versionRunner;
-}
-
 function getTestRunner(cliPath: string, debug: boolean, app: string, artifactsDir: string, credsType: string): ToolRunner {
     let testRunner = tl.tool(cliPath);
     let appSlug: string = tl.getInput('appSlug', true);
@@ -249,9 +243,6 @@ async function run() {
 
         // Get app info
         let app = resolveInputPatternToOneFile('app', true, "Binary File");
-
-        let versionRunner = getVersionRunner(cliPath);
-        await versionRunner.exec();
 
         // Test prepare
         if (prepareTests) {

--- a/Tasks/AppCenterTest/appcentertest.ts
+++ b/Tasks/AppCenterTest/appcentertest.ts
@@ -156,6 +156,12 @@ function getLoginRunner(cliPath: string, debug: boolean, credsType: string): Too
     return loginRunner;
 }
 
+function getVersionRunner(cliPath: string): ToolRunner {
+    let versionRunner = tl.tool(cliPath);
+    versionRunner.arg('-v');
+    return versionRunner;
+}
+
 function getTestRunner(cliPath: string, debug: boolean, app: string, artifactsDir: string, credsType: string): ToolRunner {
     let testRunner = tl.tool(cliPath);
     let appSlug: string = tl.getInput('appSlug', true);
@@ -243,6 +249,9 @@ async function run() {
 
         // Get app info
         let app = resolveInputPatternToOneFile('app', true, "Binary File");
+
+        let versionRunner = getVersionRunner(cliPath);
+        await versionRunner.exec();
 
         // Test prepare
         if (prepareTests) {

--- a/Tasks/AppCenterTest/package.json
+++ b/Tasks/AppCenterTest/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/microsoft/vsts-tasks",
   "dependencies": {
     "glob": "^7.0.6",
-    "appcenter-cli": "1.0.3",
+    "appcenter-cli": "1.0.7",
     "vso-node-api": "^6.2.2-preview",
     "vsts-task-lib": "2.0.5"
   }

--- a/Tasks/AppCenterTest/task.json
+++ b/Tasks/AppCenterTest/task.json
@@ -11,7 +11,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 126,
+        "Minor": 127,
         "Patch": 0
     },
     "groups": [
@@ -434,7 +434,7 @@
             "helpMarkDown": "Add --debug to appcenter cli."
         }
     ],
-    "instanceNameFormat": "Test $(app) with Visual Studio App Center",
+    "instanceNameFormat": "Test with Visual Studio App Center",
     "execution": {
         "Node": {
             "target": "appcentertest.js",

--- a/Tasks/AppCenterTest/task.json
+++ b/Tasks/AppCenterTest/task.json
@@ -11,7 +11,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 127,
+        "Minor": 129,
         "Patch": 0
     },
     "groups": [

--- a/Tasks/AppCenterTest/task.json
+++ b/Tasks/AppCenterTest/task.json
@@ -422,7 +422,7 @@
             "defaultValue": "",
             "required": false ,
             "helpMarkDown": "Path to appcenter CLI on the build or release agent."
-        },        
+        },
         {
             "name": "debug",
             "aliases": [ "showDebugOutput" ],

--- a/Tasks/AppCenterTest/task.loc.json
+++ b/Tasks/AppCenterTest/task.loc.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 126,
+    "Minor": 129,
     "Patch": 0
   },
   "groups": [


### PR DESCRIPTION
### Motivation
Fixes L0 tests broken by addition of `appcenter -v` to console output.