### PR TITLE
Adding fix for removing old trx files in case of multiple test tasks

### DIFF
--- a/Tasks/DotNetCoreCLI/Tests/TestCommandTests/publishtests.ts
+++ b/Tasks/DotNetCoreCLI/Tests/TestCommandTests/publishtests.ts
@@ -41,6 +41,11 @@ const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     'findMatch': {
         'temp.csproj': ['c:\\agent\\home\\directory\\temp.csproj'],
         '**/*.trx': ['c:\\agent\\home\\temp\\sample.trx']
+    },
+    "rmRF": {
+        "c:\\agent\\home\\temp\\sample.trx": {
+            "success": true
+        }
     }
 };
 nmh.setAnswers(a);

--- a/Tasks/DotNetCoreCLI/Tests/TestCommandTests/publishtestsWithFailedTestCommand.ts
+++ b/Tasks/DotNetCoreCLI/Tests/TestCommandTests/publishtestsWithFailedTestCommand.ts
@@ -41,6 +41,11 @@ const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     'findMatch': {
         'temp.csproj': ['c:\\agent\\home\\directory\\temp.csproj'],
         '**/*.trx': ['c:\\agent\\home\\temp\\sample.trx']
+    },
+    "rmRF": {
+        "c:\\agent\\home\\temp\\sample.trx": {
+            "success": true
+        }
     }
 };
 nmh.setAnswers(a);

--- a/Tasks/DotNetCoreCLI/Tests/TestCommandTests/publishtestsWithoutBuildConfig.ts
+++ b/Tasks/DotNetCoreCLI/Tests/TestCommandTests/publishtestsWithoutBuildConfig.ts
@@ -39,6 +39,11 @@ const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     'findMatch': {
         'temp.csproj': ['c:\\agent\\home\\directory\\temp.csproj'],
         '**/*.trx': ['c:\\agent\\home\\temp\\sample.trx']
+    },
+    "rmRF": {
+        "c:\\agent\\home\\temp\\sample.trx": {
+            "success": true
+        }
     }
 };
 nmh.setAnswers(a);

--- a/Tasks/DotNetCoreCLI/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLI/dotnetcore.ts
@@ -103,6 +103,9 @@ export class dotNetExe {
         if (enablePublishTestResults && enablePublishTestResults === true) {
             this.arguments = this.arguments.concat(` --logger trx --results-directory ${resultsDirectory}`);
         }
+        
+        // Remove old trx files
+        this.removeOldTestResultFiles(resultsDirectory);
 
         // Use empty string when no project file is specified to operate on the current directory
         const projectFiles = this.getProjectFiles();
@@ -145,6 +148,19 @@ export class dotNetExe {
             const tp: tl.TestPublisher = new tl.TestPublisher('VSTest');
             tp.publish(matchingTestResultsFiles, 'false', buildPlaform, buildConfig, '', 'true');
             //refer https://github.com/Microsoft/vsts-task-lib/blob/master/node/task.ts#L1620
+        }
+    }
+
+    private removeOldTestResultFiles(resultsDir:string): void {
+        const matchingTestResultsFiles: string[] = tl.findMatch(resultsDir, '**/*.trx');
+        if (!matchingTestResultsFiles || matchingTestResultsFiles.length === 0) {
+            tl.debug("No old result files found.");
+            return;
+        }
+        for (const fileIndex of Object.keys(matchingTestResultsFiles)) {
+            const resultFile = matchingTestResultsFiles[fileIndex];            
+            tl.rmRF(resultFile)
+            tl.debug("Successfuly removed: " + resultFile);
         }
     }
 

--- a/Tasks/DotNetCoreCLI/task.json
+++ b/Tasks/DotNetCoreCLI/task.json
@@ -16,7 +16,7 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 131,
+        "Minor": 132,
         "Patch": 0
     },
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/DotNetCoreCLI/task.loc.json
+++ b/Tasks/DotNetCoreCLI/task.loc.json
@@ -16,7 +16,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 131,
+    "Minor": 132,
     "Patch": 0
   },
   "minimumAgentVersion": "2.0.0",


### PR DESCRIPTION
This PR is to address the issue [here](https://github.com/Microsoft/vsts-tasks/issues/6488).

Currenty, if there are two or more .Net tasks with test command, all the tasks after the first one publish the result files created by the tasks before it, creating multiple runs. This code fix will delete the trx files before running the tests, thus leaving only the trx file from the current run before the publish command is called.