### PR TITLE
Allow Build Tags

### DIFF
--- a/Tasks/DownloadBuildArtifacts/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DownloadBuildArtifacts/Strings/resources.resjson/en-US/resources.resjson
@@ -12,8 +12,13 @@
   "loc.input.help.definition": "Select the build definition name",
   "loc.input.label.specificBuildWithTriggering": "When appropriate, download artifacts from the triggering build.",
   "loc.input.help.specificBuildWithTriggering": "If checked, this build task will try to download artifacts from the triggering build. If there is no triggering build from the specified definition, it will download artifacts from the build specified in the options below.",
+  "loc.input.label.buildVersionToDownload": "Build version to download",
+  "loc.input.label.branchName": "Branch name",
+  "loc.input.help.branchName": "Specify to filter on branch/ref name, for example: ```refs/heads/develop```.",
   "loc.input.label.buildId": "Build",
   "loc.input.help.buildId": "The build from which to download the artifacts",
+  "loc.input.label.Tags": "Build Tags",
+  "loc.input.help.Tags": "A comma-delimited list of tags. Only builds with these tags will be returned.",
   "loc.input.label.downloadType": "Download type",
   "loc.input.help.downloadType": "Download a specific artifact or specific files from the build.",
   "loc.input.label.artifactName": "Artifact name",
@@ -35,5 +40,8 @@
   "loc.messages.ArtifactsSuccessfullyDownloaded": "Successfully downloaded artifacts to %s",
   "loc.messages.RetryingOperation": "Error : in %s, so retrying => retries pending  : %s",
   "loc.messages.OperationFailed": "Failed in %s with error: %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "Directory '%s' does not exist. Falling back to parent directory: %s"
+  "loc.messages.ArtifactNameDirectoryNotFound": "Directory '%s' does not exist. Falling back to parent directory: %s",
+  "loc.messages.LatestBuildFound": "Latest build found:  %s",
+  "loc.messages.LatestBuildNotFound": "Latest build not found",
+  "loc.messages.LatestBuildFromBranchNotFound": "Latest build from branch %s not found"
 }

--- a/Tasks/DownloadBuildArtifacts/main.ts
+++ b/Tasks/DownloadBuildArtifacts/main.ts
@@ -69,6 +69,10 @@ async function main(): Promise<void> {
         var branchName: string =  tl.getInput("branchName", false);;
         var downloadPath: string = tl.getInput("downloadPath", true);
         var downloadType: string = tl.getInput("downloadType", true);
+        var tagFilters = tl.getInput("tagFilters", false);
+        if (tagFilters != null){
+            tagFilters = tagFilters.split(",");
+        }
 
         var endpointUrl: string = tl.getVariable("System.TeamFoundationCollectionUri");
         var accessToken: string = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'AccessToken', false);
