### PR TITLE
Added support for custom certificates

### DIFF
--- a/Tasks/AzureCloudPowerShellDeployment/Publish-AzureCloudDeployment.ps1
+++ b/Tasks/AzureCloudPowerShellDeployment/Publish-AzureCloudDeployment.ps1
@@ -16,7 +16,7 @@ try{
     $DiagnosticStorageAccountKeys = Get-VstsInput -Name DiagnosticStorageAccountKeys
     $NewServiceAdditionalArguments = Get-VstsInput -Name NewServiceAdditionalArguments
     $NewServiceAffinityGroup = Get-VstsInput -Name NewServiceAffinityGroup
-	$NewServiceCustomCertificates = Get-VstsInput -Name NewServiceCustomCertificates
+    $NewServiceCustomCertificates = Get-VstsInput -Name NewServiceCustomCertificates
 
     # Initialize Azure.
     Import-Module $PSScriptRoot\ps_modules\VstsAzureHelpers_

--- a/Tasks/AzureCloudPowerShellDeployment/Publish-AzureCloudDeployment.ps1
+++ b/Tasks/AzureCloudPowerShellDeployment/Publish-AzureCloudDeployment.ps1
@@ -16,6 +16,7 @@ try{
     $DiagnosticStorageAccountKeys = Get-VstsInput -Name DiagnosticStorageAccountKeys
     $NewServiceAdditionalArguments = Get-VstsInput -Name NewServiceAdditionalArguments
     $NewServiceAffinityGroup = Get-VstsInput -Name NewServiceAffinityGroup
+	$NewServiceCustomCertificates = Get-VstsInput -Name NewServiceCustomCertificates
 
     # Initialize Azure.
     Import-Module $PSScriptRoot\ps_modules\VstsAzureHelpers_
@@ -59,6 +60,10 @@ try{
         $azureService += " $NewServiceAdditionalArguments"
         Write-Host "$azureService"
         $azureService = Invoke-Expression -Command $azureService
+
+        #Add the custom certificates to the newly created Azure Cloud Service
+        $customCertificatesMap = Parse-CustomCertificates -CustomCertificates $NewServiceCustomCertificates
+        Add-CustomCertificates $serviceName $customCertificatesMap
     }
 
     $diagnosticExtensions = Get-DiagnosticsExtensions $StorageAccount $serviceConfigFile $storageAccountKeysMap

--- a/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/de-de/resources.resjson
@@ -32,6 +32,8 @@
   "loc.input.help.NewServiceAdditionalArguments": "Übergeben Sie zusätzliche Argumente beim Erstellen eines neuen Dienstes. Diese werden an das Cmdlet \"New-AzureService\" übergeben, z. B. \"-Label 'MyTestService'\".",
   "loc.input.label.NewServiceAffinityGroup": "Affinitätsgruppe",
   "loc.input.help.NewServiceAffinityGroup": "Beim Erstellen des neuen Diensts wird diese Affinitätsgruppe anstelle eines Dienstspeicherorts berücksichtigt.",
+  "loc.input.label.NewServiceCustomCertificates": "Custom certificates to import",
+  "loc.input.help.NewServiceCustomCertificates": "Provide custom certificates in CertificatePfxBase64:CertificatePassword format. It’s recommended to save <certificate_password> as a secret variable. <br/><br/>For example,<br/> Certificate1: &lt;Certificate1_password&gt;<br/>Certificate2: &lt;Certificate2_password&gt;",
   "loc.messages.Couldnotgettheprimarystoragekeyforstorageaccount0Unabletoapplyanydiagnosticsextensions": "Der primäre Speicherschlüssel für das Speicherkonto \"{0}\" konnte nicht abgerufen werden. Es können keine Diagnoseextensions angewendet werden.",
   "loc.messages.Couldnotgettheprimarystoragekeyforthepublicconfigstorageaccount0Unabletoapplyanydiagnosticsextensions": "Der primäre Speicherschlüssel für das öffentliche Konfigurationsspeicherkonto \"{0}\" konnte nicht abgerufen werden. Es können keine Diagnoseextensions angewendet werden.",
   "loc.messages.Applyinganyconfigureddiagnosticsextensions": "Alle konfigurierten Diagnoseextensions werden angewendet.",
@@ -40,5 +42,7 @@
   "loc.messages.Foundmorethanonefiletodeploywithsearchpattern0Therecanbeonlyone": "Es wurde mehrere Dateien zum Bereitstellen mit dem Suchmuster \"{0}\" gefunden. Es darf maximal eine Datei vorhanden sein.",
   "loc.messages.Storagekeysaredefinedininvalidformat": "Die Speicherschlüssel wurden in einem ungültigen Format definiert.",
   "loc.messages.Unabletofind0usingprovidedsubscription": "\"{0}\" wurde unter Verwendung des angegebenen Abonnements nicht gefunden.",
-  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "Die aktuelle Version von Azure PowerShell bietet keine Unterstützung für ein externes Speicherkonto zum Konfigurieren der Diagnose."
+  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "Die aktuelle Version von Azure PowerShell bietet keine Unterstützung für ein externes Speicherkonto zum Konfigurieren der Diagnose.",
+  "loc.messages.Addinganyconfiguredcustomcertificates": "Adding any configured custom certificates.",
+  "loc.messages.Customcertificatesaredefinedininvalidformat": "Custom certificates are defined in invalid format."
 }

--- a/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/en-US/resources.resjson
@@ -36,7 +36,7 @@
   "loc.input.help.NewServiceCustomCertificates": "Provide custom certificates in CertificatePfxBase64:CertificatePassword format. It’s recommended to save <certificate_password> as a secret variable. <br/><br/>For example,<br/> Certificate1: &lt;Certificate1_password&gt;<br/>Certificate2: &lt;Certificate2_password&gt;",
   "loc.messages.Couldnotgettheprimarystoragekeyforstorageaccount0Unabletoapplyanydiagnosticsextensions": "Could not get the primary storage key for storage account '{0}'. Unable to apply any diagnostics extensions.",
   "loc.messages.Couldnotgettheprimarystoragekeyforthepublicconfigstorageaccount0Unabletoapplyanydiagnosticsextensions": "Could not get the primary storage key for the public config storage account '{0}'. Unable to apply any diagnostics extensions.",
-  "loc.messages.Applyinganyconfigureddiagnosticsextensions": "Applying any configured diagnostics extensions.",  
+  "loc.messages.Applyinganyconfigureddiagnosticsextensions": "Applying any configured diagnostics extensions.",
   "loc.messages._0couldnotbeparsedintopartsforregisteringdiagnosticsextensions": "'{0}' could not be parsed into parts for registering diagnostics extensions.",
   "loc.messages.Nofileswerefoundtodeploywithsearchpattern0": "No files were found to deploy with search pattern {0}",
   "loc.messages.Foundmorethanonefiletodeploywithsearchpattern0Therecanbeonlyone": "Found more than one file to deploy with search pattern {0}. There can be only one.",

--- a/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/en-US/resources.resjson
@@ -32,13 +32,17 @@
   "loc.input.help.NewServiceAdditionalArguments": "Pass in additional arguments while creating a brand new service. These will be passed on to `New-AzureService` cmdlet. Eg: `-Label 'MyTestService'`",
   "loc.input.label.NewServiceAffinityGroup": "Affinity group",
   "loc.input.help.NewServiceAffinityGroup": "While creating new service, this affinity group will be considered instead of using service location.",
+  "loc.input.label.NewServiceCustomCertificates": "Custom certificates to import",
+  "loc.input.help.NewServiceCustomCertificates": "Provide custom certificates in CertificatePfxBase64:CertificatePassword format. It’s recommended to save <certificate_password> as a secret variable. <br/><br/>For example,<br/> Certificate1: &lt;Certificate1_password&gt;<br/>Certificate2: &lt;Certificate2_password&gt;",
   "loc.messages.Couldnotgettheprimarystoragekeyforstorageaccount0Unabletoapplyanydiagnosticsextensions": "Could not get the primary storage key for storage account '{0}'. Unable to apply any diagnostics extensions.",
   "loc.messages.Couldnotgettheprimarystoragekeyforthepublicconfigstorageaccount0Unabletoapplyanydiagnosticsextensions": "Could not get the primary storage key for the public config storage account '{0}'. Unable to apply any diagnostics extensions.",
-  "loc.messages.Applyinganyconfigureddiagnosticsextensions": "Applying any configured diagnostics extensions.",
+  "loc.messages.Applyinganyconfigureddiagnosticsextensions": "Applying any configured diagnostics extensions.",  
   "loc.messages._0couldnotbeparsedintopartsforregisteringdiagnosticsextensions": "'{0}' could not be parsed into parts for registering diagnostics extensions.",
   "loc.messages.Nofileswerefoundtodeploywithsearchpattern0": "No files were found to deploy with search pattern {0}",
   "loc.messages.Foundmorethanonefiletodeploywithsearchpattern0Therecanbeonlyone": "Found more than one file to deploy with search pattern {0}. There can be only one.",
   "loc.messages.Storagekeysaredefinedininvalidformat": "Storage keys are defined in invalid format.",
   "loc.messages.Unabletofind0usingprovidedsubscription": "Unable to find {0} using provided subscription",
-  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "Current version of azure powershell don't support external storage account for configuring diagnostics."
+  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "Current version of azure powershell don't support external storage account for configuring diagnostics.",
+  "loc.messages.Addinganyconfiguredcustomcertificates": "Adding any configured custom certificates.",
+  "loc.messages.Customcertificatesaredefinedininvalidformat": "Custom certificates are defined in invalid format."
 }

