### PR TITLE
Updating test selector package in VsTest task

### DIFF
--- a/Tasks/VsTest/make.json
+++ b/Tasks/VsTest/make.json
@@ -2,11 +2,11 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://testselectorv2.blob.core.windows.net/testselector/5568144/TestSelector.zip",
+                "url": "https://testselectorv2.blob.core.windows.net/testselector/5627107/TestSelector.zip",
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/5568144/TestAgent.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/5627107/TestAgent.zip",
                 "dest": "./Modules"
             },
             {

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 5,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 5,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Updating test selector package to reflect fixed for build API calls which compulsorily require project ids now