### PR TITLE
check load test name before creating a load test definition. We seen …

### DIFF
--- a/Tasks/QuickPerfTest/CltTasksUtility.ps1
+++ b/Tasks/QuickPerfTest/CltTasksUtility.ps1
@@ -166,7 +166,7 @@ function ComposeAccountUrl($connectedServiceUrl, $headers)
 	return $elsUrl
 }
 
-function ValidateInputs($websiteUrl, $tfsCollectionUrl, $connectedServiceName)
+function ValidateInputs($websiteUrl, $tfsCollectionUrl, $connectedServiceName, $testName)
 {
 	if (![System.Uri]::IsWellFormedUriString($websiteUrl, [System.UriKind]::Absolute))
 	{
@@ -177,6 +177,20 @@ function ValidateInputs($websiteUrl, $tfsCollectionUrl, $connectedServiceName)
 	{
 		throw "VS Team Services Connection is mandatory for using performance test tasks on non hosted TFS builds.Please specify a VS Team Services connection and try again "
 	}
+
+    # validate load test name
+    # code taken from definitionNameInvalid    
+    $invalidPattern1 = "(^\\.$|^\\.\\.$|^-$|^_$)"
+    $invalidPattern2 = "[^A-Za-z0-9 \._-]"
+
+    # find illegal characters
+    $invalidchars1 = [regex]::Matches($pathToCheck, $invalidPattern1, 'IgnoreCase').Value | Sort-Object -Unique 
+    $invalidchars2 =[regex]::Matches($pathToCheck, $invalidPattern2, 'IgnoreCase').Value | Sort-Object -Unique 
+    
+    if ($invalidchars1 -ne $null -or $invalidchars2 -ne $null)
+    {
+      "Do not use these characters in load test name: $invalidchars1 $invalidchars2"
+    }
 }
 
 function UploadSummaryMdReport($summaryMdPath)

--- a/Tasks/QuickPerfTest/CltTasksUtility.ps1
+++ b/Tasks/QuickPerfTest/CltTasksUtility.ps1
@@ -184,12 +184,12 @@ function ValidateInputs($websiteUrl, $tfsCollectionUrl, $connectedServiceName, $
     $invalidPattern2 = "[^A-Za-z0-9 \._-]"
 
     # find illegal characters
-    $invalidchars1 = [regex]::Matches($pathToCheck, $invalidPattern1, 'IgnoreCase').Value | Sort-Object -Unique 
-    $invalidchars2 =[regex]::Matches($pathToCheck, $invalidPattern2, 'IgnoreCase').Value | Sort-Object -Unique 
+    $invalidchars1 = [regex]::Matches($testName, $invalidPattern1, 'IgnoreCase').Value | Sort-Object -Unique 
+    $invalidchars2 =[regex]::Matches($testName, $invalidPattern2, 'IgnoreCase').Value | Sort-Object -Unique 
     
     if ($invalidchars1 -ne $null -or $invalidchars2 -ne $null)
     {
-      "Do not use these characters in load test name: $invalidchars1 $invalidchars2"
+		throw "Do not use these characters in load test name: $invalidchars1 $invalidchars2"
     }
 }
 

--- a/Tasks/QuickPerfTest/Invoke-QuickPerfTest.ps1
+++ b/Tasks/QuickPerfTest/Invoke-QuickPerfTest.ps1
@@ -92,7 +92,7 @@ Write-Output "Load generator machine type = $machineType"
 Write-Output "Run source identifier = build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
 
 #Validate Input
-ValidateInputs $websiteUrl $env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI $connectedServiceName
+ValidateInputs $websiteUrl $env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI $connectedServiceName $testName
 
 #Process Threshold Rules
 Write-Output "Initializing threshold rule for avg. response time with value(ms) : $avgResponseTimeThreshold "

--- a/Tasks/QuickPerfTest/task.json
+++ b/Tasks/QuickPerfTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 25
+        "Patch": 26
     },
     "demands": [
         "msbuild",

--- a/Tasks/QuickPerfTest/task.json
+++ b/Tasks/QuickPerfTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 26
+        "Patch": 27
     },
     "demands": [
         "msbuild",

--- a/Tasks/QuickPerfTest/task.loc.json
+++ b/Tasks/QuickPerfTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 25
+    "Patch": 26
   },
   "demands": [
     "msbuild",

--- a/Tasks/QuickPerfTest/task.loc.json
+++ b/Tasks/QuickPerfTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 26
+    "Patch": 27
   },
   "demands": [
     "msbuild",

--- a/Tasks/RunJMeterLoadTest/CltTasksUtility.ps1
+++ b/Tasks/RunJMeterLoadTest/CltTasksUtility.ps1
@@ -182,6 +182,20 @@ function ValidateInputs($tfsCollectionUrl, $connectedServiceName, $testDrop, $lo
         ErrorMessage "The path for the load test files does not exist. Please provide a valid path."
     }
 
+    # validate load test name
+    # code taken from definitionNameInvalid    
+    $invalidPattern1 = "(^\\.$|^\\.\\.$|^-$|^_$)"
+    $invalidPattern2 = "[^A-Za-z0-9 \._-]"
+
+    # find illegal characters
+    $invalidchars1 = [regex]::Matches($loadtest, $invalidPattern1, 'IgnoreCase').Value | Sort-Object -Unique 
+    $invalidchars2 =[regex]::Matches($loadtest, $invalidPattern2, 'IgnoreCase').Value | Sort-Object -Unique 
+    
+    if ($invalidchars1 -ne $null -or $invalidchars2 -ne $null)
+    {
+        throw "Do not use these characters in load test name: $invalidchars1 $invalidchars2"
+    }
+
     ValidateFiles "load test file" $loadTest
 }
 

