### PR TITLE
using fwd links for specifying winrm utilities (#6484)

### DIFF
--- a/Tasks/AzureFileCopy/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureFileCopy/Strings/resources.resjson/en-US/resources.resjson
@@ -88,5 +88,7 @@
   "loc.messages.AFC_UnableToSetCustomScriptExtension": "Unable to set the custom script extension '{0}' for virtual machine '{1}': {2}",
   "loc.messages.AFC_CopyPrereqsFailed": "Failed to enable copy prerequisites. {0}",
   "loc.messages.AFC_BlobStorageNotFound": "Storage account: {0} not found. Please specify existing storage account",
-  "loc.messages.AFC_RootContainerAndDirectory": "'/S' option is not valid for $root containers."
+  "loc.messages.AFC_RootContainerAndDirectory": "'/S' option is not valid for $root containers.",
+  "loc.messages.AFC_RedirectResponseInvalidStatusCode": "The HTTP response code: '{0}' is not a valid redirect status code",
+  "loc.messages.AFC_RedirectResponseLocationHeaderIsNull": "Redirect response location header is null."
 }

--- a/Tasks/AzureFileCopy/Tests/L0AddAzureVMCustomScriptExtension.ps1
+++ b/Tasks/AzureFileCopy/Tests/L0AddAzureVMCustomScriptExtension.ps1
@@ -7,6 +7,7 @@ param()
 . $PSScriptRoot\MockHelper.ps1
 
 Register-Mock Write-Telemetry { }
+Register-Mock Get-TargetUriFromFwdLink { "http://externalFile" }
 
 # Test 1 "Should throw Resource group name is null"
 Assert-Throws {

--- a/Tasks/AzureFileCopy/Utility.ps1
+++ b/Tasks/AzureFileCopy/Utility.ps1
@@ -1277,24 +1277,33 @@ function Is-WinRMCustomScriptExtensionExists
 
 function Get-TargetUriFromFwdLink { 
     param(
-        [string]$fwdLink,
-        [string]$extensionName,
-        [string]$vmName
+        [string]$fwdLink
     )   
     Write-Verbose "Trying to get the target uri from the fwdLink: $fwdLink"
     $proxy = Get-VstsWebProxy
     Add-Type -AssemblyName System.Net.Http
+    $validHttpRedirectCodes = @(
+        [System.Net.HttpStatusCode]::Moved,
+        [System.Net.HttpStatusCode]::MovedPermanently,
+        [System.Net.HttpStatusCode]::Found,
+        [System.Net.HttpStatusCode]::Redirect,
+        [System.Net.HttpStatusCode]::RedirectKeepVerb,
+        [System.Net.HttpStatusCode]::TemporaryRedirect
+    )
     $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
     $HttpClientHandler.Proxy = $proxy
     $HttpClientHandler.AllowAutoRedirect = $false
     $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
     $response = $HttpClient.GetAsync($fwdLink)
     $response.Wait()
+    if($validHttpRedirectCodes.IndexOf($response.Result.StatusCode) -eq -1) {
+        Write-Verbose "The http response code: $([int]$response.Result.StatusCode) is not a valid redirect response code."
+        throw (Get-VstsLocString -Key "AFC_RedirectResponseInvalidStatusCode" -ArgumentList $([int]$response.Result.StatusCode))
+    }
     $targetUri =  $response.Result.Headers.Location.AbsoluteUri
     if([string]::IsNullOrEmpty($targetUri)) {
         Write-Verbose "The target uri is null"
-        $errMessage = "targetUri = $targetUri"
-        throw (Get-VstsLocString -Key "AFC_SetCustomScriptExtensionFailed" -ArgumentList $extensionName, $vmName, $errMessage)
+        throw (Get-VstsLocString -Key "AFC_RedirectResponseLocationHeaderIsNull")
     }
     Write-Verbose "The target uri is: $targetUri"
     return $targetUri
@@ -1361,8 +1370,8 @@ function Add-AzureVMCustomScriptExtension
             return
         }
 
-        $configWinRMScriptFile = Get-TargetUriFromFwdLink -fwdLink $configWinRMScriptFileFwdLink -extensionName $extensionName -vmName $vmName
-        $makeCertFile = Get-TargetUriFromFwdLink -fwdLink $makeCertFileFwdLink -extensionName $extensionName -vmName $vmName
+        $configWinRMScriptFile = Get-TargetUriFromFwdLink -fwdLink $configWinRMScriptFileFwdLink
+        $makeCertFile = Get-TargetUriFromFwdLink -fwdLink $makeCertFileFwdLink
 
         $result = Set-AzureMachineCustomScriptExtension -resourceGroupName $resourceGroupName -vmName $vmName -name $extensionName -fileUri $configWinRMScriptFile, $makeCertFile  -run $scriptToRun -argument $dnsName -location $location
         $resultDetails = $result | ConvertTo-Json

--- a/Tasks/AzureFileCopy/make.json
+++ b/Tasks/AzureFileCopy/make.json
@@ -27,7 +27,7 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.8.2",
+                "version": "0.10.0",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {

--- a/Tasks/AzureFileCopy/task.json
+++ b/Tasks/AzureFileCopy/task.json
@@ -331,6 +331,8 @@
         "AFC_UnableToSetCustomScriptExtension": "Unable to set the custom script extension '{0}' for virtual machine '{1}': {2}",
         "AFC_CopyPrereqsFailed": "Failed to enable copy prerequisites. {0}",
         "AFC_BlobStorageNotFound": "Storage account: {0} not found. Please specify existing storage account",
-        "AFC_RootContainerAndDirectory": "'/S' option is not valid for $root containers."
+        "AFC_RootContainerAndDirectory": "'/S' option is not valid for $root containers.",
+        "AFC_RedirectResponseInvalidStatusCode": "The HTTP response code: '{0}' is not a valid redirect status code",
+        "AFC_RedirectResponseLocationHeaderIsNull": "Redirect response location header is null."
     }
 }

