### PR TITLE
Supporting AppService task on Deployment Group

### DIFF
--- a/Tasks/AzureAppServiceManage/task.json
+++ b/Tasks/AzureAppServiceManage/task.json
@@ -11,13 +11,14 @@
         "Release"
     ],
     "runsOn": [
-        "Agent"
+        "Agent",
+        "DeploymentGroup"
     ],
     "demands": [],
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 25
+        "Patch": 26
     },
     "minimumAgentVersion": "1.102.0",
     "instanceNameFormat": "$(Action): $(WebAppName)",

--- a/Tasks/AzureAppServiceManage/task.loc.json
+++ b/Tasks/AzureAppServiceManage/task.loc.json
@@ -11,13 +11,14 @@
     "Release"
   ],
   "runsOn": [
-    "Agent"
+    "Agent",
+    "DeploymentGroup"
   ],
   "demands": [],
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 25
+    "Patch": 26
   },
   "minimumAgentVersion": "1.102.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/AzureRmWebAppDeployment/task.json
+++ b/Tasks/AzureRmWebAppDeployment/task.json
@@ -9,7 +9,6 @@
         "Build",
         "Release"
     ],
-    "preview": "true",
     "runsOn": [
         "Agent",
         "DeploymentGroup"

--- a/Tasks/AzureRmWebAppDeployment/task.json
+++ b/Tasks/AzureRmWebAppDeployment/task.json
@@ -11,7 +11,8 @@
     ],
     "preview": "true",
     "runsOn": [
-        "Agent"
+        "Agent",
+        "DeploymentGroup"
     ],
     "author": "Microsoft Corporation",
     "version": {

--- a/Tasks/AzureRmWebAppDeployment/task.json
+++ b/Tasks/AzureRmWebAppDeployment/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "releaseNotes": "What's new in version 4.* (preview)<br />Supports Kudu Zip Deploy<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more Information.",
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeployment/task.loc.json
+++ b/Tasks/AzureRmWebAppDeployment/task.loc.json
@@ -9,7 +9,6 @@
     "Build",
     "Release"
   ],
-  "preview": "true",
   "runsOn": [
     "Agent",
     "DeploymentGroup"

--- a/Tasks/AzureRmWebAppDeployment/task.loc.json
+++ b/Tasks/AzureRmWebAppDeployment/task.loc.json
@@ -11,13 +11,14 @@
   ],
   "preview": "true",
   "runsOn": [
-    "Agent"
+    "Agent",
+    "DeploymentGroup"
   ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
     "Minor": 0,
-    "Patch": 4
+    "Patch": 5
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",


### PR DESCRIPTION
Ask for AppService task to be supported on DG phase. This avoids user setting up additional agent, agent queue instead re-use the same target to run the workload.