--- a/Tasks/RunJMeterLoadTest/task.json
+++ b/Tasks/RunJMeterLoadTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 18
+        "Patch": 19
     },
     "demands": [
         "azureps"

--- a/Tasks/RunJMeterLoadTest/task.loc.json
+++ b/Tasks/RunJMeterLoadTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 18
+    "Patch": 19
   },
   "demands": [
     "azureps"

--- a/Tasks/RunLoadTest/CltTasksUtility.ps1
+++ b/Tasks/RunLoadTest/CltTasksUtility.ps1
@@ -227,6 +227,20 @@ function ValidateFiles($inputName, $loadtestDrop, $fileName, $testSettings)
 function ValidateInputs($tfsCollectionUrl, $connectedServiceName, $testSettings, $loadtestDrop, $loadtest)
 {
     ValidateFiles "load test file" $loadtestDrop $loadTest $testSettings
+
+    # validate load test name
+    # code taken from definitionNameInvalid    
+    $invalidPattern1 = "(^\\.$|^\\.\\.$|^-$|^_$)"
+    $invalidPattern2 = "[^A-Za-z0-9 \._-]"
+
+    # find illegal characters
+    $invalidchars1 = [regex]::Matches($loadtest, $invalidPattern1, 'IgnoreCase').Value | Sort-Object -Unique 
+    $invalidchars2 =[regex]::Matches($loadtest, $invalidPattern2, 'IgnoreCase').Value | Sort-Object -Unique 
+    
+    if ($invalidchars1 -ne $null -or $invalidchars2 -ne $null)
+    {
+      throw "Do not use these characters in load test name: $invalidchars1 $invalidchars2"
+    }
 }
 
 function Get($headers, $uri)

--- a/Tasks/RunLoadTest/task.json
+++ b/Tasks/RunLoadTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 25
+        "Patch": 26
     },
     "demands": [
         "msbuild",

--- a/Tasks/RunLoadTest/task.loc.json
+++ b/Tasks/RunLoadTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 25
+    "Patch": 26
   },
   "demands": [
     "msbuild",


### PR DESCRIPTION
check load test name before creating a load test definition. We seen in past invalid path chars in file name causing error runs
