### PR TITLE
Patch to support Self-provisioned agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,4 @@ GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
 /Package
+LoadTest.code-workspace

--- a/Tasks/QuickPerfTest/CltTasksUtility.ps1
+++ b/Tasks/QuickPerfTest/CltTasksUtility.ps1
@@ -213,7 +213,8 @@ function ComposeTestRunJson($name, $tdid, $vuLoad, $runDuration, $machineType, $
             "runSpecificDetails" : {
                 "virtualUserCount": $vuLoad,
                 "duration": $runDuration,
-                "agentCount": $numOfSelfProvisionedAgents
+                "agentCount": $numOfSelfProvisionedAgents,
+                "loadGeneratorMachinesType": "userLoadAgent"
             },
             "testDrop":{"id":"$tdid"},
             "runSourceIdentifier":"build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"

--- a/Tasks/QuickPerfTest/CltTasksUtility.ps1
+++ b/Tasks/QuickPerfTest/CltTasksUtility.ps1
@@ -121,22 +121,6 @@ function MonitorTestRun($headers, $run, $CltAccountUrl)
 	Write-Output "------------------------------------"
 }
 
-function ComposeTestRunJson($name, $tdid, $machineType)
-{
-	$trjson = @"
-	{
-		"name":"$name",
-		"description":"Quick perf test from automation task",
-		"testSettings":{"cleanupCommand":"", "hostProcessPlatform":"x64", "setupCommand":""},
-		"superSedeRunSettings":{"loadGeneratorMachinesType":"$machineType"},
-		"testDrop":{"id":"$tdid"},
-		"runSourceIdentifier":"build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
-	}
-"@
-
-	return $trjson
-}
-
 function QueueTestRun($headers, $runJson, $CltAccountUrl)
 {
 	$uri = [String]::Format("{0}/_apis/clt/testruns?api-version=1.0", $CltAccountUrl)
@@ -160,7 +144,7 @@ function ComposeAccountUrl($connectedServiceUrl, $headers)
 	#Load all dependent files for execution
 	. $PSScriptRoot/VssConnectionHelper.ps1
 	$connectedServiceUrl = $connectedServiceUrl.TrimEnd('/')
-	Write-Host "Getting Clt Endpoint:"
+    Write-Host -NoNewline "Getting Clt Endpoint:"
 	$elsUrl = Get-CltEndpoint $connectedServiceUrl $headers
 
 	return $elsUrl
@@ -209,4 +193,44 @@ function IsNumericValue ($str) {
 	return $isNum
 }
 
+
+function ComposeTestRunJson($name, $tdid, $vuLoad, $runDuration, $machineType, $selfProvisionedRig, $numOfSelfProvisionedAgents)
+{
+    if ($MachineType -eq "2"){
+        Write-Host ">>> Self-Provisioned Rig Test Run"
+        $trjson = @"
+        {
+            "name":"$name",
+            "description":"Quick perf test from automation task",
+            "testSettings":{"cleanupCommand":"", "hostProcessPlatform":"x64", "setupCommand":""},
+            "superSedeRunSettings": {
+                "loadGeneratorMachinesType": "$MachineType",
+                "staticAgentRunSettings": {
+                    "loadGeneratorMachinesType": "userLoadAgent",
+                    "staticAgentGroupName": "$selfProvisionedRig"
+                }
+            },
+            "runSpecificDetails" : {
+                "virtualUserCount": $vuLoad,
+                "duration": $runDuration,
+                "agentCount": $numOfSelfProvisionedAgents
+            },
+            "testDrop":{"id":"$tdid"},
+            "runSourceIdentifier":"build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
+        }
+"@
+    } else {
+        $trjson = @"
+        {
+            "name":"$name",
+            "description":"Quick perf test from automation task",
+            "testSettings":{"cleanupCommand":"", "hostProcessPlatform":"x64", "setupCommand":""},
+            "superSedeRunSettings":{"loadGeneratorMachinesType":"$machineType"},
+            "testDrop":{"id":"$tdid"},
+            "runSourceIdentifier":"build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
+        }
+"@
+    }
+	return $trjson
+}
 

--- a/Tasks/QuickPerfTest/Invoke-QuickPerfTest.ps1
+++ b/Tasks/QuickPerfTest/Invoke-QuickPerfTest.ps1
@@ -22,7 +22,7 @@ $geoLocation,
 [String] [Parameter(Mandatory = $true)]
 $machineType,
 [String] [Parameter(Mandatory = $false)]
-$selfProvisionedRig,
+$resourceGroupName,
 [String] [Parameter(Mandatory = $false)]
 $numOfSelfProvisionedAgents,
 [String] [Parameter(Mandatory = $false)]
@@ -93,7 +93,7 @@ Write-Output "Website Url = $websiteUrl"
 Write-Output "Virtual user load = $vuLoad"
 Write-Output "Load location = $geoLocation"
 Write-Output "Load generator machine type = $machineType"
-Write-Output "Self-provisioned rig = $selfProvisionedRig"
+Write-Output "Self-provisioned rig = $resourceGroupName"
 Write-Output "Num of agents = $numOfSelfProvisionedAgents"
 Write-Output "Run source identifier = build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
 
@@ -129,7 +129,7 @@ $drop = CreateTestDrop $headers $dropjson $CltAccountUrl
 
 if ($drop.dropType -eq "InPlaceDrop")
 {
-	$runJson = ComposeTestRunJson $testName $drop.id $vuLoad $runDuration $MachineType $selfProvisionedRig $numOfSelfProvisionedAgents
+	$runJson = ComposeTestRunJson $testName $drop.id $vuLoad $runDuration $MachineType $resourceGroupName $numOfSelfProvisionedAgents
 	$run = QueueTestRun $headers $runJson $CltAccountUrl
 	MonitorTestRun $headers $run $CltAccountUrl
 	$webResultsUrl = GetTestRunUri $run.id $headers $CltAccountUrl

--- a/Tasks/QuickPerfTest/Invoke-QuickPerfTest.ps1
+++ b/Tasks/QuickPerfTest/Invoke-QuickPerfTest.ps1
@@ -22,6 +22,10 @@ $geoLocation,
 [String] [Parameter(Mandatory = $true)]
 $machineType,
 [String] [Parameter(Mandatory = $false)]
+$selfProvisionedRig,
+[String] [Parameter(Mandatory = $false)]
+$numOfSelfProvisionedAgents,
+[String] [Parameter(Mandatory = $false)]
 $avgResponseTimeThreshold
 )
 
@@ -89,6 +93,8 @@ Write-Output "Website Url = $websiteUrl"
 Write-Output "Virtual user load = $vuLoad"
 Write-Output "Load location = $geoLocation"
 Write-Output "Load generator machine type = $machineType"
+Write-Output "Self-provisioned rig = $selfProvisionedRig"
+Write-Output "Num of agents = $numOfSelfProvisionedAgents"
 Write-Output "Run source identifier = build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
 
 #Validate Input
@@ -123,7 +129,7 @@ $drop = CreateTestDrop $headers $dropjson $CltAccountUrl
 
 if ($drop.dropType -eq "InPlaceDrop")
 {
-	$runJson = ComposeTestRunJson $testName $drop.id $MachineType
+	$runJson = ComposeTestRunJson $testName $drop.id $vuLoad $runDuration $MachineType $selfProvisionedRig $numOfSelfProvisionedAgents
 	$run = QueueTestRun $headers $runJson $CltAccountUrl
 	MonitorTestRun $headers $run $CltAccountUrl
 	$webResultsUrl = GetTestRunUri $run.id $headers $CltAccountUrl

--- a/Tasks/QuickPerfTest/VssConnectionHelper.ps1
+++ b/Tasks/QuickPerfTest/VssConnectionHelper.ps1
@@ -3,7 +3,7 @@ function Get-CltEndpoint($connectedServiceUrl, $headers)
 	# Load all dependent files for execution
 	. $PSScriptRoot/CltTasksUtility.ps1
 	$vsoUrl = $connectedServiceUrl
-	Write-Host "Fetching the Clt endpoint for $vsoUrl"
+	Write-Host -NoNewline "Fetching the Clt endpoint for $vsoUrl"
 	$spsLocation = Get-SpsLocation $vsoUrl $headers
 	$cltLocation = Get-CltLocation $spsLocation $headers
 	return $cltLocation
@@ -12,7 +12,7 @@ function Get-CltEndpoint($connectedServiceUrl, $headers)
 
 function Get-SpsLocation($vsoUrl, $headers)
 {
-	Write-Host "Fetching the SPS endpoint for $vsoUrl"
+	Write-Host -NoNewline "Fetching the SPS endpoint for $vsoUrl"
 	$spsUniqueIdentifier = "951917AC-A960-4999-8464-E3F0AA25B381"
 	$spsLocation = Get-ServiceLocation $vsoUrl $headers $spsUniqueIdentifier
 	return $spsLocation
@@ -20,7 +20,7 @@ function Get-SpsLocation($vsoUrl, $headers)
 
 function Get-CltLocation($spsUrl, $headers)
 {
-	Write-Host "Fetching the CLT endpoint for $vsoUrl"
+	Write-Host -NoNewline "Fetching the CLT endpoint for $vsoUrl"
 	$cltUniqueIdentifier = "6C404D78-EF65-4E65-8B6A-DF19D6361EAE"
 	return Get-ServiceLocation $spsUrl $headers $cltUniqueIdentifier
 }

--- a/Tasks/QuickPerfTest/task.json
+++ b/Tasks/QuickPerfTest/task.json
@@ -125,6 +125,7 @@
             "label": "Load test rig",
             "required": false,
             "defaultValue": "",
+            "visibleRule": "machineType == 2",
             "helpMarkDown": "Name of self-provisioned rig of load test agents."
         },
         {
@@ -133,6 +134,7 @@
             "label": "No. of agents to use",
             "required": false,
             "defaultValue": "",
+            "visibleRule": "machineType == 2",
             "helpMarkDown": "Number of self provisioned agents to use for this test."
         },
         {

--- a/Tasks/QuickPerfTest/task.json
+++ b/Tasks/QuickPerfTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 27
+        "Patch": 28
     },
     "demands": [
         "msbuild",
@@ -56,6 +56,9 @@
                 "50": "50",
                 "100": "100",
                 "250": "250"
+            },
+            "properties": {
+                "EditableOptions": "True"
             }
         },
         {
@@ -71,6 +74,9 @@
                 "180": "180",
                 "240": "240",
                 "300": "300"
+            },
+            "properties": {
+                "EditableOptions": "True"
             }
         },
         {
@@ -97,6 +103,9 @@
                 "Brazil South": "Brazil South (Sao Paulo State)",
                 "Australia East": "Australia East (New South Wales)",
                 "Australia Southeast": "Australia Southeast (Victoria)"
+            },
+            "properties": {
+                "EditableOptions": "True"
             }
         },
         {
@@ -109,6 +118,22 @@
                 "0": "Automatically provisioned agents",
                 "2": "Self-provisioned agents"
             }
