### PR TITLE
Include prerelease versions when looking up Willow instances

### DIFF
--- a/Tasks/Common/MSBuildHelpers/PathFunctions.ps1
+++ b/Tasks/Common/MSBuildHelpers/PathFunctions.ps1
@@ -183,7 +183,7 @@ function Get-VisualStudio_15_0 {
                 # may be something like 15.2.
                 Write-Verbose "Getting latest Visual Studio 15 setup instance."
                 $output = New-Object System.Text.StringBuilder
-                Invoke-VstsTool -FileName "$PSScriptRoot\vswhere.exe" -Arguments "-version [15.0,16.0) -latest -format json" -RequireExitCodeZero 2>&1 |
+                Invoke-VstsTool -FileName "$PSScriptRoot\vswhere.exe" -Arguments "-version [15.0,16.0) -latest -prerelease -format json" -RequireExitCodeZero 2>&1 |
                     ForEach-Object {
                         if ($_ -is [System.Management.Automation.ErrorRecord]) {
                             Write-Verbose "STDERR: $($_.Exception.Message)"
@@ -202,7 +202,7 @@ function Get-VisualStudio_15_0 {
                     # the same scheme. It appears to follow the 15.<UPDATE_NUMBER>.* versioning scheme.
                     Write-Verbose "Getting latest BuildTools 15 setup instance."
                     $output = New-Object System.Text.StringBuilder
-                    Invoke-VstsTool -FileName "$PSScriptRoot\vswhere.exe" -Arguments "-version [15.0,16.0) -products Microsoft.VisualStudio.Product.BuildTools -latest -format json" -RequireExitCodeZero 2>&1 |
+                    Invoke-VstsTool -FileName "$PSScriptRoot\vswhere.exe" -Arguments "-version [15.0,16.0) -products Microsoft.VisualStudio.Product.BuildTools -latest -prerelease -format json" -RequireExitCodeZero 2>&1 |
                         ForEach-Object {
                             if ($_ -is [System.Management.Automation.ErrorRecord]) {
                                 Write-Verbose "STDERR: $($_.Exception.Message)"


### PR DESCRIPTION
This allows build agents to be provisioned with release candidate builds of Visual Studio.

Ideally this could be parameterized from the Visual Studio Build task so that you can toggle prerelease on/off or alternatively specify a custom `installationVersion` value. In the meantime this is a stopgap so that the aforementioned scenario is achievable.