--- a/Tasks/AzureFileCopy/task.json
+++ b/Tasks/AzureFileCopy/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 107
+        "Patch": 108
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopy/task.loc.json
+++ b/Tasks/AzureFileCopy/task.loc.json
@@ -345,6 +345,8 @@
     "AFC_UnableToSetCustomScriptExtension": "ms-resource:loc.messages.AFC_UnableToSetCustomScriptExtension",
     "AFC_CopyPrereqsFailed": "ms-resource:loc.messages.AFC_CopyPrereqsFailed",
     "AFC_BlobStorageNotFound": "ms-resource:loc.messages.AFC_BlobStorageNotFound",
-    "AFC_RootContainerAndDirectory": "ms-resource:loc.messages.AFC_RootContainerAndDirectory"
+    "AFC_RootContainerAndDirectory": "ms-resource:loc.messages.AFC_RootContainerAndDirectory",
+    "AFC_RedirectResponseInvalidStatusCode": "ms-resource:loc.messages.AFC_RedirectResponseInvalidStatusCode",
+    "AFC_RedirectResponseLocationHeaderIsNull": "ms-resource:loc.messages.AFC_RedirectResponseLocationHeaderIsNull"
   }
 }

--- a/Tasks/AzureFileCopy/task.loc.json
+++ b/Tasks/AzureFileCopy/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 107
+    "Patch": 108
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureResourceGroupDeployment/Tests/EnablePrereq.ts
+++ b/Tasks/AzureResourceGroupDeployment/Tests/EnablePrereq.ts
@@ -43,6 +43,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 tr.setAnswers(a);
 
 tr.registerMock('vsts-task-lib/toolrunner', require('vsts-task-lib/mock-toolrunner'));
+tr.registerMock('azure-arm-rest/webRequestUtility', require('./mock_node_modules/webRequestUtility'));
 tr.registerMock('azure-arm-rest/azure-arm-compute', require('./mock_node_modules/azure-arm-compute'));
 tr.registerMock('azure-arm-rest/azure-arm-network', require('./mock_node_modules/azure-arm-network'));
 tr.registerMock('azure-arm-rest/azure-arm-resource', require('./mock_node_modules/azure-arm-resource'));