@@ -140,10 +144,10 @@ async function main(): Promise<void> {
                 var branchNameFilter = (buildVersionToDownload == "latest") ? null : branchName;
                 
                 // get latest successful build filtered by branch
-                var buildsForThisDefinition = await executeWithRetries("getBuildId", () => buildApi.getBuilds( projectId, [parseInt(definitionId)],null,null,null,null,null,null,BuildStatus.Completed,BuildResult.Succeeded,null,null,null,null,null,null, BuildQueryOrder.FinishTimeDescending,branchNameFilter), 4).catch((reason) => {
+                var buildsForThisDefinition = await executeWithRetries("getBuildId", () => buildApi.getBuilds(projectId, [parseInt(definitionId)], null, null, null, null, null, null, BuildStatus.Completed, BuildResult.Succeeded, tagFilters, null, null, null, null, null, BuildQueryOrder.FinishTimeDescending, branchNameFilter), 4).catch((reason) => {
                     reject(reason);
                     return;
-                }); 
+                });
 
                 if (!buildsForThisDefinition || buildsForThisDefinition.length == 0){ 
                     if (buildVersionToDownload == "latestFromBranch") reject(tl.loc("LatestBuildFromBranchNotFound", branchNameFilter));

--- a/Tasks/DownloadBuildArtifacts/main.ts
+++ b/Tasks/DownloadBuildArtifacts/main.ts
@@ -69,9 +69,10 @@ async function main(): Promise<void> {
         var branchName: string =  tl.getInput("branchName", false);;
         var downloadPath: string = tl.getInput("downloadPath", true);
         var downloadType: string = tl.getInput("downloadType", true);
-        var tagFilters = tl.getInput("tagFilters", false);
-        if (tagFilters != null){
-            tagFilters = tagFilters.split(",");
+        var tagFiltersInput = tl.getInput("tagFilters", false);
+        var tagFilters = [];
+        if (!!tagFiltersInput) {
+            tagFilters = tagFiltersInput.split(",");
         }
 
         var endpointUrl: string = tl.getVariable("System.TeamFoundationCollectionUri");

--- a/Tasks/DownloadBuildArtifacts/task.json
+++ b/Tasks/DownloadBuildArtifacts/task.json
@@ -76,7 +76,7 @@
       "required": true,
       "options": {
         "latest": "Latest",
-        "latestFromBranch": "Latest from specific branch",
+        "latestFromBranch": "Latest from specific branch and specified Build Tags",
         "specific": "Specific version"
       }
     },

--- a/Tasks/DownloadBuildArtifacts/task.json
+++ b/Tasks/DownloadBuildArtifacts/task.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 133,
+    "Minor": 134,
     "Patch": 0
   },
   "groups": [
@@ -83,7 +83,7 @@
     {
       "name": "branchName",
       "type": "string",
-      "label": "Branch name", 
+      "label": "Branch name",
       "defaultValue": "refs/heads/master",
       "visibleRule": "buildType == specific && buildVersionToDownload == latestFromBranch",
       "required": true,
@@ -103,14 +103,23 @@
       "helpMarkDown": "The build from which to download the artifacts"
     },
     {
+      "name": "Tags",
+      "type": "string",
+      "label": "Build Tags",
+      "defaultValue": "",
+      "visibleRule": "buildType == specific && buildVersionToDownload != specific",
+      "required": false,
+      "helpMarkDown": "A comma-delimited list of tags. Only builds with these tags will be returned."
+    },
+    {
       "name": "downloadType",
       "type": "radio",
       "label": "Download type",
       "defaultValue": "single",
       "required": true,
       "options": {
-          "single": "Specific artifact",
-          "specific": "Specific files"
+        "single": "Specific artifact",
+        "specific": "Specific files"
       },
       "helpMarkDown": "Download a specific artifact or specific files from the build."
     },

--- a/Tasks/DownloadBuildArtifacts/task.loc.json
+++ b/Tasks/DownloadBuildArtifacts/task.loc.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 132,
+    "Minor": 133,
     "Patch": 0
   },
   "groups": [
@@ -68,17 +68,48 @@
       "helpMarkDown": "ms-resource:loc.input.help.specificBuildWithTriggering"
     },
     {
+      "name": "buildVersionToDownload",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.buildVersionToDownload",
+      "defaultValue": "latest",
+      "visibleRule": "buildType == specific",
+      "required": true,
+      "options": {
+        "latest": "Latest",
+        "latestFromBranch": "Latest from specific branch",
+        "specific": "Specific version"
+      }
+    },
+    {
+      "name": "branchName",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.branchName",
+      "defaultValue": "refs/heads/master",
+      "visibleRule": "buildType == specific && buildVersionToDownload == latestFromBranch",
+      "required": true,
+      "helpMarkDown": "ms-resource:loc.input.help.branchName"
+    },
+    {
       "name": "buildId",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.buildId",
       "defaultValue": "",
       "required": true,
-      "visibleRule": "buildType == specific",
+      "visibleRule": "buildType == specific && buildVersionToDownload == specific",
       "properties": {
         "EditableOptions": "True",
         "DisableManageLink": "True"
       },
       "helpMarkDown": "ms-resource:loc.input.help.buildId"
+    },
+    {
+      "name": "Tags",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.Tags",
+      "defaultValue": "",
+      "visibleRule": "buildType == specific && buildVersionToDownload != specific",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.Tags"
     },
     {
       "name": "downloadType",
@@ -196,6 +227,9 @@
     "ArtifactsSuccessfullyDownloaded": "ms-resource:loc.messages.ArtifactsSuccessfullyDownloaded",
     "RetryingOperation": "ms-resource:loc.messages.RetryingOperation",
     "OperationFailed": "ms-resource:loc.messages.OperationFailed",
-    "ArtifactNameDirectoryNotFound": "ms-resource:loc.messages.ArtifactNameDirectoryNotFound"
+    "ArtifactNameDirectoryNotFound": "ms-resource:loc.messages.ArtifactNameDirectoryNotFound",
+    "LatestBuildFound": "ms-resource:loc.messages.LatestBuildFound",
+    "LatestBuildNotFound": "ms-resource:loc.messages.LatestBuildNotFound",
+    "LatestBuildFromBranchNotFound": "ms-resource:loc.messages.LatestBuildFromBranchNotFound"
   }
 }


### PR DESCRIPTION
The user will be able to specify tags to filter their builds further. This will be an optional field
Example of usage:
![image](https://user-images.githubusercontent.com/37909735/38272663-ac47f8b8-373e-11e8-9f27-14b224491bca.png)