+        },
+        {
+            "name": "selfProvisionedRig",
+            "type": "string",
+            "label": "Load test rig",
+            "required": false,
+            "defaultValue": "",
+            "helpMarkDown": "Name of self-provisioned rig of load test agents."
+        },
+        {
+            "name": "numOfSelfProvisionedAgents",
+            "type": "int",
+            "label": "No. of agents to use",
+            "required": false,
+            "defaultValue": "",
+            "helpMarkDown": "Number of self provisioned agents to use for this test."
         },
         {
             "name": "avgResponseTimeThreshold",

--- a/Tasks/QuickPerfTest/task.json
+++ b/Tasks/QuickPerfTest/task.json
@@ -120,13 +120,13 @@
             }
         },
         {
-            "name": "selfProvisionedRig",
+            "name": "resourceGroupName",
             "type": "string",
-            "label": "Load test rig",
+            "label": "Resource group rig",
             "required": false,
             "defaultValue": "",
             "visibleRule": "machineType == 2",
-            "helpMarkDown": "Name of self-provisioned rig of load test agents."
+            "helpMarkDown": "Name of Resource group hosting the self-provisioned rig of load test agents."
         },
         {
             "name": "numOfSelfProvisionedAgents",

--- a/Tasks/RunLoadTest/CltTasksUtility.ps1
+++ b/Tasks/RunLoadTest/CltTasksUtility.ps1
@@ -301,7 +301,7 @@ function StopTestRun($headers, $run, $CltAccountUrl)
 
 }
 
