### PR TITLE
Allow variables in definition

### DIFF
--- a/Tasks/DownloadBuildArtifacts/main.ts
+++ b/Tasks/DownloadBuildArtifacts/main.ts
@@ -6,7 +6,7 @@ import * as tl from 'vsts-task-lib/task';
 import { IBuildApi } from './vso-node-api/BuildApi';
 import { IRequestHandler } from './vso-node-api/interfaces/common/VsoBaseInterfaces';
 import { WebApi, getHandlerFromToken } from './vso-node-api/WebApi';
-import { BuildStatus, BuildResult, BuildQueryOrder, Build } from './vso-node-api/interfaces/BuildInterfaces';
+import { BuildStatus, BuildResult, BuildQueryOrder, Build, BuildDefinitionReference } from './vso-node-api/interfaces/BuildInterfaces';
 
 import * as models from 'artifact-engine/Models';
 import * as engine from 'artifact-engine/Engine';
@@ -133,6 +133,15 @@ async function main(): Promise<void> {
             }
         }
 
+        // if the definition name includes a variable then definitionIdSpecified is a name vs a number
+        if (Number.isNaN(parseInt(definitionIdSpecified))) {
+            var definitions: BuildDefinitionReference[] = await executeWithRetries("getBuildDefinitions", () => buildApi.getDefinitions(projectId, definitionIdSpecified), 4).catch((reason) => {
+                reject(reason);
+                return;
+            });
+            definitionId = String(definitions[0].id);
+            console.log(tl.loc("DefinitionIDFound", definitionIdSpecified, definitionId));
+        }
         // verify that buildId belongs to the definition selected
         if (definitionId) {
             var build : Build;

--- a/Tasks/DownloadBuildArtifacts/task.json
+++ b/Tasks/DownloadBuildArtifacts/task.json
@@ -210,17 +210,18 @@
     "DownloadArtifacts": "Downloading artifacts from: %s",
     "LinkedArtifactCount": "Linked artifacts count:  %s",
     "FileContainerInvalidArtifactData": "Invalid file container artifact. Resource data must be in the format #/{container id}/path",
-    "UnsupportedArtifactType" :"Unsupported artifact type: %s",
+    "UnsupportedArtifactType": "Unsupported artifact type: %s",
     "BuildNotFound": "Build with id %s not found",
     "BuildArtifactNotFound": "Artifact %s not found for build %s",
     "NoArtifactsFound": "No artifacts found for build %s",
     "BuildIdBuildDefinitionMismatch": "Build with id %s not found for build definition id %s",
     "ArtifactsSuccessfullyDownloaded": "Successfully downloaded artifacts to %s",
-    "RetryingOperation" : "Error : in %s, so retrying => retries pending  : %s",
+    "RetryingOperation": "Error : in %s, so retrying => retries pending  : %s",
     "OperationFailed": "Failed in %s with error: %s",
     "ArtifactNameDirectoryNotFound": "Directory '%s' does not exist. Falling back to parent directory: %s",
     "LatestBuildFound": "Latest build found:  %s",
-    "LatestBuildNotFound":"Latest build not found",
-    "LatestBuildFromBranchNotFound":"Latest build from branch %s not found"
+    "LatestBuildNotFound": "Latest build not found",
+    "LatestBuildFromBranchNotFound": "Latest build from branch %s not found",
+    "DefinitionIDFound": "Definition Name %s resolved to id %d"
   }
 }

--- a/Tasks/DownloadBuildArtifacts/task.loc.json
+++ b/Tasks/DownloadBuildArtifacts/task.loc.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 132,
+    "Minor": 133,
     "Patch": 0
   },
   "groups": [
@@ -68,12 +68,34 @@
       "helpMarkDown": "ms-resource:loc.input.help.specificBuildWithTriggering"
     },
     {
+      "name": "buildVersionToDownload",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.buildVersionToDownload",
+      "defaultValue": "latest",
+      "visibleRule": "buildType == specific",
+      "required": true,
+      "options": {
+        "latest": "Latest",
+        "latestFromBranch": "Latest from specific branch",
+        "specific": "Specific version"
+      }
+    },
+    {
+      "name": "branchName",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.branchName",
+      "defaultValue": "refs/heads/master",
+      "visibleRule": "buildType == specific && buildVersionToDownload == latestFromBranch",
+      "required": true,
+      "helpMarkDown": "ms-resource:loc.input.help.branchName"
+    },
+    {
       "name": "buildId",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.buildId",
       "defaultValue": "",
       "required": true,
-      "visibleRule": "buildType == specific",
+      "visibleRule": "buildType == specific && buildVersionToDownload == specific",
       "properties": {
         "EditableOptions": "True",
         "DisableManageLink": "True"
@@ -196,6 +218,9 @@
     "ArtifactsSuccessfullyDownloaded": "ms-resource:loc.messages.ArtifactsSuccessfullyDownloaded",
     "RetryingOperation": "ms-resource:loc.messages.RetryingOperation",
     "OperationFailed": "ms-resource:loc.messages.OperationFailed",
-    "ArtifactNameDirectoryNotFound": "ms-resource:loc.messages.ArtifactNameDirectoryNotFound"
+    "ArtifactNameDirectoryNotFound": "ms-resource:loc.messages.ArtifactNameDirectoryNotFound",
+    "LatestBuildFound": "ms-resource:loc.messages.LatestBuildFound",
+    "LatestBuildNotFound": "ms-resource:loc.messages.LatestBuildNotFound",
+    "LatestBuildFromBranchNotFound": "ms-resource:loc.messages.LatestBuildFromBranchNotFound"
   }
 }


### PR DESCRIPTION
Here is an example of usage:
![image](https://user-images.githubusercontent.com/4304076/37935226-93384538-3105-11e8-98bf-19cf33f70868.png)

In this case the definitionId would resolve in a name rather than a number