### PR TITLE
Allow variables in the Definition ID

### DIFF
--- a/Tasks/DownloadBuildArtifacts/main.ts
+++ b/Tasks/DownloadBuildArtifacts/main.ts
@@ -6,6 +6,7 @@ import * as tl from 'vsts-task-lib/task';
 import { IBuildApi } from './vso-node-api/BuildApi';
 import { IRequestHandler } from './vso-node-api/interfaces/common/VsoBaseInterfaces';
 import { WebApi, getHandlerFromToken } from './vso-node-api/WebApi';
+import { BuildStatus, BuildResult, BuildQueryOrder, Build, BuildDefinitionReference } from './vso-node-api/interfaces/BuildInterfaces';
 
 import * as models from 'artifact-engine/Models';
 import * as engine from 'artifact-engine/Engine';
@@ -64,6 +65,8 @@ async function main(): Promise<void> {
         var definitionIdSpecified: string = null;
         var definitionIdTriggered: string = null;
         var buildId: number = null;
+        var buildVersionToDownload: string = tl.getInput("buildVersionToDownload", false);
+        var branchName: string =  tl.getInput("branchName", false);;
         var downloadPath: string = tl.getInput("downloadPath", true);
         var downloadType: string = tl.getInput("downloadType", true);
 
@@ -126,16 +129,48 @@ async function main(): Promise<void> {
                 // Triggering build info not found, or requested, default to specified build info
                 projectId = tl.getInput("project", true);
                 definitionId = definitionIdSpecified;
-                buildId = parseInt(tl.getInput("buildId", true));
+                buildId = parseInt(tl.getInput("buildId", buildVersionToDownload == "specific"));
             }
         }
 
