### PR TITLE
Fixing PyPI task's description. Fixing out-of-sync task.loc.json

### DIFF
--- a/Tasks/PyPIPublisher/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PyPIPublisher/Strings/resources.resjson/en-US/resources.resjson
@@ -1,10 +1,12 @@
 {
   "loc.friendlyName": "PyPI Publisher",
   "loc.helpMarkDown": "[More Information](https://aka.ms/pypipublisher)",
-  "loc.description": "Publish Python packages to the PyPI",
+  "loc.description": "Publish Python packages to PyPI",
   "loc.instanceNameFormat": "PyPI Publisher",
   "loc.input.label.serviceEndpoint": "PyPI connection",
   "loc.input.help.serviceEndpoint": "Select the generic service endpoint where PyPI server details are present. \n\nNote: To configure a new generic service endpoint, under your VSTS project, go to Settings -> Services -> New Service Endpoint -> Generic. \n\nConnection Name – Use a friendly connection name of your choice. \nServer URL – PyPI package server (for example: https://upload.pypi.org/legacy/). \nUser Name – PyPI registered username. \nPassword – password for your PyPI account",
   "loc.input.label.wd": "Python package path",
-  "loc.input.help.wd": "Python package directory to be published, where setup.py is present."
+  "loc.input.help.wd": "Python package directory to be published, where setup.py is present.",
+  "loc.input.label.wheel": "Upload wheel",
+  "loc.input.help.wheel": "If checked, then task will additionally build and publish universal wheel (platform independent) of this package. For more information regarding universal wheel [see here](https://packaging.python.org/tutorials/distributing-packages/#wheels)."
 }

--- a/Tasks/PyPIPublisher/task.json
+++ b/Tasks/PyPIPublisher/task.json
@@ -2,7 +2,7 @@
   "id": "2d8a1d60-8ccd-11e7-a792-11ac56e9f553",
   "name": "PyPIPublisher",
   "friendlyName": "PyPI Publisher",
-  "description": "Publish Python packages to the PyPI",
+  "description": "Publish Python packages to PyPI",
   "author": "Microsoft Corporation",
   "helpMarkDown": "[More Information](https://aka.ms/pypipublisher)",
   "category": "Utility",

--- a/Tasks/PyPIPublisher/task.loc.json
+++ b/Tasks/PyPIPublisher/task.loc.json
@@ -14,11 +14,18 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [
+    {
+      "name": "serviceEndpoint",
+      "type": "connectedService:generic",
+      "label": "ms-resource:loc.input.label.serviceEndpoint",
+      "required": true,
+      "helpMarkDown": "ms-resource:loc.input.help.serviceEndpoint"
+    },
     {
       "name": "wd",
       "type": "filePath",
@@ -27,11 +34,12 @@
       "helpMarkDown": "ms-resource:loc.input.help.wd"
     },
     {
-      "name": "serviceEndpoint",
-      "type": "connectedService:generic",
-      "label": "ms-resource:loc.input.label.serviceEndpoint",
-      "required": true,
-      "helpMarkDown": "ms-resource:loc.input.help.serviceEndpoint"
+      "name": "wheel",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.wheel",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.wheel"
     }
   ],
   "execution": {


### PR DESCRIPTION
https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/PyPIPublisher/task.json

"PyPI" does not get prefixed with "the." See the official docs: https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi

also looks like task.loc.json did not get updated with version 0.1.1.