### PR TITLE
Instead of setting GOPATH and GOBIN in installer, it will be moved to…

### DIFF
--- a/Tasks/GoTool/gotool.ts
+++ b/Tasks/GoTool/gotool.ts
@@ -100,8 +100,6 @@ function setGoEnvironmentVariables(goRoot: string) {
 
     let defaultDirectory = tl.getVariable('System.DefaultWorkingDirectory');
     tl.setVariable('GOROOT', goRoot);
-    tl.setVariable('GOPATH', defaultDirectory);
-    tl.setVariable('GOBIN', path.join(defaultDirectory, 'bin'));
 }
 
 run();

--- a/Tasks/GoTool/gotool.ts
+++ b/Tasks/GoTool/gotool.ts
@@ -97,8 +97,6 @@ function getDownloadUrl(filename: string): string {
 }
 
 function setGoEnvironmentVariables(goRoot: string) {
-
-    let defaultDirectory = tl.getVariable('System.DefaultWorkingDirectory');
     tl.setVariable('GOROOT', goRoot);
 }
 


### PR DESCRIPTION
Will not set the GOPATH and GOBIN explicitly. Instead we will use their default value