--- a/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/es-es/resources.resjson
@@ -32,6 +32,8 @@
   "loc.input.help.NewServiceAdditionalArguments": "Pase argumentos adicionales al crear un servicio completamente nuevo. Estos se pasarán al cmdlet \"New-AzureService\". Por ejemplo: \"-Label 'MiServicioDePrueba'\"",
   "loc.input.label.NewServiceAffinityGroup": "Grupo de afinidad",
   "loc.input.help.NewServiceAffinityGroup": "Mientras se crea el nuevo servicio, se tendrá en cuenta este grupo de afinidad en lugar de utilizar la ubicación del servicio.",
+  "loc.input.label.NewServiceCustomCertificates": "Custom certificates to import",
+  "loc.input.help.NewServiceCustomCertificates": "Provide custom certificates in CertificatePfxBase64:CertificatePassword format. It’s recommended to save <certificate_password> as a secret variable. <br/><br/>For example,<br/> Certificate1: &lt;Certificate1_password&gt;<br/>Certificate2: &lt;Certificate2_password&gt;",
   "loc.messages.Couldnotgettheprimarystoragekeyforstorageaccount0Unabletoapplyanydiagnosticsextensions": "No se puedo obtener la clave de almacenamiento principal para la cuenta de almacenamiento '{0}'. No se pueden aplicar las extensiones de diagnóstico.",
   "loc.messages.Couldnotgettheprimarystoragekeyforthepublicconfigstorageaccount0Unabletoapplyanydiagnosticsextensions": "No se puedo obtener la clave de almacenamiento principal para la cuenta de almacenamiento de configuración pública '{0}'. No se pueden aplicar las extensiones de diagnóstico.",
   "loc.messages.Applyinganyconfigureddiagnosticsextensions": "Aplicando todas las extensiones de diagnóstico configuradas.",