-function ComposeTestRunJson($name, $tdid, $machineType)
+function ComposeTestRunJson($name, $tdid, $machineType, $selfProvisionedRig, $numOfSelfProvisionedAgents)
 {
     $processPlatform = "x64"
     $setupScript=""
@@ -329,16 +329,40 @@ function ComposeTestRunJson($name, $tdid, $machineType)
         }
     }
 
-    $trjson = @"
-    {
-        "name":"$name",
-        "description":"Load Test queued from build",
-        "testSettings":{"cleanupCommand":"$cleanupScript", "hostProcessPlatform":"$processPlatform", "setupCommand":"$setupScript"},
-        "superSedeRunSettings":{"loadGeneratorMachinesType":"$machineType"},
-        "testDrop":{"id":"$tdid"},
-        "runSourceIdentifier":"build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
-    }
+    if ($MachineType -eq "2"){
+        Write-Host ">>> Self-Provisioned Rig Test Run"
+        $trjson = @"
+        {
+            "name":"$name",
+            "description":"Load Test queued from build",
+            "testSettings":{"cleanupCommand":"$cleanupScript", "hostProcessPlatform":"$processPlatform", "setupCommand":"$setupScript"},
+            "superSedeRunSettings": {
+                "loadGeneratorMachinesType": "$MachineType",
+                "staticAgentRunSettings": {
+                    "loadGeneratorMachinesType": "userLoadAgent",
+                    "staticAgentGroupName": "$selfProvisionedRig"
+                }
+            },
+            "runSpecificDetails" : {
+                "agentCount": $numOfSelfProvisionedAgents,
+                "loadGeneratorMachinesType": "userLoadAgent"
+            },
+            "testDrop":{"id":"$tdid"},
+            "runSourceIdentifier":"build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
+        }
 "@
+    } else {
+        $trjson = @"
+        {
+            "name":"$name",
+            "description":"Load Test queued from build",
+            "testSettings":{"cleanupCommand":"$cleanupScript", "hostProcessPlatform":"$processPlatform", "setupCommand":"$setupScript"},
+            "superSedeRunSettings":{"loadGeneratorMachinesType":"$machineType"},
+            "testDrop":{"id":"$tdid"},
+            "runSourceIdentifier":"build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
+        }
+"@
+    }
     return $trjson
 }
 

