### PR TITLE
Azure App Service Deploy must support setting Runtime Stack to .NET Core 2.0

### DIFF
--- a/Tasks/AzureRmWebAppDeployment/task.json
+++ b/Tasks/AzureRmWebAppDeployment/task.json
@@ -311,8 +311,8 @@
                 "php|5.6": "PHP 5.6",
                 "php|7.0": "PHP 7.0",
                 "dotnetcore|1.0": ".NET Core 1.0",
-                "dotnetcore|1.1": ".NET Core 1.1",
-				"dotnetcore|2.0": ".NET Core 2.0",
+                "dotnetcore|1.1": ".NET Core 1.1",				
+                "dotnetcore|2.0": ".NET Core 2.0",
                 "ruby|2.3": "Ruby 2.3"
             },
             "helpMarkDown": "Select the framework and version.",

--- a/Tasks/AzureRmWebAppDeployment/task.json
+++ b/Tasks/AzureRmWebAppDeployment/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 3,
         "Minor": 3,
-        "Patch": 41
+        "Patch": 42
     },
     "releaseNotes": "What's new in Version 3.0: <br/>&nbsp;&nbsp;Supports File Transformations (XDT) <br/>&nbsp;&nbsp;Supports Variable Substitutions(XML, JSON) <br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more Information.",
     "minimumAgentVersion": "2.104.1",
@@ -310,8 +310,9 @@
                 "node|8.1": "Node.js 8.1",
                 "php|5.6": "PHP 5.6",
                 "php|7.0": "PHP 7.0",
-                "dotnetcore|1.0": ".Net Core 1.0",
-                "dotnetcore|1.1": ".Net Core 1.1",
+                "dotnetcore|1.0": ".NET Core 1.0",
+                "dotnetcore|1.1": ".NET Core 1.1",
+				"dotnetcore|2.0": ".NET Core 2.0",
                 "ruby|2.3": "Ruby 2.3"
             },
             "helpMarkDown": "Select the framework and version.",

--- a/Tasks/AzureRmWebAppDeployment/task.loc.json
+++ b/Tasks/AzureRmWebAppDeployment/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 3,
     "Minor": 3,
-    "Patch": 41
+    "Patch": 42
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",
@@ -318,8 +318,9 @@
         "node|8.1": "Node.js 8.1",
         "php|5.6": "PHP 5.6",
         "php|7.0": "PHP 7.0",
-        "dotnetcore|1.0": ".Net Core 1.0",
-        "dotnetcore|1.1": ".Net Core 1.1",
+        "dotnetcore|1.0": ".NET Core 1.0",
+        "dotnetcore|1.1": ".NET Core 1.1",
+        "dotnetcore|2.0": ".NET Core 2.0",
         "ruby|2.3": "Ruby 2.3"
       },
       "helpMarkDown": "ms-resource:loc.input.help.RuntimeStack",


### PR DESCRIPTION
Azure App Service supports .Net Core 2.0 as Runtime Stack. The task Azure App Service Deploy must support setting Runtime Stack to .NET Core 2.0