--- a/Tasks/AzureResourceGroupDeployment/Tests/addVSTSExtension.ts
+++ b/Tasks/AzureResourceGroupDeployment/Tests/addVSTSExtension.ts
@@ -51,6 +51,7 @@ process.env["MOCK_NORMALIZE_SLASHES"] = "true";
 tr.setAnswers(a);
 
 tr.registerMock('vsts-task-lib/toolrunner', require('vsts-task-lib/mock-toolrunner'));
+tr.registerMock('azure-arm-rest/webRequestUtility', require('./mock_node_modules/webRequestUtility'));
 tr.registerMock('azure-arm-rest/azure-arm-network', require('./mock_node_modules/azure-arm-network'));
 tr.registerMock('azure-arm-rest/azure-arm-resource', require('./mock_node_modules/azure-arm-resource'));
 tr.registerMock('azure-arm-rest/azure-arm-compute', require('./mock_node_modules/azure-arm-compute'));

--- a/Tasks/AzureResourceGroupDeployment/Tests/mock_node_modules/webRequestUtility.ts
+++ b/Tasks/AzureResourceGroupDeployment/Tests/mock_node_modules/webRequestUtility.ts
@@ -1,0 +1,12 @@
+class WebRequestUtility {
+    public static async getTargetUriFromFwdLink(fwdLink: string) {
+        if(fwdLink == "https://aka.ms/vstsconfigurewinrm") {
+            return "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/501dc7d24537e820df7c80bce51aba9674233b2b/201-vm-winrm-windows/ConfigureWinRM.ps1"
+        }
+        if(fwdLink == "https://aka.ms/vstsmakecertexe") {
+            return "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/501dc7d24537e820df7c80bce51aba9674233b2b/201-vm-winrm-windows/makecert.exe"
+        }
+    }
+}
+
+export = WebRequestUtility;

--- a/Tasks/AzureResourceGroupDeployment/operations/WinRMExtensionHelper.ts
+++ b/Tasks/AzureResourceGroupDeployment/operations/WinRMExtensionHelper.ts
@@ -6,6 +6,7 @@ import azure_utils = require("./AzureUtil");
 import deployAzureRG = require("../models/DeployAzureRG");
 import az = require("azure-arm-rest/azureModels");
 import utils = require("./Utils");
+import webRequestUtility = require("azure-arm-rest/webRequestUtility");
 
 export class WinRMExtensionHelper {
     private taskParameters: deployAzureRG.AzureRGTaskParameters;
@@ -289,8 +290,12 @@ export class WinRMExtensionHelper {
 
     private async AddWinRMExtension(vmId: string, vmName: string, dnsName: string, location: string) {
         var extensionName: string = "WinRMCustomScriptExtension";
-        var configWinRMScriptFile: string = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/501dc7d24537e820df7c80bce51aba9674233b2b/201-vm-winrm-windows/ConfigureWinRM.ps1";
-        var makeCertFile: string = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/501dc7d24537e820df7c80bce51aba9674233b2b/201-vm-winrm-windows/makecert.exe";
+        var configWinRMScriptFileFwdLink: string = "https://aka.ms/vstsconfigurewinrm";
+        var makeCertFileFwdLink: string = "https://aka.ms/vstsmakecertexe";
+
+        var configWinRMScriptFile: string = await webRequestUtility.getTargetUriFromFwdLink(configWinRMScriptFileFwdLink);
+        var makeCertFile: string = await webRequestUtility.getTargetUriFromFwdLink(makeCertFileFwdLink);
+        
         var fileUris = [configWinRMScriptFile, makeCertFile];
 
         tl.debug("Adding custom script extension for virtual machine " + vmName);

--- a/Tasks/AzureResourceGroupDeployment/task.json
+++ b/Tasks/AzureResourceGroupDeployment/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 131,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.119.1",

--- a/Tasks/AzureResourceGroupDeployment/task.loc.json
+++ b/Tasks/AzureResourceGroupDeployment/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 131,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.119.1",

--- a/Tasks/Common/azure-arm-rest/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Common/azure-arm-rest/Strings/resources.resjson/en-US/resources.resjson
@@ -127,5 +127,7 @@
   "loc.messages.FailedToUploadFile": "Failed to upload file '%s/%s from Kudu. Error: %s",
   "loc.messages.FailedToGetFileContent": "Failed to get file content '%s/%s' from Kudu. Error: %s",
   "loc.messages.FailedToListPath": "Failed to list path '%s'. Error: %s",
-  "loc.messages.FailedToGetDeploymentLogs": "Failed to get deployment logs. Error: %s"
+  "loc.messages.FailedToGetDeploymentLogs": "Failed to get deployment logs. Error: %s",
+  "loc.messages.ARG_RedirectResponseInvalidStatusCode": "The HTTP response code: '%s' is not a valid redirect status code.",
+  "loc.messages.ARG_RedirectResponseLocationHeaderIsNull": "Location header is null for HTTP response with status code: %s"
 }

--- a/Tasks/Common/azure-arm-rest/module.json
+++ b/Tasks/Common/azure-arm-rest/module.json
@@ -128,6 +128,8 @@
         "FailedToUploadFile": "Failed to upload file '%s/%s from Kudu. Error: %s",
         "FailedToGetFileContent": "Failed to get file content '%s/%s' from Kudu. Error: %s",
         "FailedToListPath": "Failed to list path '%s'. Error: %s",
-        "FailedToGetDeploymentLogs": "Failed to get deployment logs. Error: %s"
+        "FailedToGetDeploymentLogs": "Failed to get deployment logs. Error: %s",
+        "ARG_RedirectResponseInvalidStatusCode": "The HTTP response code: '%s' is not a valid redirect status code.",
+        "ARG_RedirectResponseLocationHeaderIsNull": "Location header is null for HTTP response with status code: %s"
     }
 }

