### PR TITLE
Stop special handling of exportPath in VSTS Xcode task

### DIFF
--- a/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
@@ -59,8 +59,6 @@
   "loc.input.help.args": "(Optional) Enter additional command line arguments with which to build. This is useful for specifying `-target` or `-project` arguments instead of specifying a workspace/project and scheme. See the [xcodebuild man page](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/xcodebuild.1.html).",
   "loc.input.label.cwd": "Working directory",
   "loc.input.help.cwd": "(Optional) Enter the working directory in which to run the build. If no value is entered, the root of the repository will be used.",
-  "loc.input.label.outputPattern": "Output directory",
-  "loc.input.help.outputPattern": "(Optional) Enter a path relative to the working directory where build output (binaries) will be placed. Examples: `output/$(SDK)/$(Configuration)` or `output/$(TestSDK)/$(TestConfiguration)`. Archive and export paths are configured separately.",
   "loc.input.label.useXcpretty": "Use xcpretty",
   "loc.input.help.useXcpretty": "Specify whether to use xcpretty to format xcodebuild output and generate JUnit test results. Enabling this requires xcpretty to be installed on the agent machine. It is preinstalled on VSTS hosted build agents. See [xcpretty](https://github.com/supermarin/xcpretty) on GitHub.",
   "loc.input.label.publishJUnitResults": "Publish test results to VSTS/TFS",