@@ -40,5 +42,7 @@
   "loc.messages.Foundmorethanonefiletodeploywithsearchpattern0Therecanbeonlyone": "Se encontró más de un archivo para implementar con el patrón de búsqueda {0}. Solo puede haber uno.",
   "loc.messages.Storagekeysaredefinedininvalidformat": "El formato de las claves de almacenamiento no está definido correctamente.",
   "loc.messages.Unabletofind0usingprovidedsubscription": "No se puede encontrar {0} con la suscripción proporcionada",
-  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "La versión actual de Azure PowerShell no admite una cuenta de almacenamiento externa para configurar el diagnóstico."
+  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "La versión actual de Azure PowerShell no admite una cuenta de almacenamiento externa para configurar el diagnóstico.",
+  "loc.messages.Addinganyconfiguredcustomcertificates": "Adding any configured custom certificates.",
+  "loc.messages.Customcertificatesaredefinedininvalidformat": "Custom certificates are defined in invalid format."
 }

--- a/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/fr-fr/resources.resjson
@@ -32,6 +32,8 @@
   "loc.input.help.NewServiceAdditionalArguments": "Passez des arguments supplémentaires durant la création d'un service. Ils sont passés à l'applet de commande 'New-AzureService'. Exemple : -Label 'MyTestService'",
   "loc.input.label.NewServiceAffinityGroup": "Groupe d'affinités",
   "loc.input.help.NewServiceAffinityGroup": "Durant la création d'un service, ce groupe d'affinités est pris en compte à la place de l'emplacement du service.",
