### PR TITLE
ServiceFabricDeploy: Allow only registering/creating

### DIFF
--- a/Tasks/ServiceFabricDeploy/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ServiceFabricDeploy/Strings/resources.resjson/en-US/resources.resjson
@@ -14,6 +14,8 @@
   "loc.input.help.publishProfilePath": "Path to the publish profile that defines the settings to use. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) and wildcards can be used in the path.",
   "loc.input.label.applicationParameterPath": "Application Parameters",
   "loc.input.help.applicationParameterPath": "Path to the application parameters file. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) and wildcards can be used in the path. If specified, this will override the value in the publish profile.",
+  "loc.input.label.action": "Action",
+  "loc.input.help.action": "Determines the action performed by this task. **Register**: Registers the application type in the cluster. **Create**: Creates or upgrades an application instance.",
   "loc.input.label.compressPackage": "Compress Package",
   "loc.input.help.compressPackage": "Indicates whether the application package should be compressed before copying to the image store. If enabled, this will override the value in the publish profile.",
   "loc.input.label.useDiffPackage": "Use Diff Package",

--- a/Tasks/ServiceFabricDeploy/Tests/AadDeploy.ps1
+++ b/Tasks/ServiceFabricDeploy/Tests/AadDeploy.ps1
@@ -21,6 +21,7 @@ $overwriteBehavior = "SameAppTypeAndVersion"
 Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
+Register-Mock Get-VstsInput { "RegisterAndCreate" } -- -Name action -Require
 Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
 Register-Mock Get-VstsInput { $overwriteBehavior } -- -Name overwriteBehavior
 Register-Mock Get-VstsInput { "false" } -- -Name skipUpgradeSameTypeAndVersion

--- a/Tasks/ServiceFabricDeploy/Tests/CertDeploy.ps1
+++ b/Tasks/ServiceFabricDeploy/Tests/CertDeploy.ps1
@@ -15,6 +15,7 @@ $overwriteBehavior = "SameAppTypeAndVersion"
 Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
+Register-Mock Get-VstsInput { "RegisterAndCreate" } -- -Name action -Require
 Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
 Register-Mock Get-VstsInput { $overwriteBehavior } -- -Name overwriteBehavior
 Register-Mock Get-VstsInput { "false" } -- -Name skipUpgradeSameTypeAndVersion

--- a/Tasks/ServiceFabricDeploy/Tests/CertDeployWithDocker.ps1
+++ b/Tasks/ServiceFabricDeploy/Tests/CertDeployWithDocker.ps1
@@ -18,6 +18,7 @@ $servicePrincipalKey = "random spn key"
 Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
+Register-Mock Get-VstsInput { "RegisterAndCreate" } -- -Name action -Require
 Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
 Register-Mock Get-VstsInput { $overwriteBehavior } -- -Name overwriteBehavior
 Register-Mock Get-VstsInput { "false" } -- -Name skipUpgradeSameTypeAndVersion

--- a/Tasks/ServiceFabricDeploy/Tests/CertDeployWithDockerMultiThumbprint.ps1
+++ b/Tasks/ServiceFabricDeploy/Tests/CertDeployWithDockerMultiThumbprint.ps1
@@ -21,6 +21,7 @@ $servicePrincipalKey = "random spn key"
 Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
+Register-Mock Get-VstsInput { "RegisterAndCreate" } -- -Name action -Require
 Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
 Register-Mock Get-VstsInput { $overwriteBehavior } -- -Name overwriteBehavior
 Register-Mock Get-VstsInput { "false" } -- -Name skipUpgradeSameTypeAndVersion

--- a/Tasks/ServiceFabricDeploy/Tests/CreateDiffPkg.ps1
+++ b/Tasks/ServiceFabricDeploy/Tests/CreateDiffPkg.ps1
@@ -35,6 +35,7 @@ $codeDiffPkg4 = $diffPackagePath + "\Stateless4Pkg\Code.zip"
 Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
