### PR TITLE
Tell the user they need to set Destination platform when the build fails

### DIFF
--- a/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
@@ -86,5 +86,6 @@
   "loc.messages.NoSchemeFound": "No shared scheme found in the workspace. Use \"Manage Schemes\" in Xcode to share a scheme.",
   "loc.messages.SchemeSelected": "The workspace contains a single shared scheme. '%s' will be used.",
   "loc.messages.FailedToFindScheme": "Failed to find a scheme in the workspace. Use `Scheme` to specify a target scheme.",
-  "loc.messages.OutputDirectoryIgnored": "Output directory for build output (binaries) ignored. Specifying an output directory is incompatible with the '%s' action."
+  "loc.messages.OutputDirectoryIgnored": "Output directory for build output (binaries) ignored. Specifying an output directory is incompatible with the '%s' action.",
+  "loc.messages.NoDestinationPlatformWarning": "UI tests must be run against a simulator or a connected device. In the Xcode task, set `Destination platform` to a value other than `Default`."
 }

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 5,
         "Minor": 133,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "xcode"
@@ -362,6 +362,7 @@
         "NoSchemeFound": "No shared scheme found in the workspace. Use \"Manage Schemes\" in Xcode to share a scheme.",
         "SchemeSelected": "The workspace contains a single shared scheme. '%s' will be used.",
         "FailedToFindScheme": "Failed to find a scheme in the workspace. Use `Scheme` to specify a target scheme.",
-        "OutputDirectoryIgnored": "Output directory for build output (binaries) ignored. Specifying an output directory is incompatible with the '%s' action."
+        "OutputDirectoryIgnored": "Output directory for build output (binaries) ignored. Specifying an output directory is incompatible with the '%s' action.",
+        "NoDestinationPlatformWarning": "UI tests must be run against a simulator or a connected device. In the Xcode task, set `Destination platform` to a value other than `Default`."
     }
 }

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 5,
     "Minor": 133,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "xcode"
@@ -364,6 +364,7 @@
     "NoSchemeFound": "ms-resource:loc.messages.NoSchemeFound",
     "SchemeSelected": "ms-resource:loc.messages.SchemeSelected",
     "FailedToFindScheme": "ms-resource:loc.messages.FailedToFindScheme",
-    "OutputDirectoryIgnored": "ms-resource:loc.messages.OutputDirectoryIgnored"
+    "OutputDirectoryIgnored": "ms-resource:loc.messages.OutputDirectoryIgnored",
+    "NoDestinationPlatformWarning": "ms-resource:loc.messages.NoDestinationPlatformWarning"
   }
 }


### PR DESCRIPTION
with: 'A build only device cannot be used to run this target.'