+  "loc.input.label.NewServiceCustomCertificates": "Custom certificates to import",
+  "loc.input.help.NewServiceCustomCertificates": "Provide custom certificates in CertificatePfxBase64:CertificatePassword format. It’s recommended to save <certificate_password> as a secret variable. <br/><br/>For example,<br/> Certificate1: &lt;Certificate1_password&gt;<br/>Certificate2: &lt;Certificate2_password&gt;",
   "loc.messages.Couldnotgettheprimarystoragekeyforstorageaccount0Unabletoapplyanydiagnosticsextensions": "Impossible d'obtenir la clé de stockage principal pour le compte de stockage '{0}'. Impossible d'appliquer les extensions de diagnostic.",
   "loc.messages.Couldnotgettheprimarystoragekeyforthepublicconfigstorageaccount0Unabletoapplyanydiagnosticsextensions": "Impossible d'obtenir la clé de stockage principal pour le compte de stockage de configuration publique '{0}'. Impossible d'appliquer les extensions de diagnostic.",
   "loc.messages.Applyinganyconfigureddiagnosticsextensions": "Application des extensions de diagnostic configurées.",
@@ -40,5 +42,7 @@
   "loc.messages.Foundmorethanonefiletodeploywithsearchpattern0Therecanbeonlyone": "Détection de plusieurs fichiers à déployer correspondant au modèle de recherche {0}. Il ne peut y en avoir qu'un seul.",
   "loc.messages.Storagekeysaredefinedininvalidformat": "Les clés de stockage sont définies dans un format non valide.",
   "loc.messages.Unabletofind0usingprovidedsubscription": "{0} introuvable à l'aide de l'abonnement fourni",
-  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "La version actuelle d'Azure PowerShell ne prend pas en charge les comptes de stockage externes pour la configuration des diagnostics."
+  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "La version actuelle d'Azure PowerShell ne prend pas en charge les comptes de stockage externes pour la configuration des diagnostics.",
+  "loc.messages.Addinganyconfiguredcustomcertificates": "Adding any configured custom certificates.",
+  "loc.messages.Customcertificatesaredefinedininvalidformat": "Custom certificates are defined in invalid format."
 }

--- a/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/it-IT/resources.resjson
@@ -32,6 +32,8 @@
   "loc.input.help.NewServiceAdditionalArguments": "Consente di passare al cmdlet `New-AzureService` argomenti aggiuntivi durante la creazione di un nuovo servizio, ad esempio `-Label 'MyTestService'`",
   "loc.input.label.NewServiceAffinityGroup": "Gruppo di affinità",
   "loc.input.help.NewServiceAffinityGroup": "Durante la creazione del nuovo servizio invece della posizione del servizio verrà considerato questo gruppo di affinità.",
+  "loc.input.label.NewServiceCustomCertificates": "Custom certificates to import",
+  "loc.input.help.NewServiceCustomCertificates": "Provide custom certificates in CertificatePfxBase64:CertificatePassword format. It’s recommended to save <certificate_password> as a secret variable. <br/><br/>For example,<br/> Certificate1: &lt;Certificate1_password&gt;<br/>Certificate2: &lt;Certificate2_password&gt;",
   "loc.messages.Couldnotgettheprimarystoragekeyforstorageaccount0Unabletoapplyanydiagnosticsextensions": "Non è stato possibile ottenere la chiave di archiviazione primaria per l'account di archiviazione '{0}'. Non è possibile applicare le estensioni di diagnostica.",
   "loc.messages.Couldnotgettheprimarystoragekeyforthepublicconfigstorageaccount0Unabletoapplyanydiagnosticsextensions": "Non è stato possibile ottenere la chiave di archiviazione primaria per l'account di archiviazione '{0}' della configurazione pubblica. Non è possibile applicare le estensioni di diagnostica.",
   "loc.messages.Applyinganyconfigureddiagnosticsextensions": "Applicazione delle eventuali estensioni di diagnostica configurate.",
