### PR TITLE
Updating the test execution package to get run name changes

### DIFF
--- a/Tasks/VsTest/make.json
+++ b/Tasks/VsTest/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/5312315/TestExecution.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/5586956/TestAgent.zip",
                 "dest": "./Modules"
             }
         ],

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 4,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 4,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Description: Currently if a user provides a custom run name in the distributed testing mode with Rerun enabled, the run name is not reflected in the final run that is created. This fix will correct this behavior.

Testing: Manually verified the fix.