+Register-Mock Get-VstsInput { "RegisterAndCreate" } -- -Name action -Require
 Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
 Register-Mock Get-VstsInput { $overwriteBehavior } -- -Name overwriteBehavior
 Register-Mock Get-VstsInput { "false" } -- -Name skipUpgradeSameTypeAndVersion

--- a/Tasks/ServiceFabricDeploy/Tests/NoAuthDeploy.ps1
+++ b/Tasks/ServiceFabricDeploy/Tests/NoAuthDeploy.ps1
@@ -14,6 +14,7 @@ $overwriteBehavior = "SameAppTypeAndVersion"
 Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
+Register-Mock Get-VstsInput { "RegisterAndCreate" } -- -Name action -Require
 Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
 Register-Mock Get-VstsInput { $overwriteBehavior } -- -Name overwriteBehavior
 Register-Mock Get-VstsInput { "false" } -- -Name skipUpgradeSameTypeAndVersion

--- a/Tasks/ServiceFabricDeploy/Tests/WindowsAuthDeploy.ps1
+++ b/Tasks/ServiceFabricDeploy/Tests/WindowsAuthDeploy.ps1
@@ -17,6 +17,7 @@ $clusterFqdn = "fqdn"
 Register-Mock Get-VstsInput { $publishProfilePath } -- -Name publishProfilePath
 Register-Mock Get-VstsInput { $applicationPackagePath } -- -Name applicationPackagePath -Require
 Register-Mock Get-VstsInput { $serviceConnectionName } -- -Name serviceConnectionName -Require
+Register-Mock Get-VstsInput { "RegisterAndCreate" } -- -Name action -Require
 Register-Mock Get-VstsInput { "false" } -- -Name compressPackage
 Register-Mock Get-VstsInput { $overwriteBehavior } -- -Name overwriteBehavior
 Register-Mock Get-VstsInput { "false" } -- -Name skipUpgradeSameTypeAndVersion