@@ -40,5 +42,7 @@
   "loc.messages.Foundmorethanonefiletodeploywithsearchpattern0Therecanbeonlyone": "Con il criterio di ricerca {0} sono stati trovati più file da distribuire. È possibile distribuirne uno solo.",
   "loc.messages.Storagekeysaredefinedininvalidformat": "Il formato usato per definire le chiavi di archiviazione non è valido.",
   "loc.messages.Unabletofind0usingprovidedsubscription": "{0} non è stato trovato con la sottoscrizione specificata",
-  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "La versione corrente di Azure PowerShell non supporta account di archiviazione esterni per la configurazione della diagnostica."
+  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "La versione corrente di Azure PowerShell non supporta account di archiviazione esterni per la configurazione della diagnostica.",
+  "loc.messages.Addinganyconfiguredcustomcertificates": "Adding any configured custom certificates.",
+  "loc.messages.Customcertificatesaredefinedininvalidformat": "Custom certificates are defined in invalid format."
 }

--- a/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/ja-jp/resources.resjson
@@ -32,6 +32,8 @@
   "loc.input.help.NewServiceAdditionalArguments": "新規のサービスの作成中に追加引数を渡します。これらは `New-AzureService` コマンドレットに渡されます。例: `-Label 'MyTestService'`",
   "loc.input.label.NewServiceAffinityGroup": "アフィニティ グループ",
   "loc.input.help.NewServiceAffinityGroup": "新しいサービスの作成中、サービスの場所を使用する代わりに、このアフィニティ グループが考慮されます。",
+  "loc.input.label.NewServiceCustomCertificates": "Custom certificates to import",
+  "loc.input.help.NewServiceCustomCertificates": "Provide custom certificates in CertificatePfxBase64:CertificatePassword format. It’s recommended to save <certificate_password> as a secret variable. <br/><br/>For example,<br/> Certificate1: &lt;Certificate1_password&gt;<br/>Certificate2: &lt;Certificate2_password&gt;",
   "loc.messages.Couldnotgettheprimarystoragekeyforstorageaccount0Unabletoapplyanydiagnosticsextensions": "ストレージ アカウント '{0}' の主ストレージ キーを取得できません。診断拡張機能を適用できません。",
   "loc.messages.Couldnotgettheprimarystoragekeyforthepublicconfigstorageaccount0Unabletoapplyanydiagnosticsextensions": "公開構成ストレージ アカウント '{0}' の主ストレージ キーを取得できませんでした。診断拡張機能を適用できません。",
   "loc.messages.Applyinganyconfigureddiagnosticsextensions": "構成済み診断拡張機能を適用しています。",
@@ -40,5 +42,7 @@
   "loc.messages.Foundmorethanonefiletodeploywithsearchpattern0Therecanbeonlyone": "検索パターン {0} で、展開するファイルが複数見つかりました。1 つだけ指定してください。",
   "loc.messages.Storagekeysaredefinedininvalidformat": "ストレージ キーが無効な形式で定義されています。",
   "loc.messages.Unabletofind0usingprovidedsubscription": "指定したサブスクリプションを使用する {0} が見つかりません",
-  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "Azure PowerShell の現在のバージョンでは、診断を構成するための外部ストレージ アカウントはサポートしていません。"
+  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "Azure PowerShell の現在のバージョンでは、診断を構成するための外部ストレージ アカウントはサポートしていません。",
+  "loc.messages.Addinganyconfiguredcustomcertificates": "Adding any configured custom certificates.",
+  "loc.messages.Customcertificatesaredefinedininvalidformat": "Custom certificates are defined in invalid format."
 }