--- a/Tasks/Common/azure-arm-rest/webRequestUtility.ts
+++ b/Tasks/Common/azure-arm-rest/webRequestUtility.ts
@@ -1,0 +1,23 @@
+import tl = require("vsts-task-lib/task");
+import webClient = require("./webClient");
+const HttpRedirectCodes: number[] = [301, 302, 307, 308];
+class WebRequestUtility {
+    public static async getTargetUriFromFwdLink(fwdLink: string) {
+        tl.debug("Trying to fetch target link from the fwdlink: " + fwdLink);
+        var httpRequest = new webClient.WebRequest();
+        httpRequest.method = 'GET';
+        httpRequest.uri = fwdLink;
+        var httpResponse = await webClient.sendRequest(httpRequest);
+        if(HttpRedirectCodes.indexOf(httpResponse.statusCode) == -1) {
+            throw new Error(`HttpResponse statuscode: ${httpResponse.statusCode} is not a valid HTTP redirect code.`); 
+        }
+        var targetLink: string = httpResponse.headers["location"];
+        if(!targetLink) {
+            throw new Error(`Unable to find location header after HTTP ${httpResponse.statusCode} redirect.`);
+        }
+        tl.debug("the target link is : " + targetLink);
+        return targetLink;
+    }
+}
+
+export = WebRequestUtility;

--- a/Tasks/Common/azure-arm-rest/webRequestUtility.ts
+++ b/Tasks/Common/azure-arm-rest/webRequestUtility.ts
@@ -9,11 +9,11 @@ class WebRequestUtility {
         httpRequest.uri = fwdLink;
         var httpResponse = await webClient.sendRequest(httpRequest);
         if(HttpRedirectCodes.indexOf(httpResponse.statusCode) == -1) {
-            throw new Error(`HttpResponse statuscode: ${httpResponse.statusCode} is not a valid HTTP redirect code.`); 
+            throw new Error(tl.loc('ARG_RedirectResponseInvalidStatusCode', httpResponse.statusCode)); 
         }
         var targetLink: string = httpResponse.headers["location"];
         if(!targetLink) {
-            throw new Error(`Unable to find location header after HTTP ${httpResponse.statusCode} redirect.`);
+            throw new Error(tl.loc('ARG_RedirectResponseLocationHeaderIsNull', httpResponse.statusCode));
         }
         tl.debug("the target link is : " + targetLink);
         return targetLink;


### PR DESCRIPTION
* using fwd links for specifying winrm utilities

* handling proxy for invoking a web request

* putting add-type under a try catch block

* changing patch to 108

* removing add-type from a try catch block as the task does not run on ps core

* throwing an exception if target uri is null