### PR TITLE
Updated the markdown for results link to be valid with new parser

### DIFF
--- a/Tasks/XamarinTestCloud/XamarinTestCloud.ps1
+++ b/Tasks/XamarinTestCloud/XamarinTestCloud.ps1
@@ -187,8 +187,8 @@ if($testCloudResults)
     $mdReportFile = Join-Path $testDir "xamarintestcloud_$buildId.md"
     foreach($result in $testCloudResults)
     {
-       Write-Output $result | Out-File $mdReportFile -Append
-       Write-Output [Environment]::NewLine | Out-File $mdReportFile -Append
+       Write-Output "[$result]($result)" | Out-File $mdReportFile -Append
+       Write-Output "" | Out-File $mdReportFile -Append
     }
     Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=Xamarin Test Cloud Results;]$mdReportFile"
 }

--- a/Tasks/XamarinTestCloud/package-lock.json
+++ b/Tasks/XamarinTestCloud/package-lock.json
@@ -52,7 +52,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }

--- a/Tasks/XamarinTestCloud/task.json
+++ b/Tasks/XamarinTestCloud/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 131,
+        "Minor": 133,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/XamarinTestCloud/task.loc.json
+++ b/Tasks/XamarinTestCloud/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 131,
-    "Patch": 3
+    "Minor": 133,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.83.0",

--- a/Tasks/XamarinTestCloud/task.loc.json
+++ b/Tasks/XamarinTestCloud/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 131,
-    "Patch": 0
+    "Patch": 3
   },
   "demands": [],
   "minimumAgentVersion": "1.83.0",


### PR DESCRIPTION
A new markdown parser is being used for rendering the results link on the build summary page. Updating the script to generate a valid markdown link. Fix for this ticket: https://developercommunity.visualstudio.com/content/problem/117498/xamarin-testcloud-results-in-release-management-di.html