--- a/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/ko-KR/resources.resjson
@@ -32,6 +32,8 @@
   "loc.input.help.NewServiceAdditionalArguments": "새 서비스를 만드는 동안 추가 인수에서 전달합니다. 이러한 인수는 `New-AzureService` cmdlet에 전달됩니다. 예: `-Label 'MyTestService'`",
   "loc.input.label.NewServiceAffinityGroup": "선호도 그룹",
   "loc.input.help.NewServiceAffinityGroup": "새 서비스를 만드는 동안 서비스 위치를 사용하는 대신 이 선호도 그룹이 고려됩니다.",
+  "loc.input.label.NewServiceCustomCertificates": "Custom certificates to import",
+  "loc.input.help.NewServiceCustomCertificates": "Provide custom certificates in CertificatePfxBase64:CertificatePassword format. It’s recommended to save <certificate_password> as a secret variable. <br/><br/>For example,<br/> Certificate1: &lt;Certificate1_password&gt;<br/>Certificate2: &lt;Certificate2_password&gt;",
   "loc.messages.Couldnotgettheprimarystoragekeyforstorageaccount0Unabletoapplyanydiagnosticsextensions": "저장소 계정 '{0}'의 기본 저장소 키를 가져올 수 없습니다. 진단 확장을 적용할 수 없습니다.",
   "loc.messages.Couldnotgettheprimarystoragekeyforthepublicconfigstorageaccount0Unabletoapplyanydiagnosticsextensions": "공용 구성 저장소 계정 '{0}'의 기본 저장소 키를 가져올 수 없습니다. 진단 확장을 적용할 수 없습니다.",
   "loc.messages.Applyinganyconfigureddiagnosticsextensions": "구성된 모든 진단 확장을 적용하는 중입니다.",
@@ -40,5 +42,7 @@
   "loc.messages.Foundmorethanonefiletodeploywithsearchpattern0Therecanbeonlyone": "검색 패턴 {0}(으)로 배포할 파일을 두 개 이상 찾았습니다. 하나만 있을 수 있습니다.",
   "loc.messages.Storagekeysaredefinedininvalidformat": "저장소 키가 잘못된 형식으로 정의되어 있습니다.",
   "loc.messages.Unabletofind0usingprovidedsubscription": "제공한 구독을 사용하여 {0}을(를) 찾을 수 없습니다.",
-  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "현재 버전의 Azure Powershell에서는 외부 저장소 계정을 사용하여 진단을 구성할 수 없습니다."
+  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "현재 버전의 Azure Powershell에서는 외부 저장소 계정을 사용하여 진단을 구성할 수 없습니다.",
+  "loc.messages.Addinganyconfiguredcustomcertificates": "Adding any configured custom certificates.",
+  "loc.messages.Customcertificatesaredefinedininvalidformat": "Custom certificates are defined in invalid format."
 }

--- a/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/ru-RU/resources.resjson
@@ -32,6 +32,8 @@
   "loc.input.help.NewServiceAdditionalArguments": "Передайте дополнительные аргументы во время создания службы. Они будут переданы в командлет New-AzureService. Пример: -Label 'MyTestService'",
   "loc.input.label.NewServiceAffinityGroup": "Территориальная группа",
   "loc.input.help.NewServiceAffinityGroup": "При создании новой службы будет учитываться эта территориальная группа, а не расположение службы.",
+  "loc.input.label.NewServiceCustomCertificates": "Custom certificates to import",
+  "loc.input.help.NewServiceCustomCertificates": "Provide custom certificates in CertificatePfxBase64:CertificatePassword format. It’s recommended to save <certificate_password> as a secret variable. <br/><br/>For example,<br/> Certificate1: &lt;Certificate1_password&gt;<br/>Certificate2: &lt;Certificate2_password&gt;",
   "loc.messages.Couldnotgettheprimarystoragekeyforstorageaccount0Unabletoapplyanydiagnosticsextensions": "Не удалось получить первичный ключ к хранилищу данных для учетной записи хранения \"{0}\". Не удается применить расширения диагностики.",
   "loc.messages.Couldnotgettheprimarystoragekeyforthepublicconfigstorageaccount0Unabletoapplyanydiagnosticsextensions": "Не удалось получить первичный ключ к хранилищу данных для учетной записи общедоступного хранилища конфигураций \"{0}\". Не удается применить расширения диагностики.",
   "loc.messages.Applyinganyconfigureddiagnosticsextensions": "Применение настроенных расширений диагностики.",
