### PR TITLE
Bug and minor fixes for go tool

### DIFF
--- a/Tasks/GoTool/gotool.ts
+++ b/Tasks/GoTool/gotool.ts
@@ -115,7 +115,7 @@ function setGoEnvironmentVariables(goRoot: string) {
 // which have patch number as well.
 function fixVersion(version: string): string {
     let versionPart = version.split(".");
-    if(versionPart == null) {
+    if(versionPart[2] == null) {
         return version.concat(".0");
     } 
     return version;

--- a/Tasks/GoTool/gotool.ts
+++ b/Tasks/GoTool/gotool.ts
@@ -115,7 +115,12 @@ function setGoEnvironmentVariables(goRoot: string) {
 // which have patch number as well.
 function fixVersion(version: string): string {
     let versionPart = version.split(".");
-    if(versionPart[2] == null) {
+    if(versionPart[1] == null) {
+        //append minor and patch version if not available
+        return version.concat(".0.0");
+    }
+    else if(versionPart[2] == null) {
+        //append patch version if not available
         return version.concat(".0");
     } 
     return version;

--- a/Tasks/GoTool/package-lock.json
+++ b/Tasks/GoTool/package-lock.json
@@ -26,7 +26,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -44,7 +44,7 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -78,7 +78,7 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
     },
     "vsts-task-lib": {
       "version": "2.1.0",

--- a/Tasks/GoTool/task.json
+++ b/Tasks/GoTool/task.json
@@ -31,7 +31,7 @@
             "name": "version",
             "type": "string",
             "label": "Version",
-            "defaultValue": "1.9.3",
+            "defaultValue": "1.10",
             "required": true,
             "helpMarkDown": "Go tool version to download and install.  Examples: 1.9.3"
         },

--- a/Tasks/GoTool/task.loc.json
+++ b/Tasks/GoTool/task.loc.json
@@ -33,7 +33,7 @@
       "name": "version",
       "type": "string",
       "label": "ms-resource:loc.input.label.version",
-      "defaultValue": "1.9.3",
+      "defaultValue": "1.10",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.version"
     },


### PR DESCRIPTION
1. Bug 1188548 - When user enter the version with no patch number, cache utility fails, because it is expecting sementic version. Therefore, added the small function which can actually add patch version if not available

2. Removing localization - We cannot set the resource file, as it is already set by tool runner utility. we can only set resource file once. hence, we cannot have localization. Other task is also behaving the same way.

3. updating the default version to 1.10, as it the latest stable version