### PR TITLE
Azure Key Vault: Support flattening of downloaded secrets initial commit

### DIFF
--- a/Tasks/AzureKeyVault/models/KeyVaultTaskParameters.ts
+++ b/Tasks/AzureKeyVault/models/KeyVaultTaskParameters.ts
@@ -9,6 +9,7 @@ export class KeyVaultTaskParameters {
     public subscriptionId: string;
     public keyVaultName: string;
     public secretsFilter: string[];
+    public flattenVariableName: string;
     public vaultCredentials: msRestAzure.ApplicationTokenCredentials;
     public keyVaultUrl: string;
     public servicePrincipalId: string;
@@ -18,6 +19,7 @@ export class KeyVaultTaskParameters {
         this.subscriptionId = tl.getEndpointDataParameter(connectedService, "SubscriptionId", true);
         this.keyVaultName = tl.getInput("KeyVaultName", true);
         this.secretsFilter = tl.getDelimitedInput("SecretsFilter", ",", true);
+        this.flattenVariableName = tl.getInput("FlattenVariableName", true);
         var azureKeyVaultDnsSuffix = tl.getEndpointDataParameter(connectedService, "AzureKeyVaultDnsSuffix", true);
 
         this.servicePrincipalId = tl.getEndpointAuthorizationParameter(connectedService, 'serviceprincipalid', false);

--- a/Tasks/AzureKeyVault/operations/KeyVault.ts
+++ b/Tasks/AzureKeyVault/operations/KeyVault.ts
@@ -117,6 +117,7 @@ Set-AzureRmKeyVaultAccessPolicy -VaultName %s -ObjectId $spnObjectId -Permission
                 Promise.all(getSecretValuePromises).then(() =>{
                     if (this.taskParameters.flattenVariableName) {
                         this.setVaultVariable(this.taskParameters.flattenVariableName, JSON.stringify(this.flattenedSecrets));
+                        this.flattenedSecrets = {};
                     } else {
                         return resolve();
                     }
@@ -139,6 +140,7 @@ Set-AzureRmKeyVaultAccessPolicy -VaultName %s -ObjectId $spnObjectId -Permission
             Promise.all(getSecretValuePromises).then(() =>{
                 if (this.taskParameters.flattenVariableName) {
                     this.setVaultVariable(this.taskParameters.flattenVariableName, JSON.stringify(this.flattenedSecrets));
+                    this.flattenedSecrets = {};
                 } else {
                     return resolve();
                 }

--- a/Tasks/AzureKeyVault/operations/KeyVault.ts
+++ b/Tasks/AzureKeyVault/operations/KeyVault.ts
@@ -118,9 +118,9 @@ Set-AzureRmKeyVaultAccessPolicy -VaultName %s -ObjectId $spnObjectId -Permission
                     if (this.taskParameters.flattenVariableName) {
                         this.setVaultVariable(this.taskParameters.flattenVariableName, JSON.stringify(this.flattenedSecrets));
                         this.flattenedSecrets = {};
-                    } else {
-                        return resolve();
                     }
+
+                    return resolve();
                 });
             });
         });
@@ -141,9 +141,9 @@ Set-AzureRmKeyVaultAccessPolicy -VaultName %s -ObjectId $spnObjectId -Permission
                 if (this.taskParameters.flattenVariableName) {
                     this.setVaultVariable(this.taskParameters.flattenVariableName, JSON.stringify(this.flattenedSecrets));
                     this.flattenedSecrets = {};
-                } else {
-                    return resolve();
                 }
+
+                return resolve();
             });
         });
     }

--- a/Tasks/AzureKeyVault/task.json
+++ b/Tasks/AzureKeyVault/task.json
@@ -48,6 +48,17 @@
             "options": {
                 "EditableOptions": "True"
             }
+        },
+        {
+            "name": "FlattenVariableName",
+            "type": "string",
+            "label": "Flatten to single variable",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "If present, the downloaded secrets will be stored in this single variable in JSON format.",
+            "options": {
+                "EditableOptions": "True"
+            }
         }
     ],
     "dataSourceBindings": [


### PR DESCRIPTION
We have a scenario where we need to pass the downloaded secrets further in a dynamic way. So what we'd like to achieve is to download and store the secrets in a single variable in a JSON serialized format. This way we'd have a future-proof control over the contents of the Key Vault.

Please give some hints on the following points.
- Unfortunately I could not set up the build locally so it's not thoroughly tested.
- Also, I don't know what the practice is regarding localization, so for now I've updated only the `task.json` descriptor file.

Please tell me your opinion and let me know if we miss anything here.