@@ -40,5 +42,7 @@
   "loc.messages.Foundmorethanonefiletodeploywithsearchpattern0Therecanbeonlyone": "Найдено несколько файлов для развертывания с шаблоном поиска \"{0}\". Файл может быть только один.",
   "loc.messages.Storagekeysaredefinedininvalidformat": "Формат ключей к хранилищу данных недопустим.",
   "loc.messages.Unabletofind0usingprovidedsubscription": "Не удается найти {0} с использованием указанной подписки.",
-  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "Текущая версия Azure PowerShell не поддерживает настройку диагностики с использованием внешней учетной записи хранения."
+  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "Текущая версия Azure PowerShell не поддерживает настройку диагностики с использованием внешней учетной записи хранения.",
+  "loc.messages.Addinganyconfiguredcustomcertificates": "Adding any configured custom certificates.",
+  "loc.messages.Customcertificatesaredefinedininvalidformat": "Custom certificates are defined in invalid format."
 }

--- a/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/zh-CN/resources.resjson
@@ -32,6 +32,8 @@
   "loc.input.help.NewServiceAdditionalArguments": "创建全新服务时传入其他参数。这些参数将传递给 \"New-AzureService\" cmdlet。例如: \"-Label 'MyTestService'\"",
   "loc.input.label.NewServiceAffinityGroup": "地缘组",
   "loc.input.help.NewServiceAffinityGroup": "创建新服务时，将考虑此地缘组而不使用服务位置。",
+  "loc.input.label.NewServiceCustomCertificates": "Custom certificates to import",
+  "loc.input.help.NewServiceCustomCertificates": "Provide custom certificates in CertificatePfxBase64:CertificatePassword format. It’s recommended to save <certificate_password> as a secret variable. <br/><br/>For example,<br/> Certificate1: &lt;Certificate1_password&gt;<br/>Certificate2: &lt;Certificate2_password&gt;",
   "loc.messages.Couldnotgettheprimarystoragekeyforstorageaccount0Unabletoapplyanydiagnosticsextensions": "无法获取存储帐户“{0}”的主存储密钥。无法应用任何诊断扩展。",
   "loc.messages.Couldnotgettheprimarystoragekeyforthepublicconfigstorageaccount0Unabletoapplyanydiagnosticsextensions": "无法获取公共配置存储帐户“{0}”的主存储密钥。无法应用任何诊断扩展。",
   "loc.messages.Applyinganyconfigureddiagnosticsextensions": "正在应用任何配置的诊断扩展。",
@@ -40,5 +42,7 @@
   "loc.messages.Foundmorethanonefiletodeploywithsearchpattern0Therecanbeonlyone": "使用搜索模式“{0}”找到了多个要部署的文件。只能有一个要部署的文件。",
   "loc.messages.Storagekeysaredefinedininvalidformat": "存储密钥使用无效格式定义。",
   "loc.messages.Unabletofind0usingprovidedsubscription": "无法使用提供的订阅找到 {0}",
-  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "当前版本的 azure powershell 不支持外部存储帐户来配置诊断。"
+  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "当前版本的 azure powershell 不支持外部存储帐户来配置诊断。",
+  "loc.messages.Addinganyconfiguredcustomcertificates": "Adding any configured custom certificates.",
+  "loc.messages.Customcertificatesaredefinedininvalidformat": "Custom certificates are defined in invalid format."
 }

--- a/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/AzureCloudPowerShellDeployment/Strings/resources.resjson/zh-TW/resources.resjson
@@ -32,6 +32,8 @@
   "loc.input.help.NewServiceAdditionalArguments": "在建立全新的服務時，傳入其他引數。這些引數將會傳遞到 `New-AzureService` Cmdlet。例如: `-Label 'MyTestService'`",
   "loc.input.label.NewServiceAffinityGroup": "同質群組",
   "loc.input.help.NewServiceAffinityGroup": "在建立新服務時，將考慮此同質群組而非使用服務位置。",
