### PR TITLE
Allow using build definition name in 'Build definition' input

### DIFF
--- a/Tasks/DownloadBuildArtifacts/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DownloadBuildArtifacts/Strings/resources.resjson/en-US/resources.resjson
@@ -12,6 +12,9 @@
   "loc.input.help.definition": "Select the build definition name",
   "loc.input.label.specificBuildWithTriggering": "When appropriate, download artifacts from the triggering build.",
   "loc.input.help.specificBuildWithTriggering": "If checked, this build task will try to download artifacts from the triggering build. If there is no triggering build from the specified definition, it will download artifacts from the build specified in the options below.",
+  "loc.input.label.buildVersionToDownload": "Build version to download",
+  "loc.input.label.branchName": "Branch name",
+  "loc.input.help.branchName": "Specify to filter on branch/ref name, for example: ```refs/heads/develop```.",
   "loc.input.label.buildId": "Build",
   "loc.input.help.buildId": "The build from which to download the artifacts",
   "loc.input.label.downloadType": "Download type",
@@ -35,5 +38,9 @@
   "loc.messages.ArtifactsSuccessfullyDownloaded": "Successfully downloaded artifacts to %s",
   "loc.messages.RetryingOperation": "Error : in %s, so retrying => retries pending  : %s",
   "loc.messages.OperationFailed": "Failed in %s with error: %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "Directory '%s' does not exist. Falling back to parent directory: %s"
+  "loc.messages.ArtifactNameDirectoryNotFound": "Directory '%s' does not exist. Falling back to parent directory: %s",
+  "loc.messages.LatestBuildFound": "Latest build found:  %s",
+  "loc.messages.LatestBuildNotFound": "Latest build not found",
+  "loc.messages.LatestBuildFromBranchNotFound": "Latest build from branch %s not found",
+  "loc.messages.DefinitionIDFound": "Definition Name %s resolved to id %d"
 }

--- a/Tasks/DownloadBuildArtifacts/main.ts
+++ b/Tasks/DownloadBuildArtifacts/main.ts
@@ -6,7 +6,7 @@ import * as tl from 'vsts-task-lib/task';
 import { IBuildApi } from './vso-node-api/BuildApi';
 import { IRequestHandler } from './vso-node-api/interfaces/common/VsoBaseInterfaces';
 import { WebApi, getHandlerFromToken } from './vso-node-api/WebApi';
-import { BuildStatus, BuildResult, BuildQueryOrder, Build } from './vso-node-api/interfaces/BuildInterfaces';
+import { BuildStatus, BuildResult, BuildQueryOrder, Build, BuildDefinitionReference } from './vso-node-api/interfaces/BuildInterfaces';
 
 import * as models from 'artifact-engine/Models';
 import * as engine from 'artifact-engine/Engine';
@@ -132,6 +132,17 @@ async function main(): Promise<void> {
                 buildId = parseInt(tl.getInput("buildId", buildVersionToDownload == "specific"));
             }
         }
