### PR TITLE
Fixes to the test selector calls to build APIs to send project ids

### DIFF
--- a/Tasks/VsTest/make.json
+++ b/Tasks/VsTest/make.json
@@ -2,7 +2,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://testselector.blob.core.windows.net/testselector/4808807/TestSelector.zip",
+                "url": "https://testselectorv2.blob.core.windows.net/testselector/5626421/TestSelector.zip",
                 "dest": "./"
             },
             {

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 4,
-        "Patch": 5
+        "Patch": 6
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 4,
-    "Patch": 5
+    "Patch": 6
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Description: Some build API calls from test selector today do not send the project id, which is not compliant with the current usage. Fixing this issue by updating the package with the fixes.