--- a/Tasks/Xcode/Tests/L0.ts
+++ b/Tasks/Xcode/Tests/L0.ts
@@ -38,7 +38,7 @@ describe('Xcode L0 Suite', function () {
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive ' +
             '-archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            '-exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.invokedToolCount === 11, 'should have run xcodebuild for version, build, archive and export and PlistBuddy to init and add export method.');
@@ -72,7 +72,7 @@ describe('Xcode L0 Suite', function () {
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive ' +
             '-archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            '-exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.invokedToolCount === 6, 'should have run xcodebuild for version, build, archive and export and PlistBuddy to init and add export method.');
@@ -106,7 +106,7 @@ describe('Xcode L0 Suite', function () {
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive ' +
             '-archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist /user/build/exportOptions.plist'),
+            '-exportPath /user/build -exportOptionsPlist /user/build/exportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.invokedToolCount === 4, 'should have run xcodebuild for version, build, archive and export.');
@@ -206,7 +206,7 @@ describe('Xcode L0 Suite', function () {
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive ' +
             '-archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            '-exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
@@ -239,7 +239,7 @@ describe('Xcode L0 Suite', function () {
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive ' +
             '-archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            '-exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
@@ -276,7 +276,7 @@ describe('Xcode L0 Suite', function () {
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive ' +
             '-archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            '-exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
@@ -314,7 +314,7 @@ describe('Xcode L0 Suite', function () {
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive ' +
             '-archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            '-exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
@@ -351,7 +351,7 @@ describe('Xcode L0 Suite', function () {
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive ' +
             '-archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            '-exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
@@ -388,7 +388,7 @@ describe('Xcode L0 Suite', function () {
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive ' +
             '-archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist ' +
+            '-exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist ' +
             '-allowProvisioningUpdates'),
             'xcodebuild exportArchive should have been run with -allowProvisioningUpdates to export the IPA from the .xcarchive');
 
@@ -417,7 +417,7 @@ describe('Xcode L0 Suite', function () {
 
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            '-exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
@@ -455,7 +455,7 @@ describe('Xcode L0 Suite', function () {
 
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            '-exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
@@ -496,7 +496,7 @@ describe('Xcode L0 Suite', function () {
 
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            '-exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
@@ -537,7 +537,7 @@ describe('Xcode L0 Suite', function () {
 
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive ' +
-            '-exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            '-exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
@@ -623,7 +623,7 @@ describe('Xcode L0 Suite', function () {
 
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive'
-            +' -exportPath /user/build/_XcodeTaskExport_funScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            +' -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
@@ -650,7 +650,7 @@ describe('Xcode L0 Suite', function () {
 
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive'
-            +' -exportPath /user/build/_XcodeTaskExport_funScheme -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            +' -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
             'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');

--- a/Tasks/Xcode/Tests/L0.ts
+++ b/Tasks/Xcode/Tests/L0.ts
@@ -25,11 +25,7 @@ describe('Xcode L0 Suite', function () {
         assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
         //build
         assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
-            '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build ' +
-            'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-            'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-            'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-            'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch'),
+            '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build'),
             'xcodebuild for building the ios project/workspace should have been run.');
         //archive
         assert(tr.ran('/home/bin/xcodebuild -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme ' +
@@ -59,11 +55,7 @@ describe('Xcode L0 Suite', function () {
         assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
         //build
         assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
-            '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build ' +
-            'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-            'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-            'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-            'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch'),
+            '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build'),
             'xcodebuild for building the ios project/workspace should have been run.');
         //archive
         assert(tr.ran('/home/bin/xcodebuild -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme ' +
@@ -93,11 +85,7 @@ describe('Xcode L0 Suite', function () {
         assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
         //build
         assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
-            '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build ' +
-            'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-            'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-            'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-            'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch'),
+            '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build'),
             'xcodebuild for building the ios project/workspace should have been run.');
         //archive
         assert(tr.ran('/home/bin/xcodebuild -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme ' +
@@ -127,11 +115,7 @@ describe('Xcode L0 Suite', function () {
         assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
         //build
         assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
-            '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build ' +
-            'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-            'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-            'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-            'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch'),
+            '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build'),
             'xcodebuild for building the ios project/workspace should have been run.');
         //archive
         assert(tr.ran('/home/bin/xcodebuild -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme ' +
@@ -157,11 +141,7 @@ describe('Xcode L0 Suite', function () {
         assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
         //build
         assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
-            '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build ' +
-            'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-            'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-            'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-            'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch'),
+            '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build'),
             'xcodebuild for building the ios project/workspace should have been run.');
         //archive
         assert(tr.ran('/home/bin/xcodebuild -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme ' +
@@ -192,10 +172,6 @@ describe('Xcode L0 Suite', function () {
         //build
         assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
             '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build ' +
-            'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-            'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-            'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-            'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch ' +
             'CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid'),
             'xcodebuild for building the ios project/workspace should have been run.');
         //archive
@@ -227,10 +203,7 @@ describe('Xcode L0 Suite', function () {
         //build
         assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
             '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build ' +
-            'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-            'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-            'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-            'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Automatic'),
+            'CODE_SIGN_STYLE=Automatic'),
             'xcodebuild for building the ios project/workspace should have been run.');
         //archive
         assert(tr.ran('/home/bin/xcodebuild -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme ' +
@@ -260,10 +233,6 @@ describe('Xcode L0 Suite', function () {
         //build
         assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
             '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build ' +
-            'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-            'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-            'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-            'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch ' +
             'CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=testDevTeamId'),
             'xcodebuild for building the ios project/workspace should have been run.');
 
@@ -297,10 +266,6 @@ describe('Xcode L0 Suite', function () {
         //build
         assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
             '-project /user/build/fun.xcodeproj -scheme testScheme build ' +
-            'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-            'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-            'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-            'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch ' +
             'CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=testDevTeamId'),
             'xcodebuild for building the ios project/workspace should have been run.');
 
@@ -335,10 +300,6 @@ describe('Xcode L0 Suite', function () {
         //build
         assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
             '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build ' +
-            'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-            'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-            'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-            'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch ' +
             'CODE_SIGN_STYLE=Automatic'),
             'xcodebuild for building the ios project/workspace should have been run.');
 
@@ -372,10 +333,6 @@ describe('Xcode L0 Suite', function () {
         //build
         assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
             '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build ' +
-            'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-            'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-            'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-            'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch ' +
             '-allowProvisioningUpdates CODE_SIGN_STYLE=Automatic'),
             'xcodebuild for building the ios project/workspace should have been run with -allowProvisioningUpdates.');
 

--- a/Tasks/Xcode/Tests/L0CreateIpaWithCodeSigningIdentifiers.ts
+++ b/Tasks/Xcode/Tests/L0CreateIpaWithCodeSigningIdentifiers.ts
@@ -53,9 +53,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "getVariable": {
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -85,7 +82,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0CreateIpaWithCodeSigningIdentifiers.ts
+++ b/Tasks/Xcode/Tests/L0CreateIpaWithCodeSigningIdentifiers.ts
@@ -74,7 +74,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 7.3.1"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0ExportArchiveAtSpecificPath.ts
+++ b/Tasks/Xcode/Tests/L0ExportArchiveAtSpecificPath.ts
@@ -63,7 +63,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 7.3.1"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0ExportArchiveAtSpecificPath.ts
+++ b/Tasks/Xcode/Tests/L0ExportArchiveAtSpecificPath.ts
@@ -45,9 +45,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "build.sourcesDirectory": "/user/build",
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -74,7 +71,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/output/myipa.ipa/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/output/myipa.ipa -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0ExportArchiveSpecify.ts
+++ b/Tasks/Xcode/Tests/L0ExportArchiveSpecify.ts
@@ -69,7 +69,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 7.3.1"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0ExportArchiveSpecify.ts
+++ b/Tasks/Xcode/Tests/L0ExportArchiveSpecify.ts
@@ -48,9 +48,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "build.sourcesDirectory": "/user/build",
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -80,7 +77,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0ExportArchiveWithAuto.ts
+++ b/Tasks/Xcode/Tests/L0ExportArchiveWithAuto.ts
@@ -75,7 +75,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 7.3.1"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0ExportArchiveWithAuto.ts
+++ b/Tasks/Xcode/Tests/L0ExportArchiveWithAuto.ts
@@ -51,9 +51,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "build.sourcesDirectory": "/user/build",
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -86,7 +83,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0ExportArchiveWithPlist.ts
+++ b/Tasks/Xcode/Tests/L0ExportArchiveWithPlist.ts
@@ -73,7 +73,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 8.0"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0ExportArchiveWithPlist.ts
+++ b/Tasks/Xcode/Tests/L0ExportArchiveWithPlist.ts
@@ -49,9 +49,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "build.sourcesDirectory": "/user/build",
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -84,7 +81,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist /user/build/exportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist /user/build/exportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         }

--- a/Tasks/Xcode/Tests/L0ExportOptionsPlistBadPath.ts
+++ b/Tasks/Xcode/Tests/L0ExportOptionsPlistBadPath.ts
@@ -73,7 +73,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 8.0"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0ExportOptionsPlistBadPath.ts
+++ b/Tasks/Xcode/Tests/L0ExportOptionsPlistBadPath.ts
@@ -49,9 +49,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "build.sourcesDirectory": "/user/build",
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false

--- a/Tasks/Xcode/Tests/L0FilePathForArchiveAndExportPath.ts
+++ b/Tasks/Xcode/Tests/L0FilePathForArchiveAndExportPath.ts
@@ -69,7 +69,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 7.3.1"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0FilePathForArchiveAndExportPath.ts
+++ b/Tasks/Xcode/Tests/L0FilePathForArchiveAndExportPath.ts
@@ -48,9 +48,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "build.sourcesDirectory": "/user/build",
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false

--- a/Tasks/Xcode/Tests/L0TaskDefaults_4.127.0.ts
+++ b/Tasks/Xcode/Tests/L0TaskDefaults_4.127.0.ts
@@ -53,9 +53,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "getVariable": {
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false

--- a/Tasks/Xcode/Tests/L0XCode9SigningDefaultsToAutoWithAutoExport.ts
+++ b/Tasks/Xcode/Tests/L0XCode9SigningDefaultsToAutoWithAutoExport.ts
@@ -107,7 +107,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 9.0"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0XCode9SigningDefaultsToAutoWithAutoExport.ts
+++ b/Tasks/Xcode/Tests/L0XCode9SigningDefaultsToAutoWithAutoExport.ts
@@ -80,9 +80,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "build.sourcesDirectory": "/user/build",
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -118,7 +115,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0XCode9SigningDefaultsToManualWithAutoExport.ts
+++ b/Tasks/Xcode/Tests/L0XCode9SigningDefaultsToManualWithAutoExport.ts
@@ -81,9 +81,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "build.sourcesDirectory": "/user/build",
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -119,7 +116,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0XCode9SigningDefaultsToManualWithAutoExport.ts
+++ b/Tasks/Xcode/Tests/L0XCode9SigningDefaultsToManualWithAutoExport.ts
@@ -108,7 +108,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 9.0"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode8AutomaticSignWithDevTeam.ts
+++ b/Tasks/Xcode/Tests/L0Xcode8AutomaticSignWithDevTeam.ts
@@ -54,9 +54,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "getVariable": {
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -86,7 +83,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode8AutomaticSignWithDevTeam.ts
+++ b/Tasks/Xcode/Tests/L0Xcode8AutomaticSignWithDevTeam.ts
@@ -75,7 +75,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 8.0"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=testDevTeamId": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=testDevTeamId": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode8AutomaticSignWithIdentifiers.ts
+++ b/Tasks/Xcode/Tests/L0Xcode8AutomaticSignWithIdentifiers.ts
@@ -74,7 +74,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 8.0"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Automatic": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build CODE_SIGN_STYLE=Automatic": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode8AutomaticSignWithIdentifiers.ts
+++ b/Tasks/Xcode/Tests/L0Xcode8AutomaticSignWithIdentifiers.ts
@@ -53,9 +53,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "getVariable": {
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -85,7 +82,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode9AutomaticSignWithAllowProvisioningUpdates.ts
+++ b/Tasks/Xcode/Tests/L0Xcode9AutomaticSignWithAllowProvisioningUpdates.ts
@@ -52,9 +52,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "getVariable": {
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -84,7 +81,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist -allowProvisioningUpdates": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist -allowProvisioningUpdates": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode9AutomaticSignWithAllowProvisioningUpdates.ts
+++ b/Tasks/Xcode/Tests/L0Xcode9AutomaticSignWithAllowProvisioningUpdates.ts
@@ -73,7 +73,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 9.0"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch -allowProvisioningUpdates CODE_SIGN_STYLE=Automatic": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build -allowProvisioningUpdates CODE_SIGN_STYLE=Automatic": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode9AutomaticSignWithFiles.ts
+++ b/Tasks/Xcode/Tests/L0Xcode9AutomaticSignWithFiles.ts
@@ -74,7 +74,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 9.0"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Automatic": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build CODE_SIGN_STYLE=Automatic": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode9AutomaticSignWithFiles.ts
+++ b/Tasks/Xcode/Tests/L0Xcode9AutomaticSignWithFiles.ts
@@ -53,9 +53,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "getVariable": {
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -85,7 +82,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode9ExportArchiveWithAutoAndCloudEntitlementForDevelopment.ts
+++ b/Tasks/Xcode/Tests/L0Xcode9ExportArchiveWithAutoAndCloudEntitlementForDevelopment.ts
@@ -81,9 +81,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "build.sourcesDirectory": "/user/build",
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -119,7 +116,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode9ExportArchiveWithAutoAndCloudEntitlementForDevelopment.ts
+++ b/Tasks/Xcode/Tests/L0Xcode9ExportArchiveWithAutoAndCloudEntitlementForDevelopment.ts
@@ -108,7 +108,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 9.0"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode9ExportArchiveWithAutoAndCloudEntitlementForProduction.ts
+++ b/Tasks/Xcode/Tests/L0Xcode9ExportArchiveWithAutoAndCloudEntitlementForProduction.ts
@@ -81,9 +81,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "build.sourcesDirectory": "/user/build",
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -119,7 +116,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0Xcode9ExportArchiveWithAutoAndCloudEntitlementForProduction.ts
+++ b/Tasks/Xcode/Tests/L0Xcode9ExportArchiveWithAutoAndCloudEntitlementForProduction.ts
@@ -108,7 +108,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 9.0"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0XcodeArchiveExportProject.ts
+++ b/Tasks/Xcode/Tests/L0XcodeArchiveExportProject.ts
@@ -75,7 +75,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 8.0"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -project /user/build/fun.xcodeproj -scheme testScheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=testDevTeamId": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -project /user/build/fun.xcodeproj -scheme testScheme build CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=testDevTeamId": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },

--- a/Tasks/Xcode/Tests/L0XcodeArchiveExportProject.ts
+++ b/Tasks/Xcode/Tests/L0XcodeArchiveExportProject.ts
@@ -54,9 +54,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "getVariable": {
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -86,7 +83,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_testScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0macOSAutoExport.ts
+++ b/Tasks/Xcode/Tests/L0macOSAutoExport.ts
@@ -77,9 +77,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "getVariable": {
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -120,7 +117,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_funScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/Tests/L0macOSProvisionlessAutoExport.ts
+++ b/Tasks/Xcode/Tests/L0macOSProvisionlessAutoExport.ts
@@ -75,9 +75,6 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "getVariable": {
         "HOME": "/users/test"
     },
-    "exist": {
-        "/user/build/_XcodeTaskExport_testScheme": false
-    },
     "stats": {
         "/user/build": {
             "isFile": false
@@ -118,7 +115,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },
-        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build/_XcodeTaskExport_funScheme -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/testScheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
             "code": 0,
             "stdout": "xcodebuild export output here"
         },

--- a/Tasks/Xcode/package-lock.json
+++ b/Tasks/Xcode/package-lock.json
@@ -25,30 +25,14 @@
     },
     "ios-signing-common": {
       "version": "file:../../_build/Tasks/Common/ios-signing-common-1.0.0.tgz",
-      "integrity": "sha1-H7bmnqbdL78k2DmCDCjGNW35/8s=",
       "requires": {
         "vsts-task-lib": "2.2.1"
-      },
-      "dependencies": {
-        "vsts-task-lib": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.2.1.tgz",
-          "integrity": "sha512-FYllK73r1K7+sPUtWKZ4tihskJgpGB3YdNX4qr1YO0cmhFAWHm9FfEVxmKdlNeIyDtu3NyRb4wVUz0Gwi5LyGA==",
-          "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.5.1",
-            "semver": "5.5.0",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
-          }
-        }
       }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -10,8 +10,8 @@
     ],
     "author": "Microsoft Corporation",
     "version": {
-        "Major": 4,
-        "Minor": 130,
+        "Major": 5,
+        "Minor": 132,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -11,7 +11,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 5,
-        "Minor": 132,
+        "Minor": 133,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -308,14 +308,6 @@
             "groupName": "advanced"
         },
         {
-            "name": "outputPattern",
-            "type": "string",
-            "label": "Output directory",
-            "required": false,
-            "helpMarkDown": "(Optional) Enter a path relative to the working directory where build output (binaries) will be placed. Examples: `output/$(SDK)/$(Configuration)` or `output/$(TestSDK)/$(TestConfiguration)`. Archive and export paths are configured separately.",
-            "groupName": "advanced"
-        },
-        {
             "name": "useXcpretty",
             "type": "boolean",
             "label": "Use xcpretty",

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 132,
+    "Minor": 133,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -10,8 +10,8 @@
   ],
   "author": "Microsoft Corporation",
   "version": {
-    "Major": 4,
-    "Minor": 130,
+    "Major": 5,
+    "Minor": 132,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -310,14 +310,6 @@
       "groupName": "advanced"
     },
     {
-      "name": "outputPattern",
-      "type": "string",
-      "label": "ms-resource:loc.input.label.outputPattern",
-      "required": false,
-      "helpMarkDown": "ms-resource:loc.input.help.outputPattern",
-      "groupName": "advanced"
-    },
-    {
       "name": "useXcpretty",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.useXcpretty",

--- a/Tasks/Xcode/xcode.ts
+++ b/Tasks/Xcode/xcode.ts
@@ -28,18 +28,8 @@ async function run() {
         let tool: string = tl.which('xcodebuild', true);
         tl.debug('Tool selected: ' + tool);
 
-        //--------------------------------------------------------
-        // Paths
-        //--------------------------------------------------------
         let workingDir: string = tl.getPathInput('cwd');
         tl.cd(workingDir);
-
-        let outPath: string;
-        let outputPattern: string = tl.getInput('outputPattern', false);
-        if (outputPattern) {
-            outPath = tl.resolve(workingDir, outputPattern); //use posix implementation to resolve paths to prevent unit test failures on Windows
-            tl.mkdirP(outPath);
-        }
 
         //--------------------------------------------------------
         // Xcode args
@@ -161,19 +151,6 @@ async function run() {
             });
         }
         xcb.arg(actions);
-        if (outPath) {
-            if (actions.toString().indexOf('archive') < 0) {
-                // redirect build output if archive action is not passed
-                // xcodebuild archive produces an invalid archive if output is redirected
-                xcb.arg('DSTROOT=' + tl.resolve(outPath, 'build.dst'));
-                xcb.arg('OBJROOT=' + tl.resolve(outPath, 'build.obj'));
-                xcb.arg('SYMROOT=' + tl.resolve(outPath, 'build.sym'));
-                xcb.arg('SHARED_PRECOMPS_DIR=' + tl.resolve(outPath, 'build.pch'));
-            }
-            else {
-                tl.warning(tl.loc('OutputDirectoryIgnored', 'archive'));
-            }
-        }
         if (args) {
             xcb.line(args);
         }

--- a/Tasks/Xcode/xcode.ts
+++ b/Tasks/Xcode/xcode.ts
@@ -410,14 +410,7 @@ async function run() {
 
                 //export path
                 let exportPath: string = tl.getInput('exportPath');
-                if (!exportPath.endsWith('.ipa')) {
-                    exportPath = tl.resolve(exportPath, '_XcodeTaskExport_' + scheme);
-                }
-                // delete if it already exists, otherwise export will fail
-                if (tl.exist(exportPath)) {
-                    tl.rmRF(exportPath);
-                }
-
+                
                 for (var i = 0; i < archiveFolders.length; i++) {
                     let archive: string = archiveFolders.pop();
 

--- a/Tests-Legacy/L0/Xcode/_suite.ts
+++ b/Tests-Legacy/L0/Xcode/_suite.ts
@@ -38,7 +38,6 @@ describe('Xcode Suite', function() {
         tr.setInput('provisioningProfileUuid', '');
         tr.setInput('args', '');
         tr.setInput('cwd', '/user/build');
-        tr.setInput('outputPattern', 'output/$(SDK)/$(Configuration)');
         tr.setInput('xcodeVersion', 'default');
         tr.setInput('xcodeDeveloperDir', '');
         tr.setInput('publishJUnitResults', 'false');
@@ -47,11 +46,7 @@ describe('Xcode Suite', function() {
         .then(() => {
             assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
             assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
-                    '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme build ' +
-                    'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-                    'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-                    'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-                    'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch'),
+                    '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme build'),
                 'xcodebuild for building the ios project/workspace should have been run.');
             assert(tr.invokedToolCount == 2, 'should have xcodebuild for version, xcodebuild for build and xcrun for packaging');
             assert(tr.resultWasSet, 'task should have set a result');
@@ -79,7 +74,6 @@ describe('Xcode Suite', function() {
         tr.setInput('provisioningProfileUuid', '');
         tr.setInput('args', '-project test.xcodeproj');
         tr.setInput('cwd', '/user/build');
-        tr.setInput('outputPattern', 'output/$(SDK)/$(Configuration)');
         tr.setInput('xcodeVersion', 'default');
         tr.setInput('xcodeDeveloperDir', '');
         tr.setInput('publishJUnitResults', 'false');
@@ -88,11 +82,7 @@ describe('Xcode Suite', function() {
             .then(() => {
                 assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
                 assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
-                        'build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-                        'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-                        'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-                        'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch ' +
-                        '-project test.xcodeproj'),
+                        'build -project test.xcodeproj'),
                     'xcodebuild for building the ios project should have been run.');
                 assert(tr.invokedToolCount == 2, 'should have xcodebuild for version, xcodebuild for build and xcrun for packaging');
                 assert(tr.resultWasSet, 'task should have set a result');
@@ -122,7 +112,6 @@ describe('Xcode Suite', function() {
         tr.setInput('cwd', '/user/build');
         tr.setInput('xcodeVersion', 'default');
         tr.setInput('xcodeDeveloperDir', '');
-        tr.setInput('outputPattern', 'output/$(SDK)/$(Configuration)');
         tr.setInput('useXcpretty', 'true');
         tr.setInput('publishJUnitResults', 'true');
 
@@ -132,10 +121,6 @@ describe('Xcode Suite', function() {
 
                 assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
                         '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme test ' +
-                        'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-                        'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-                        'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-                        'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch ' +
                         '| /home/bin/xcpretty -r junit --no-color'),
                     'xcodebuild for running tests in the ios project/workspace should have been run with xcpretty formatting.');
 
@@ -167,7 +152,6 @@ describe('Xcode Suite', function() {
         tr.setInput('cwd', '/user/build');
         tr.setInput('xcodeVersion', 'default');
         tr.setInput('xcodeDeveloperDir', '');
-        tr.setInput('outputPattern', 'output/$(SDK)/$(Configuration)');
         tr.setInput('useXcpretty', 'false');
         tr.setInput('publishJUnitResults', 'true');
 
@@ -176,11 +160,7 @@ describe('Xcode Suite', function() {
                 assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
 
                 assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
-                        '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme test ' +
-                        'DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst ' +
-                        'OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj ' +
-                        'SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym ' +
-                        'SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch'),
+                        '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme test'),
                     'xcodebuild for running tests in the ios project/workspace should have been run without xcpretty formatting.');
 
                 assert(tr.stdout.search(/##vso\[results.publish type=JUnit;publishRunAttachments=true;resultFiles=\/user\/build\/build\/reports\/junit.xml;\]/) < 0,
@@ -220,7 +200,6 @@ describe('Xcode Suite', function() {
             tr.setInput('provisioningProfileUuid', 'testuuid');
             tr.setInput('args', '');
             tr.setInput('cwd', '/user/build');
-            tr.setInput('outputPattern', 'output/$(SDK)/$(Configuration)');
             tr.setInput('xcodeVersion', 'default');
             tr.setInput('xcodeDeveloperDir', '');
             tr.setInput('publishJUnitResults', 'false');
@@ -228,7 +207,7 @@ describe('Xcode Suite', function() {
             tr.run()
                 .then(() => {
                     assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
-                    assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid'),
+                    assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid'),
                         'xcodebuild for building the ios project/workspace should have been run with signing options.');
                     assert(tr.resultWasSet, 'task should have set a result');
                     assert(tr.stderr.length == 0, 'should not have written to stderr');
@@ -261,7 +240,6 @@ describe('Xcode Suite', function() {
             tr.setInput('provisioningProfileUuid', '');
             tr.setInput('args', '');
             tr.setInput('cwd', '/user/build');
-            tr.setInput('outputPattern', 'output/$(SDK)/$(Configuration)');
             tr.setInput('xcodeVersion', 'default');
             tr.setInput('xcodeDeveloperDir', '');
             tr.setInput('publishJUnitResults', 'false');
@@ -269,7 +247,7 @@ describe('Xcode Suite', function() {
             tr.run()
                 .then(() => {
                     assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
-                    assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q)'),
+                    assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q)'),
                         'xcodebuild for building the ios project/workspace should have been run with signing options with P12 only, no provisioning profile.');
                     assert(tr.resultWasSet, 'task should have set a result');
                     assert(tr.stderr.length == 0, 'should not have written to stderr');
@@ -297,7 +275,6 @@ describe('Xcode Suite', function() {
         tr.setInput('provisioningProfileUuid', 'testuuid');
         tr.setInput('args', '');
         tr.setInput('cwd', '/user/build');
-        tr.setInput('outputPattern', 'output/$(SDK)/$(Configuration)');
         tr.setInput('xcodeVersion', 'default');
         tr.setInput('xcodeDeveloperDir', '');
         tr.setInput('publishJUnitResults', 'false');
@@ -305,7 +282,7 @@ describe('Xcode Suite', function() {
         tr.run()
             .then(() => {
                 assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
-                assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE=testuuid'),
+                assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE=testuuid'),
                     'xcodebuild for building the ios project/workspace should have been run with signing options with provisioning profile only.');
                 assert(tr.resultWasSet, 'task should have set a result');
                 assert(tr.stderr.length == 0, 'should not have written to stderr');
@@ -333,7 +310,6 @@ describe('Xcode Suite', function() {
         tr.setInput('provisioningProfileUuid', 'testUUID');
         tr.setInput('args', '');
         tr.setInput('cwd', '/user/build');
-        tr.setInput('outputPattern', 'output/$(SDK)/$(Configuration)');
         tr.setInput('xcodeVersion', 'default');
         tr.setInput('xcodeDeveloperDir', '');
         tr.setInput('publishJUnitResults', 'false');
@@ -341,7 +317,7 @@ describe('Xcode Suite', function() {
         tr.run()
             .then(() => {
                 assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
-                assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=testSignIdentity PROVISIONING_PROFILE=testUUID'),
+                assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=testSignIdentity PROVISIONING_PROFILE=testUUID'),
                     'xcodebuild for building the ios project/workspace should have been run with signing options.');
                 assert(tr.resultWasSet, 'task should have set a result');
                 assert(tr.stderr.length == 0, 'should not have written to stderr');
@@ -368,7 +344,6 @@ describe('Xcode Suite', function() {
      tr.setInput('provisioningProfileUuid', '');
      tr.setInput('args', '');
      tr.setInput('cwd', '/user/build');
-     tr.setInput('outputPattern', '');
      tr.setInput('xcodeVersion', 'default');
      tr.setInput('xcodeDeveloperDir', '');
      tr.setInput('publishJUnitResults', 'false');
@@ -406,7 +381,6 @@ describe('Xcode Suite', function() {
         tr.setInput('provisioningProfileUuid', '');
         tr.setInput('args', '-exportArchive -exportPath /user/build/output/iphone/release');
         tr.setInput('cwd', '/user/build');
-        tr.setInput('outputPattern', 'output/iphone/release');
         tr.setInput('xcodeVersion', 'specifyPath');
         tr.setInput('xcodeDeveloperDir', '/Applications/Xcode5');
         tr.setInput('publishJUnitResults', 'false');
@@ -414,7 +388,7 @@ describe('Xcode Suite', function() {
         tr.run()
             .then(() => {
                 assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
-                assert(tr.ran('/home/bin/xcodebuild -sdk iphone -configuration Release -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun clean build DSTROOT=/user/build/output/iphone/release/build.dst OBJROOT=/user/build/output/iphone/release/build.obj SYMROOT=/user/build/output/iphone/release/build.sym SHARED_PRECOMPS_DIR=/user/build/output/iphone/release/build.pch -exportArchive -exportPath /user/build/output/iphone/release'),
+                assert(tr.ran('/home/bin/xcodebuild -sdk iphone -configuration Release -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun clean build -exportArchive -exportPath /user/build/output/iphone/release'),
                     'xcodebuild for building the ios project/workspace should have been run with all optional args.');
                 assert(tr.resultWasSet, 'task should have set a result');
                 assert(tr.stderr.length == 0, 'should not have written to stderr');

--- a/Tests-Legacy/L0/Xcode/responseDefaultInputs.json
+++ b/Tests-Legacy/L0/Xcode/responseDefaultInputs.json
@@ -22,7 +22,7 @@
       "code": 0,
       "stdout": "Xcode 7.2.1"
     },
-    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme build": {
       "code": 0,
       "stdout": "xcodebuild output here"
     }

--- a/Tests-Legacy/L0/Xcode/responseOptionalArgs.json
+++ b/Tests-Legacy/L0/Xcode/responseOptionalArgs.json
@@ -19,7 +19,7 @@
       "code": 0,
       "stdout": "Xcode 7.3.1"
     },
-    "/home/bin/xcodebuild -sdk iphone -configuration Release -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun clean build DSTROOT=/user/build/output/iphone/release/build.dst OBJROOT=/user/build/output/iphone/release/build.obj SYMROOT=/user/build/output/iphone/release/build.sym SHARED_PRECOMPS_DIR=/user/build/output/iphone/release/build.pch -exportArchive -exportPath /user/build/output/iphone/release": {
+    "/home/bin/xcodebuild -sdk iphone -configuration Release -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun clean build -exportArchive -exportPath /user/build/output/iphone/release": {
       "code": 0,
       "stdout": "xcodebuild output here"
     }

--- a/Tests-Legacy/L0/Xcode/responseProject.json
+++ b/Tests-Legacy/L0/Xcode/responseProject.json
@@ -19,7 +19,7 @@
       "code": 0,
       "stdout": "Xcode 6.4"
     },
-    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch -project test.xcodeproj": {
+    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) build -project test.xcodeproj": {
       "code": 0,
       "stdout": "xcodebuild output here"
     }

--- a/Tests-Legacy/L0/Xcode/responseSigningFile.json
+++ b/Tests-Legacy/L0/Xcode/responseSigningFile.json
@@ -31,15 +31,15 @@
       "code": 0,
       "stdout": "Xcode 7.3.1"
     },
-    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid": {
+    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid": {
       "code": 0,
       "stdout": "xcodebuild output here"
     },
-    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q)": {
+    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q)": {
       "code": 0,
       "stdout": "xcodebuild output here"
     },
-    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE=testuuid": {
+    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE=testuuid": {
       "code": 0,
       "stdout": "xcodebuild output here"
     },

--- a/Tests-Legacy/L0/Xcode/responseSigningId.json
+++ b/Tests-Legacy/L0/Xcode/responseSigningId.json
@@ -21,7 +21,7 @@
       "code": 0,
       "stdout": "Xcode 7.3.1"
     },
-    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=testSignIdentity PROVISIONING_PROFILE=testUUID": {
+    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=testSignIdentity PROVISIONING_PROFILE=testUUID": {
       "code": 0,
       "stdout": "xcodebuild output here"
     },

--- a/Tests-Legacy/L0/Xcode/responseXcpretty.json
+++ b/Tests-Legacy/L0/Xcode/responseXcpretty.json
@@ -27,11 +27,11 @@
       "code": 0,
       "stdout": "Xcode 7.3.1"
     },
-    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme test DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch | /home/bin/xcpretty -r junit --no-color": {
+    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme test | /home/bin/xcpretty -r junit --no-color": {
       "code": 0,
       "stdout": "xcodebuild | xcpretty output here"
     },
-    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme test DSTROOT=/user/build/output/$(SDK)/$(Configuration)/build.dst OBJROOT=/user/build/output/$(SDK)/$(Configuration)/build.obj SYMROOT=/user/build/output/$(SDK)/$(Configuration)/build.sym SHARED_PRECOMPS_DIR=/user/build/output/$(SDK)/$(Configuration)/build.pch": {
+    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme test": {
       "code": 0,
       "stdout": "xcodebuild output without xcpretty here"
     }


### PR DESCRIPTION
Issue #6323. We can stop doing special handling of the exportPath with Xcode 8.3 and Xcode 9. In both versions of Xcode "-exportPath" option is always treated as a folder and xcodebuild overwrites it without errors now.