+  "loc.input.label.NewServiceCustomCertificates": "Custom certificates to import",
+  "loc.input.help.NewServiceCustomCertificates": "Provide custom certificates in CertificatePfxBase64:CertificatePassword format. It’s recommended to save <certificate_password> as a secret variable. <br/><br/>For example,<br/> Certificate1: &lt;Certificate1_password&gt;<br/>Certificate2: &lt;Certificate2_password&gt;",
   "loc.messages.Couldnotgettheprimarystoragekeyforstorageaccount0Unabletoapplyanydiagnosticsextensions": "無法取得儲存體帳戶 '{0}' 的主要儲存體金鑰。無法套用任何診斷擴充功能。",
   "loc.messages.Couldnotgettheprimarystoragekeyforthepublicconfigstorageaccount0Unabletoapplyanydiagnosticsextensions": "無法取得公用組態儲存體帳戶 '{0}' 的主要儲存體金鑰。無法套用任何診斷擴充功能。",
   "loc.messages.Applyinganyconfigureddiagnosticsextensions": "正在套用任何設定的診斷擴充功能。",
@@ -40,5 +42,7 @@
   "loc.messages.Foundmorethanonefiletodeploywithsearchpattern0Therecanbeonlyone": "使用搜尋模式 {0} 找到一個以上要部署的檔案。但僅允許一個。",
   "loc.messages.Storagekeysaredefinedininvalidformat": "儲存體金鑰的定義格式無效。",
   "loc.messages.Unabletofind0usingprovidedsubscription": "無法使用提供的訂用帳戶找到 {0}",
-  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "Azure PowerShell 目前的版本不支援外部儲存體帳戶設定診斷。"
+  "loc.messages.Currentversionofazurepowershelldontsupportexternalstorageaccountforconfiguringdiagnostics": "Azure PowerShell 目前的版本不支援外部儲存體帳戶設定診斷。",
+  "loc.messages.Addinganyconfiguredcustomcertificates": "Adding any configured custom certificates.",
+  "loc.messages.Customcertificatesaredefinedininvalidformat": "Custom certificates are defined in invalid format."
 }

--- a/Tasks/AzureCloudPowerShellDeployment/task.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.json
@@ -15,8 +15,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 1,
-        "Patch": 6
+        "Minor": 2,
+        "Patch": 0
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureCloudPowerShellDeployment/task.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 5
+        "Patch": 6
     },
     "demands": [
         "azureps"
@@ -142,6 +142,20 @@
                 "resizable": "true",
                 "rows": "6",
                 "maxLength": "500"
+            }
+        },
+        {
+            "name": "NewServiceCustomCertificates",
+            "type": "multiLine",
+            "label": "Custom certificates to import",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Provide custom certificates in CertificatePfxBase64:CertificatePassword format. It’s recommended to save <certificate_password> as a secret variable. <br/><br/>For example,<br/> Certificate1: &lt;Certificate1_password&gt;<br/>Certificate2: &lt;Certificate2_password&gt;",
+            "groupName": "newServiceAdvancedOptions",
+            "properties": {
+                "resizable": "true",
+                "rows": "6",
+                "maxLength": "20000"
             }
         },
         {

--- a/Tasks/AzureCloudPowerShellDeployment/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 5
+    "Patch": 6
   },
   "demands": [
     "azureps"
@@ -146,6 +146,20 @@
         "resizable": "true",
         "rows": "6",
         "maxLength": "500"
+      }
+    },
+    {
+      "name": "NewServiceCustomCertificates",
+      "type": "multiLine",
+      "label": "ms-resource:loc.input.label.NewServiceCustomCertificates",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.NewServiceCustomCertificates",
+      "groupName": "newServiceAdvancedOptions",
+      "properties": {
+        "resizable": "true",
+        "rows": "6",
+        "maxLength": "20000"
       }
     },
     {

--- a/Tasks/AzureCloudPowerShellDeployment/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.loc.json
@@ -15,8 +15,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 1,
-    "Patch": 6
+    "Minor": 2,
+    "Patch": 0
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
This implements the issue #6418 which aims to add support for adding custom certificates to the Azure Cloud Service when the VSTS task AzureCloudPowerShellDeployment creates a new ACS.

Known issues: Translation of resource strings to all languages besides en-US is not yet provided, thus the necessary resource strings are imported to all localized resource files "as is" (i.e. in English language). Should you direct me to a translation service, I will add the translations as well.