--- a/Tasks/RunLoadTest/Start-CloudLoadTest.ps1
+++ b/Tasks/RunLoadTest/Start-CloudLoadTest.ps1
@@ -19,6 +19,10 @@ $LoadTest,
 $ThresholdLimit,
 [String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
 $MachineType,
+[String] [Parameter(Mandatory = $false)]
+$selfProvisionedRig,
+[String] [Parameter(Mandatory = $false)]
+$numOfSelfProvisionedAgents,
 [ValidateSet('changeActive', 'useFile', '')]
 $activeRunSettings,
 [String]
@@ -95,6 +99,8 @@ Write-Output "Run Settings Name = $runSettingName"
 Write-Output "Active Run Settings = $activeRunSettings"
 Write-Output "Run Test Parameters $testContextParameters"
 Write-Output "Load generator machine type = $MachineType"
+Write-Output "Self-provisioned rig = $selfProvisionedRig"
+Write-Output "Num of agents = $numOfSelfProvisionedAgents"
 Write-Output "Run source identifier = build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
 
 #Validate Input
@@ -142,7 +148,7 @@ if ($drop.dropType -eq "TestServiceBlobDrop")
 	WriteTaskMessages ("Uploading test files took {0}. Queuing the test run." -f $($elapsed.Elapsed.ToString()))
 
 	#Queue the test run
-	$runJson = ComposeTestRunJson $LoadTest $drop.id $MachineType
+	$runJson = ComposeTestRunJson $LoadTest $drop.id $MachineType $selfProvisionedRig $numOfSelfProvisionedAgents
 
 	$run = QueueTestRun $headers $runJson $CltAccountUrl
 	MonitorAcquireResource $headers $run $CltAccountUrl

--- a/Tasks/RunLoadTest/Start-CloudLoadTest.ps1
+++ b/Tasks/RunLoadTest/Start-CloudLoadTest.ps1
@@ -20,7 +20,7 @@ $ThresholdLimit,
 [String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
 $MachineType,
 [String] [Parameter(Mandatory = $false)]
-$selfProvisionedRig,
+$resourceGroupName,
 [String] [Parameter(Mandatory = $false)]
 $numOfSelfProvisionedAgents,
 [ValidateSet('changeActive', 'useFile', '')]
@@ -99,7 +99,7 @@ Write-Output "Run Settings Name = $runSettingName"
 Write-Output "Active Run Settings = $activeRunSettings"
 Write-Output "Run Test Parameters $testContextParameters"
 Write-Output "Load generator machine type = $MachineType"
-Write-Output "Self-provisioned rig = $selfProvisionedRig"
+Write-Output "Self-provisioned rig = $resourceGroupName"
 Write-Output "Num of agents = $numOfSelfProvisionedAgents"
 Write-Output "Run source identifier = build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
 
@@ -148,7 +148,7 @@ if ($drop.dropType -eq "TestServiceBlobDrop")
 	WriteTaskMessages ("Uploading test files took {0}. Queuing the test run." -f $($elapsed.Elapsed.ToString()))
 
 	#Queue the test run
-	$runJson = ComposeTestRunJson $LoadTest $drop.id $MachineType $selfProvisionedRig $numOfSelfProvisionedAgents
+	$runJson = ComposeTestRunJson $LoadTest $drop.id $MachineType $resourceGroupName $numOfSelfProvisionedAgents
 
 	$run = QueueTestRun $headers $runJson $CltAccountUrl
 	MonitorAcquireResource $headers $run $CltAccountUrl

--- a/Tasks/RunLoadTest/task.json
+++ b/Tasks/RunLoadTest/task.json
@@ -111,6 +111,7 @@
             "label": "Load test rig",
             "required": false,
             "defaultValue": "",
+            "visibleRule": "MachineType == 2",
             "helpMarkDown": "Name of self-provisioned rig of load test agents."
         },
         {
@@ -119,6 +120,7 @@
             "label": "No. of agents to use",
             "required": false,
             "defaultValue": "",
+            "visibleRule": "MachineType == 2",
             "helpMarkDown": "Number of self provisioned agents to use for this test."
         }
     ],

