### PR TITLE
Resolved issue of passing arguments which have quotes to kubectl command

### DIFF
--- a/Tasks/Kubernetes/src/kubernetescommand.ts
+++ b/Tasks/Kubernetes/src/kubernetescommand.ts
@@ -16,7 +16,7 @@ export function run(connection: ClusterConnection, kubecommand: string, outputUp
     command.arg(kubecommand)
     command.arg(getNameSpace());
     command.arg(getCommandConfigurationFile());
-    command.arg(getCommandArguments());
+    command.line(getCommandArguments());
     command.arg(getCommandOutputFormat());
     return connection.execCommand(command);
 }
@@ -49,14 +49,8 @@ function getCommandConfigurationFile() : string[] {
     return args;
 }
 
-function getCommandArguments(): string[] {
-    var args: string[] =[];
-    var argument = tl.getInput("arguments", false);
-    if(argument){
-        args = argument.split(" ");
-    }
-
-    return args;
+function getCommandArguments(): string {
+    return tl.getInput("arguments", false);
 }
 
 function getNameSpace(): string[] {

--- a/Tasks/Kubernetes/task.json
+++ b/Tasks/Kubernetes/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 12
+        "Patch": 13
     },
     "demands": [],
     "preview": "false",
@@ -30,8 +30,8 @@
         }, 
         {
             "name": "advanced",
-			"displayName": "Advanced",
-			"isExpanded": false
+            "displayName": "Advanced",
+            "isExpanded": false
         },
         {
             "name": "output",
@@ -95,7 +95,7 @@
             "properties": {
                 "resizable": "true",
                 "rows": "2",
-				"editorExtension": "ms.vss-services-azure.parameters-grid"
+                "editorExtension": "ms.vss-services-azure.parameters-grid"
             },
             "label": "Arguments",
             "helpMarkDown": "Command arguments.",
@@ -185,7 +185,7 @@
             "type": "boolean",
             "label": "Check for Latest Version",
             "defaultValue": "false",
-			"helpMarkDown": "Always checks online for the latest available version (stable.txt) that satisfies the version spec. This is typically false unless you have a specific scenario to always get latest. This will cause it to incur download costs when potentially not necessary, especially with the hosted build pool.",
+            "helpMarkDown": "Always checks online for the latest available version (stable.txt) that satisfies the version spec. This is typically false unless you have a specific scenario to always get latest. This will cause it to incur download costs when potentially not necessary, especially with the hosted build pool.",
             "required": false,
 			"groupName": "advanced",
 			"visibleRule": "versionOrLocation = version"

--- a/Tasks/Kubernetes/task.loc.json
+++ b/Tasks/Kubernetes/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 12
+    "Patch": 13
   },
   "demands": [],
   "preview": "false",


### PR DESCRIPTION
Arguments can have parameters in quotes and we should be able to parse and append them to the command correctly. We support literals only  in double quotes.