+
+        // if the definition name includes a variable then definitionIdSpecified is a name vs a number
+        if (Number.isNaN(parseInt(definitionIdSpecified))) {
+            var definitions: BuildDefinitionReference[] = await executeWithRetries("getBuildDefinitions", () => buildApi.getDefinitions(projectId, definitionIdSpecified), 4).catch((reason) => {
+                reject(reason);
+                return;
+            });
+            definitionId = String(definitions[0].id);
+            console.log(tl.loc("DefinitionIDFound", definitionIdSpecified, definitionId));
+        }
+
 
         // verify that buildId belongs to the definition selected
         if (definitionId) {

--- a/Tasks/DownloadBuildArtifacts/task.json
+++ b/Tasks/DownloadBuildArtifacts/task.json
@@ -210,17 +210,18 @@
     "DownloadArtifacts": "Downloading artifacts from: %s",
     "LinkedArtifactCount": "Linked artifacts count:  %s",
     "FileContainerInvalidArtifactData": "Invalid file container artifact. Resource data must be in the format #/{container id}/path",
-    "UnsupportedArtifactType" :"Unsupported artifact type: %s",
+    "UnsupportedArtifactType": "Unsupported artifact type: %s",
     "BuildNotFound": "Build with id %s not found",
     "BuildArtifactNotFound": "Artifact %s not found for build %s",
     "NoArtifactsFound": "No artifacts found for build %s",
     "BuildIdBuildDefinitionMismatch": "Build with id %s not found for build definition id %s",
     "ArtifactsSuccessfullyDownloaded": "Successfully downloaded artifacts to %s",
-    "RetryingOperation" : "Error : in %s, so retrying => retries pending  : %s",
+    "RetryingOperation": "Error : in %s, so retrying => retries pending  : %s",
     "OperationFailed": "Failed in %s with error: %s",
     "ArtifactNameDirectoryNotFound": "Directory '%s' does not exist. Falling back to parent directory: %s",
     "LatestBuildFound": "Latest build found:  %s",
-    "LatestBuildNotFound":"Latest build not found",
-    "LatestBuildFromBranchNotFound":"Latest build from branch %s not found"
+    "LatestBuildNotFound": "Latest build not found",
+    "LatestBuildFromBranchNotFound": "Latest build from branch %s not found",
+    "DefinitionIDFound": "Definition Name %s resolved to id %d"
   }
 }

--- a/Tasks/DownloadBuildArtifacts/task.json
+++ b/Tasks/DownloadBuildArtifacts/task.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 133,
+    "Minor": 134,
     "Patch": 0
   },
   "groups": [

--- a/Tasks/DownloadBuildArtifacts/task.loc.json
+++ b/Tasks/DownloadBuildArtifacts/task.loc.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 132,
+    "Minor": 134,
     "Patch": 0
   },
   "groups": [
@@ -68,12 +68,34 @@
       "helpMarkDown": "ms-resource:loc.input.help.specificBuildWithTriggering"
     },
     {
+      "name": "buildVersionToDownload",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.buildVersionToDownload",
+      "defaultValue": "latest",
+      "visibleRule": "buildType == specific",
+      "required": true,
+      "options": {
+        "latest": "Latest",
+        "latestFromBranch": "Latest from specific branch",
+        "specific": "Specific version"
+      }
+    },
+    {
+      "name": "branchName",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.branchName",
+      "defaultValue": "refs/heads/master",
+      "visibleRule": "buildType == specific && buildVersionToDownload == latestFromBranch",
+      "required": true,
+      "helpMarkDown": "ms-resource:loc.input.help.branchName"
+    },
+    {
       "name": "buildId",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.buildId",
       "defaultValue": "",
       "required": true,
-      "visibleRule": "buildType == specific",
+      "visibleRule": "buildType == specific && buildVersionToDownload == specific",
       "properties": {
         "EditableOptions": "True",
         "DisableManageLink": "True"
@@ -196,6 +218,10 @@
     "ArtifactsSuccessfullyDownloaded": "ms-resource:loc.messages.ArtifactsSuccessfullyDownloaded",
     "RetryingOperation": "ms-resource:loc.messages.RetryingOperation",
     "OperationFailed": "ms-resource:loc.messages.OperationFailed",
-    "ArtifactNameDirectoryNotFound": "ms-resource:loc.messages.ArtifactNameDirectoryNotFound"
+    "ArtifactNameDirectoryNotFound": "ms-resource:loc.messages.ArtifactNameDirectoryNotFound",
+    "LatestBuildFound": "ms-resource:loc.messages.LatestBuildFound",
+    "LatestBuildNotFound": "ms-resource:loc.messages.LatestBuildNotFound",
+    "LatestBuildFromBranchNotFound": "ms-resource:loc.messages.LatestBuildFromBranchNotFound",
+    "DefinitionIDFound": "ms-resource:loc.messages.DefinitionIDFound"
   }
 }


### PR DESCRIPTION
Here is an example of usage:
![image](https://user-images.githubusercontent.com/37909735/38208245-43ba2688-3665-11e8-9209-7d61033a0f7c.png)
In this case the definitionId would resolve in a name rather than a number