-        // verify that buildId belongs to the definition selected
-        if (definitionId) {
-            var build = await executeWithRetries("getBuild", () => buildApi.getBuild(buildId, projectId), 4).catch((reason) => {
+        // if the definition name includes a variable then definitionIdSpecified is a name vs a number
+        if (Number.isNaN(parseInt(definitionIdSpecified))) {
+            var definitions: BuildDefinitionReference[] = await executeWithRetries("getBuildDefinitions", () => buildApi.getDefinitions(projectId, definitionIdSpecified), 4).catch((reason) => {
                 reject(reason);
                 return;
             });
+            definitionId = String(definitions[0].id);
+            console.log(tl.loc("DefinitionIDFound", definitionIdSpecified, definitionId));
+        }
+        // verify that buildId belongs to the definition selected
+        if (definitionId) {
+            var build : Build;
+            if (buildVersionToDownload != "specific"){ 
+                var branchNameFilter = (buildVersionToDownload == "latest") ? null : branchName;
+                
+                // get latest successful build filtered by branch
+                var buildsForThisDefinition = await executeWithRetries("getBuildId", () => buildApi.getBuilds( projectId, [parseInt(definitionId)],null,null,null,null,null,null,BuildStatus.Completed,BuildResult.Succeeded,null,null,null,null,null,null, BuildQueryOrder.FinishTimeDescending,branchNameFilter), 4).catch((reason) => {
+                    reject(reason);
+                    return;
+                }); 
+
+                if (!buildsForThisDefinition || buildsForThisDefinition.length == 0){ 
+                    if (buildVersionToDownload == "latestFromBranch") reject(tl.loc("LatestBuildFromBranchNotFound", branchNameFilter));
+                    else reject(tl.loc("LatestBuildNotFound"));
+                    return;
+                }
+                
+                build = buildsForThisDefinition[0];
+                console.log(tl.loc("LatestBuildFound", build.id));
+                buildId = build.id
+            } 
+
+            if (!build){
+                build = await executeWithRetries("getBuild", () => buildApi.getBuild(buildId, projectId), 4).catch((reason) => {
+                    reject(reason);
+                    return;
+                });
+            }
 
             if (build) {
                 if (!build.definition || build.definition.id !== parseInt(definitionId)) {
@@ -249,13 +284,13 @@ async function main(): Promise<void> {
 
 function executeWithRetries(operationName: string, operation: () => Promise<any>, retryCount): Promise<any> {
     var executePromise = new Promise((resolve, reject) => {
-        executeWithRetriesImplementaion(operationName, operation, retryCount, resolve, reject);
+        executeWithRetriesImplementation(operationName, operation, retryCount, resolve, reject);
     });
 
     return executePromise;
 }
 
-function executeWithRetriesImplementaion(operationName: string, operation: () => Promise<any>, currentRetryCount, resolve, reject) {
+function executeWithRetriesImplementation(operationName: string, operation: () => Promise<any>, currentRetryCount, resolve, reject) {
     operation().then((result) => {
         resolve(result);
     }).catch((error) => {
@@ -266,7 +301,7 @@ function executeWithRetriesImplementaion(operationName: string, operation: () =>
         else {
             console.log(tl.loc('RetryingOperation', operationName, currentRetryCount));
             currentRetryCount = currentRetryCount - 1;
-            setTimeout(() => executeWithRetriesImplementaion(operationName, operation, currentRetryCount, resolve, reject), 4 * 1000);
+            setTimeout(() => executeWithRetriesImplementation(operationName, operation, currentRetryCount, resolve, reject), 4 * 1000);
         }
     });
 }

--- a/Tasks/DownloadBuildArtifacts/task.json
+++ b/Tasks/DownloadBuildArtifacts/task.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 132,
+    "Minor": 133,
     "Patch": 0
   },
   "groups": [
@@ -68,12 +68,34 @@
       "helpMarkDown": "If checked, this build task will try to download artifacts from the triggering build. If there is no triggering build from the specified definition, it will download artifacts from the build specified in the options below."
     },
     {
+      "name": "buildVersionToDownload",
+      "type": "pickList",
+      "label": "Build version to download",
+      "defaultValue": "latest",
+      "visibleRule": "buildType == specific",
+      "required": true,
+      "options": {
+        "latest": "Latest",
+        "latestFromBranch": "Latest from specific branch",
+        "specific": "Specific version"
+      }
+    },
+    {
+      "name": "branchName",
+      "type": "string",
+      "label": "Branch name", 
+      "defaultValue": "refs/heads/master",
+      "visibleRule": "buildType == specific && buildVersionToDownload == latestFromBranch",
+      "required": true,
+      "helpMarkDown": "Specify to filter on branch/ref name, for example: ```refs/heads/develop```."
+    },
+    {
       "name": "buildId",
       "type": "pickList",
       "label": "Build",
       "defaultValue": "",
       "required": true,
-      "visibleRule": "buildType == specific",
+      "visibleRule": "buildType == specific && buildVersionToDownload == specific",
       "properties": {
         "EditableOptions": "True",
         "DisableManageLink": "True"
@@ -188,14 +210,18 @@
     "DownloadArtifacts": "Downloading artifacts from: %s",
     "LinkedArtifactCount": "Linked artifacts count:  %s",
     "FileContainerInvalidArtifactData": "Invalid file container artifact. Resource data must be in the format #/{container id}/path",
-    "UnsupportedArtifactType" :"Unsupported artifact type: %s",
+    "UnsupportedArtifactType": "Unsupported artifact type: %s",
     "BuildNotFound": "Build with id %s not found",
     "BuildArtifactNotFound": "Artifact %s not found for build %s",
     "NoArtifactsFound": "No artifacts found for build %s",
     "BuildIdBuildDefinitionMismatch": "Build with id %s not found for build definition id %s",
     "ArtifactsSuccessfullyDownloaded": "Successfully downloaded artifacts to %s",
-    "RetryingOperation" : "Error : in %s, so retrying => retries pending  : %s",
+    "RetryingOperation": "Error : in %s, so retrying => retries pending  : %s",
     "OperationFailed": "Failed in %s with error: %s",
-    "ArtifactNameDirectoryNotFound": "Directory '%s' does not exist. Falling back to parent directory: %s"
+    "ArtifactNameDirectoryNotFound": "Directory '%s' does not exist. Falling back to parent directory: %s",
+    "LatestBuildFound": "Latest build found:  %s",
+    "LatestBuildNotFound": "Latest build not found",
+    "LatestBuildFromBranchNotFound": "Latest build from branch %s not found",
+    "DefinitionIDFound": "Definition Name %s resolved to id %d"
   }
 }

--- a/Tasks/DownloadBuildArtifacts/task.loc.json
+++ b/Tasks/DownloadBuildArtifacts/task.loc.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 132,
+    "Minor": 133,
     "Patch": 0
   },
   "groups": [
@@ -68,12 +68,34 @@
       "helpMarkDown": "ms-resource:loc.input.help.specificBuildWithTriggering"
     },
     {
+      "name": "buildVersionToDownload",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.buildVersionToDownload",
+      "defaultValue": "latest",
+      "visibleRule": "buildType == specific",
+      "required": true,
+      "options": {
+        "latest": "Latest",
+        "latestFromBranch": "Latest from specific branch",
+        "specific": "Specific version"
+      }
+    },
+    {
+      "name": "branchName",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.branchName",
+      "defaultValue": "refs/heads/master",
+      "visibleRule": "buildType == specific && buildVersionToDownload == latestFromBranch",
+      "required": true,
+      "helpMarkDown": "ms-resource:loc.input.help.branchName"
+    },
+    {
       "name": "buildId",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.buildId",
       "defaultValue": "",
       "required": true,
-      "visibleRule": "buildType == specific",
+      "visibleRule": "buildType == specific && buildVersionToDownload == specific",
       "properties": {
         "EditableOptions": "True",
         "DisableManageLink": "True"
@@ -196,6 +218,9 @@
     "ArtifactsSuccessfullyDownloaded": "ms-resource:loc.messages.ArtifactsSuccessfullyDownloaded",
     "RetryingOperation": "ms-resource:loc.messages.RetryingOperation",
     "OperationFailed": "ms-resource:loc.messages.OperationFailed",
-    "ArtifactNameDirectoryNotFound": "ms-resource:loc.messages.ArtifactNameDirectoryNotFound"
+    "ArtifactNameDirectoryNotFound": "ms-resource:loc.messages.ArtifactNameDirectoryNotFound",
+    "LatestBuildFound": "ms-resource:loc.messages.LatestBuildFound",
+    "LatestBuildNotFound": "ms-resource:loc.messages.LatestBuildNotFound",
+    "LatestBuildFromBranchNotFound": "ms-resource:loc.messages.LatestBuildFromBranchNotFound"
   }
 }


### PR DESCRIPTION
When variables are part of the Build Definition then they are resolved to a string rather than an ID at run time.

Here is an example:
![image](https://user-images.githubusercontent.com/4304076/37934882-92398d82-3104-11e8-92de-66b00d605a88.png)
This would resolve at a string and not a number during execution