--- a/Tasks/RunLoadTest/task.json
+++ b/Tasks/RunLoadTest/task.json
@@ -106,13 +106,13 @@
             }
         },
         {
-            "name": "selfProvisionedRig",
+            "name": "resourceGroupName",
             "type": "string",
-            "label": "Load test rig",
+            "label": "Resource group rig",
             "required": false,
             "defaultValue": "",
             "visibleRule": "MachineType == 2",
-            "helpMarkDown": "Name of self-provisioned rig of load test agents."
+            "helpMarkDown": "Name of Resource group hosting the self-provisioned rig of load test agents."
         },
         {
             "name": "numOfSelfProvisionedAgents",

--- a/Tasks/RunLoadTest/task.json
+++ b/Tasks/RunLoadTest/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 26
+        "Patch": 27
     },
     "demands": [
         "msbuild",
@@ -104,6 +104,22 @@
                 "0": "Automatically provisioned agents",
                 "2": "Self-provisioned agents"
             }
+        },
+        {
+            "name": "selfProvisionedRig",
+            "type": "string",
+            "label": "Load test rig",
+            "required": false,
+            "defaultValue": "",
+            "helpMarkDown": "Name of self-provisioned rig of load test agents."
+        },
+        {
+            "name": "numOfSelfProvisionedAgents",
+            "type": "int",
+            "label": "No. of agents to use",
+            "required": false,
+            "defaultValue": "",
+            "helpMarkDown": "Number of self provisioned agents to use for this test."
         }
     ],
     "instanceNameFormat": "Cloud Load Test $(LoadTest)",


### PR DESCRIPTION
Change to _Cloud-based Web Performance Test_ (QuickPerfTest) and _Cloud-based Load Test_ (CloudLoadTest) to support Self-provisioned agents.

Adds two parameters `selfProvisionedRig` and `numOfSelfProvisionedAgents` and pass them in the `superSedeRunSettings` and `runSpecificDetails` elements of Test Run Creation