--- a/Tasks/ServiceFabricDeploy/deploy.ps1
+++ b/Tasks/ServiceFabricDeploy/deploy.ps1
@@ -27,6 +27,7 @@ try {
     $serviceConnectionName = Get-VstsInput -Name serviceConnectionName -Require
     $connectedServiceEndpoint = Get-VstsEndpoint -Name $serviceConnectionName -Require
 
+    $action = Get-VstsInput -Name action -Require
     $copyPackageTimeoutSec = Get-VstsInput -Name copyPackageTimeoutSec
     $registerPackageTimeoutSec = Get-VstsInput -Name registerPackageTimeoutSec
     $compressPackage = [System.Boolean]::Parse((Get-VstsInput -Name compressPackage))
@@ -150,7 +151,7 @@ try {
     # Do an upgrade if configured to do so and the app actually exists
     if ($isUpgrade -and $app)
     {
-        $publishParameters['Action'] = "RegisterAndUpgrade"
+        $publishParameters['Action'] = ($action -replace 'Create', 'Upgrade')
         $publishParameters['UpgradeParameters'] = $upgradeParameters
         $publishParameters['UnregisterUnusedVersions'] = $unregisterUnusedVersions
         $publishParameters['SkipUpgradeSameTypeAndVersion'] = $skipUpgrade
@@ -159,7 +160,7 @@ try {
     }
     else
     {
-        $publishParameters['Action'] = "RegisterAndCreate"
+        $publishParameters['Action'] = $action
         $publishParameters['OverwriteBehavior'] = Get-VstsInput -Name overwriteBehavior
 
         Publish-NewServiceFabricApplication @publishParameters

--- a/Tasks/ServiceFabricDeploy/deploy.ps1
+++ b/Tasks/ServiceFabricDeploy/deploy.ps1
@@ -151,6 +151,9 @@ try {
     # Do an upgrade if configured to do so and the app actually exists
     if ($isUpgrade -and $app)
     {
+        # Available options for create are Register, Create, RegisterAndCreate
+        # Available options for upgrade are Register, Upgrade, RegisterAndUpgrade
+        # The task parameter uses the create options, so convert between them
         $publishParameters['Action'] = ($action -replace 'Create', 'Upgrade')
         $publishParameters['UpgradeParameters'] = $upgradeParameters
         $publishParameters['UnregisterUnusedVersions'] = $unregisterUnusedVersions

--- a/Tasks/ServiceFabricDeploy/task.json
+++ b/Tasks/ServiceFabricDeploy/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 7,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "Cmd"
@@ -75,13 +75,28 @@
             "helpMarkDown": "Path to the application parameters file. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) and wildcards can be used in the path. If specified, this will override the value in the publish profile."
         },
         {
+            "name": "action",
+            "type": "pickList",
+            "label": "Action",
+            "defaultValue": "RegisterAndCreate",
+            "required": true,
+            "options": {
+                "RegisterAndCreate": "RegisterAndCreate",
+                "Register": "Register",
+                "Create": "Create"
+            },
+            "groupname": "advanced",
+            "helpMarkDown": "Determines the action performed by this task. **Register**: Registers the application type in the cluster. **Create**: Creates or upgrades an application instance."
+        },
+        {
             "name": "compressPackage",
             "type": "boolean",
             "label": "Compress Package",
             "defaultValue": "false",
             "required": false,
             "groupname": "advanced",
-            "helpMarkDown": "Indicates whether the application package should be compressed before copying to the image store. If enabled, this will override the value in the publish profile."
+            "helpMarkDown": "Indicates whether the application package should be compressed before copying to the image store. If enabled, this will override the value in the publish profile.",
+            "visibleRule": "action = Register || action = RegisterAndCreate"
         },
         {
             "name": "useDiffPackage",
@@ -90,7 +105,8 @@
             "defaultValue": "false",
             "required": false,
             "groupname": "advanced",
-            "helpMarkDown": "Upgrade by using a diff package that contains only the updated application files, the updated application manifest, and the service manifest files."
+            "helpMarkDown": "Upgrade by using a diff package that contains only the updated application files, the updated application manifest, and the service manifest files.",
+            "visibleRule": "action = Register || action = RegisterAndCreate"
         },
         {
             "name": "copyPackageTimeoutSec",
@@ -99,7 +115,8 @@
             "defaultValue": "",
             "required": false,
             "groupname": "advanced",
-            "helpMarkDown": "Timeout in seconds for copying application package to image store. If specified, this will override the value in the publish profile."
+            "helpMarkDown": "Timeout in seconds for copying application package to image store. If specified, this will override the value in the publish profile.",
+            "visibleRule": "action = Register || action = RegisterAndCreate"
         },
         {
             "name": "registerPackageTimeoutSec",
@@ -108,7 +125,8 @@
             "defaultValue": "",
             "required": false,
             "groupname": "advanced",
-            "helpMarkDown": "Timeout in seconds for registering application package."
+            "helpMarkDown": "Timeout in seconds for registering application package.",
+            "visibleRule": "action = Register || action = RegisterAndCreate"
         },
         {
             "name": "overwriteBehavior",
@@ -131,7 +149,8 @@
             "defaultValue": "false",
             "required": false,
             "groupname": "advanced",
-            "helpMarkDown": "Indicates whether an upgrade will be skipped if the same application type and version already exists in the cluster, otherwise the upgrade fails during validation. If enabled, re-deployments are idempotent."
+            "helpMarkDown": "Indicates whether an upgrade will be skipped if the same application type and version already exists in the cluster, otherwise the upgrade fails during validation. If enabled, re-deployments are idempotent.",
+            "visibleRule": "action = Create || action = RegisterAndCreate"
         },
         {
             "name": "skipPackageValidation",
@@ -140,7 +159,8 @@
             "defaultValue": "false",
             "required": false,
             "groupname": "advanced",
-            "helpMarkDown": "Indicates whether the package should be validated or not before deployment."
+            "helpMarkDown": "Indicates whether the package should be validated or not before deployment.",
+            "visibleRule": "action = Register || action = RegisterAndCreate"
         },
         {
             "name": "overridePublishProfileSettings",

--- a/Tasks/ServiceFabricDeploy/task.loc.json
+++ b/Tasks/ServiceFabricDeploy/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 7,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "Cmd"
@@ -75,13 +75,28 @@
       "helpMarkDown": "ms-resource:loc.input.help.applicationParameterPath"
     },
     {
+      "name": "action",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.action",
+      "defaultValue": "RegisterAndCreate",
+      "required": true,
+      "options": {
+        "RegisterAndCreate": "RegisterAndCreate",
+        "Register": "Register",
+        "Create": "Create"
+      },
+      "groupname": "advanced",
+      "helpMarkDown": "ms-resource:loc.input.help.action"
+    },
+    {
       "name": "compressPackage",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.compressPackage",
       "defaultValue": "false",
       "required": false,
       "groupname": "advanced",
-      "helpMarkDown": "ms-resource:loc.input.help.compressPackage"
+      "helpMarkDown": "ms-resource:loc.input.help.compressPackage",
+      "visibleRule": "action = Register || action = RegisterAndCreate"
     },
     {
       "name": "useDiffPackage",
@@ -90,7 +105,8 @@
       "defaultValue": "false",
       "required": false,
       "groupname": "advanced",
-      "helpMarkDown": "ms-resource:loc.input.help.useDiffPackage"
+      "helpMarkDown": "ms-resource:loc.input.help.useDiffPackage",
+      "visibleRule": "action = Register || action = RegisterAndCreate"
     },
     {
       "name": "copyPackageTimeoutSec",
@@ -99,7 +115,8 @@
       "defaultValue": "",
       "required": false,
       "groupname": "advanced",
-      "helpMarkDown": "ms-resource:loc.input.help.copyPackageTimeoutSec"
+      "helpMarkDown": "ms-resource:loc.input.help.copyPackageTimeoutSec",
+      "visibleRule": "action = Register || action = RegisterAndCreate"
     },
     {
       "name": "registerPackageTimeoutSec",
@@ -108,7 +125,8 @@
       "defaultValue": "",
       "required": false,
       "groupname": "advanced",
-      "helpMarkDown": "ms-resource:loc.input.help.registerPackageTimeoutSec"
+      "helpMarkDown": "ms-resource:loc.input.help.registerPackageTimeoutSec",
+      "visibleRule": "action = Register || action = RegisterAndCreate"
     },
     {
       "name": "overwriteBehavior",
@@ -131,7 +149,8 @@
       "defaultValue": "false",
       "required": false,
       "groupname": "advanced",
-      "helpMarkDown": "ms-resource:loc.input.help.skipUpgradeSameTypeAndVersion"
+      "helpMarkDown": "ms-resource:loc.input.help.skipUpgradeSameTypeAndVersion",
+      "visibleRule": "action = Create || action = RegisterAndCreate"
     },
     {
       "name": "skipPackageValidation",
@@ -140,7 +159,8 @@
       "defaultValue": "false",
       "required": false,
       "groupname": "advanced",
-      "helpMarkDown": "ms-resource:loc.input.help.skipPackageValidation"
+      "helpMarkDown": "ms-resource:loc.input.help.skipPackageValidation",
+      "visibleRule": "action = Register || action = RegisterAndCreate"
     },
     {
       "name": "overridePublishProfileSettings",


### PR DESCRIPTION
When deploying a multi-tenant app, register and create/update are usually separate operations. The task currently always performs both at once. This new parameter allows selecting `Register`, `Create` or `RegisterAndCreate`. Note it is already implemented by the SDK; the new parameter just exposes this functionality.