### PR TITLE
Users/stfrance/documentation

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -2,12 +2,7 @@
 Checkout how to troubleshoot failures and collect debug logs: https://docs.microsoft.com/en-us/vsts/build-release/actions/troubleshooting
 
 ## Diagnostic Logs
-In order to ease the debugging process we have enabled a feature called diagnostic logs. With this setting turned on we capture more verbose
-logs about the task, agent, and environment within which the build was run. In order to get access to these logs go to the build summary page 
-and look for the "Queue new build" button. To the right of the button you will see a dropdown and a second option to "Queue new build with 
-diagnostic logs". Select this option. A new build will be queued. Once the build is complete there are two ways to access these logs: (1) 
-There will be a Diagnostic logs section on the build summary page and (2) you can click to "Download all logs as zip". These logs will help 
-you debug your issues and help us assist you in debugging them.
+In order to ease the debugging process we have enabled a feature called diagnostic logs. With this setting turned on we capture more verbose logs about the task, agent, and environment within which the build was run. In order to get access to these logs go to the build summary page and look for the "Queue new build" button. To the right of the button you will see a dropdown and a second option to "Queue new build with diagnostic logs". Select this option. A new build will be queued. Once the build is complete there are two ways to access these logs: (1) There will be a Diagnostic logs section on the build summary page and (2) you can click to "Download all logs as zip". These logs will help you debug your issues and help us assist you in debugging them.
 
 ## Environment
 - Server - VSTS or TFS on-premises?

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,6 +1,14 @@
 ## Troubleshooting
 Checkout how to troubleshoot failures and collect debug logs: https://docs.microsoft.com/en-us/vsts/build-release/actions/troubleshooting
 
+## Diagnostic Logs
+In order to ease the debugging process we have enabled a feature called diagnostic logs. With this setting turned on we capture more verbose
+logs about the task, agent, and environment within which the build was run. In order to get access to these logs go to the build summary page 
+and look for the "Queue new build" button. To the right of the button you will see a dropdown and a second option to "Queue new build with 
+diagnostic logs". Select this option. A new build will be queued. Once the build is complete there are two ways to access these logs: (1) 
+There will be a Diagnostic logs section on the build summary page and (2) you can click to "Download all logs as zip". These logs will help 
+you debug your issues and help us assist you in debugging them.
+
 ## Environment
 - Server - VSTS or TFS on-premises?
     


### PR DESCRIPTION
This change adds a section to the issue template to describe the purpose of diagnostic logs and how to gather them. I think this may be too verbose for an issue template. Perhaps we just give them the steps and then link them to another location to read more about diagnostic logs? We also need to close the loop in terms of how we get the diagnostic logs conveniently. Since there are currently limitations with the CSS tool I can see two options: 1. Modify the CSS tool to look back longer in history(could still be problematic) 2. Ask them to send the logs to a specific email address and reference a build identifier.

@madhurig @bryanmacfarlane What do you think will be most convenient for users?