### PR TITLE
Use Python Version: Use built-in task support for output variables.  Add per-user scripts directory on Windows

### DIFF
--- a/Tasks/UsePythonVersion/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UsePythonVersion/Strings/resources.resjson/en-US/resources.resjson
@@ -6,9 +6,9 @@
   "loc.input.label.versionSpec": "Version spec",
   "loc.input.help.versionSpec": "Version range or exact version of a Python version to use.",
   "loc.input.label.outputVariable": "Output variable",
-  "loc.input.help.outputVariable": "Set a name for the variable that will contain the directory of the decompressed Python distribution. Use this in subsequent tasks to access this installation of Python.",
+  "loc.input.help.outputVariable": "Name for the variable that will be created to contain the directory of the installed Python distribution. Use this in subsequent tasks to access this installation of Python.",
   "loc.input.label.addToPath": "Add to PATH",
-  "loc.input.help.addToPath": "Prepend the retrieved Python version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable.",
+  "loc.input.help.addToPath": "Whether to prepend the retrieved Python version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable.",
   "loc.messages.ListAvailableVersions": "Available versions:",
   "loc.messages.PlatformNotRecognized": "Platform not recognized",
   "loc.messages.VersionNotFound": "Version spec %s did not match any version in the tool cache."

--- a/Tasks/UsePythonVersion/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UsePythonVersion/Strings/resources.resjson/en-US/resources.resjson
@@ -9,5 +9,6 @@
   "loc.input.help.addToPath": "Whether to prepend the retrieved Python version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable.",
   "loc.messages.ListAvailableVersions": "Available versions:",
   "loc.messages.PlatformNotRecognized": "Platform not recognized",
+  "loc.messages.PrependPath": "Prepending PATH environment variable with directory: %s",
   "loc.messages.VersionNotFound": "Version spec %s did not match any version in the tool cache."
 }

--- a/Tasks/UsePythonVersion/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UsePythonVersion/Strings/resources.resjson/en-US/resources.resjson
@@ -5,8 +5,6 @@
   "loc.instanceNameFormat": "Use Python $(versionSpec)",
   "loc.input.label.versionSpec": "Version spec",
   "loc.input.help.versionSpec": "Version range or exact version of a Python version to use.",
-  "loc.input.label.outputVariable": "Output variable",
-  "loc.input.help.outputVariable": "Name for the variable that will be created to contain the directory of the installed Python distribution. Use this in subsequent tasks to access this installation of Python.",
   "loc.input.label.addToPath": "Add to PATH",
   "loc.input.help.addToPath": "Whether to prepend the retrieved Python version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable.",
   "loc.messages.ListAvailableVersions": "Available versions:",

--- a/Tasks/UsePythonVersion/Tests/L0.ts
+++ b/Tasks/UsePythonVersion/Tests/L0.ts
@@ -130,7 +130,7 @@ describe('UsePythonVersion L0 Suite', function () {
     it('sets PATH correctly on Linux', async function () {
         mockery.registerMock('vsts-task-lib/task', mockTask);
 
-        const toolPath = path.join('/', 'Python', '3.6.4');
+        const toolPath = path.join('/', 'Python', '3.6.4', 'x64');
         let mockPath = '';
         mockery.registerMock('vsts-task-tool-lib/tool', {
             findLocalTool: () => toolPath,
@@ -153,7 +153,7 @@ describe('UsePythonVersion L0 Suite', function () {
     it('sets PATH correctly on Windows', async function () {
         mockery.registerMock('vsts-task-lib/task', mockTask);
 
-        const toolPath = path.join('/', 'Python', '3.6.4');
+        const toolPath = path.join('/', 'Python', '3.6.4', 'x64');
         let mockPath = '';
         mockery.registerMock('vsts-task-tool-lib/tool', {
             findLocalTool: () => toolPath,
@@ -170,7 +170,11 @@ describe('UsePythonVersion L0 Suite', function () {
         };
 
         await uut.usePythonVersion(parameters, uut.Platform.Windows);
-        // On Windows, must add the "Scripts" directory to PATH as well
-        assert.strictEqual(`${path.join(toolPath, 'Scripts')};${toolPath};`, mockPath);
+
+        // On Windows, must add the two "Scripts" directories to PATH as well
+        const expectedScripts = path.join(toolPath, 'Scripts');
+        const expectedUserScripts = path.join(process.env['APPDATA'], 'Python', 'Python36', 'Scripts');
+        const expectedPath = `${expectedUserScripts};${expectedScripts};${toolPath};`;
+        assert.strictEqual(expectedPath, mockPath);
     });
 });

--- a/Tasks/UsePythonVersion/Tests/L0.ts
+++ b/Tasks/UsePythonVersion/Tests/L0.ts
@@ -88,14 +88,13 @@ describe('UsePythonVersion L0 Suite', function () {
         const uut = reload();
         const parameters = {
             versionSpec: '3.6',
-            outputVariable: 'Python',
             addToPath: false
         };
 
-        assert.strictEqual(buildVariables['Python'], undefined);
+        assert.strictEqual(buildVariables['pythonLocation'], undefined);
 
         await uut.usePythonVersion(parameters, uut.Platform.Linux);
-        assert.strictEqual(buildVariables['Python'], toolPath);
+        assert.strictEqual(buildVariables['pythonLocation'], toolPath);
     });
 
     it('rejects version not in cache', async function (done: MochaDone) {
@@ -108,7 +107,6 @@ describe('UsePythonVersion L0 Suite', function () {
         const uut = reload();
         const parameters = {
             versionSpec: '3.x',
-            outputVariable: 'Python',
             addToPath: false
         };
 
@@ -165,7 +163,6 @@ describe('UsePythonVersion L0 Suite', function () {
         const uut = reload();
         const parameters = {
             versionSpec: '3.6',
-            outputVariable: 'Python',
             addToPath: true
         };
 

--- a/Tasks/UsePythonVersion/Tests/L0.ts
+++ b/Tasks/UsePythonVersion/Tests/L0.ts
@@ -71,7 +71,7 @@ describe('UsePythonVersion L0 Suite', function () {
     })
 
     it('finds version in cache', async function () {
-        let buildVariables: any = {};
+        let buildVariables: { [key: string]: string } = {};
         const mockBuildVariables = {
             setVariable: (variable: string, value: string) => {
                 buildVariables[variable] = value;

--- a/Tasks/UsePythonVersion/Tests/L0.ts
+++ b/Tasks/UsePythonVersion/Tests/L0.ts
@@ -168,6 +168,8 @@ describe('UsePythonVersion L0 Suite', function () {
             }
         });
 
+        process.env['APPDATA'] = '/mock-appdata';
+
         const uut = reload();
         const parameters = {
             versionSpec: '3.6',

--- a/Tasks/UsePythonVersion/Tests/L0.ts
+++ b/Tasks/UsePythonVersion/Tests/L0.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 
 import * as mockery from 'mockery';
 import * as mockTask from 'vsts-task-lib/mock-task';
+
+import { Platform } from '../taskutil';
 import * as usePythonVersion from '../usepythonversion';
 
 /** Reload the unit under test to use mocks that have been registered. */
@@ -93,7 +95,7 @@ describe('UsePythonVersion L0 Suite', function () {
 
         assert.strictEqual(buildVariables['pythonLocation'], undefined);
 
-        await uut.usePythonVersion(parameters, uut.Platform.Linux);
+        await uut.usePythonVersion(parameters, Platform.Linux);
         assert.strictEqual(buildVariables['pythonLocation'], toolPath);
     });
 
@@ -111,7 +113,7 @@ describe('UsePythonVersion L0 Suite', function () {
         };
 
         try {
-            await uut.usePythonVersion(parameters, uut.Platform.Linux);
+            await uut.usePythonVersion(parameters, Platform.Linux);
             done(new Error('should not have succeeded'));
         } catch (e) {
             const expectedMessage = [
@@ -129,10 +131,13 @@ describe('UsePythonVersion L0 Suite', function () {
         mockery.registerMock('vsts-task-lib/task', mockTask);
 
         const toolPath = path.join('/', 'Python', '3.6.4', 'x64');
-        let mockPath = '';
         mockery.registerMock('vsts-task-tool-lib/tool', {
             findLocalTool: () => toolPath,
-            prependPath: (s: string) => {
+        });
+
+        let mockPath = '';
+        mockery.registerMock('./toolutil', {
+            prependPathSafe: (s: string) => {
                 mockPath = s + ':' + mockPath;
             }
         });
@@ -144,7 +149,7 @@ describe('UsePythonVersion L0 Suite', function () {
             addToPath: true
         };
 
-        await uut.usePythonVersion(parameters, uut.Platform.Linux);
+        await uut.usePythonVersion(parameters, Platform.Linux);
         assert.strictEqual(`${toolPath}:`, mockPath);
     });
 
@@ -152,10 +157,13 @@ describe('UsePythonVersion L0 Suite', function () {
         mockery.registerMock('vsts-task-lib/task', mockTask);
 
         const toolPath = path.join('/', 'Python', '3.6.4', 'x64');
-        let mockPath = '';
         mockery.registerMock('vsts-task-tool-lib/tool', {
-            findLocalTool: () => toolPath,
-            prependPath: (s: string) => {
+            findLocalTool: () => toolPath
+        });
+
+        let mockPath = '';
+        mockery.registerMock('./toolutil', {
+            prependPathSafe: (s: string) => {
                 mockPath = s + ';' + mockPath;
             }
         });
@@ -166,7 +174,7 @@ describe('UsePythonVersion L0 Suite', function () {
             addToPath: true
         };
 
-        await uut.usePythonVersion(parameters, uut.Platform.Windows);
+        await uut.usePythonVersion(parameters, Platform.Windows);
 
         // On Windows, must add the two "Scripts" directories to PATH as well
         const expectedScripts = path.join(toolPath, 'Scripts');

--- a/Tasks/UsePythonVersion/main.ts
+++ b/Tasks/UsePythonVersion/main.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as task from 'vsts-task-lib/task';
-import { getPlatform, usePythonVersion } from './usepythonversion';
+import { getPlatform } from './taskutil';
+import { usePythonVersion } from './usepythonversion';
 
 (async () => {
     try {

--- a/Tasks/UsePythonVersion/main.ts
+++ b/Tasks/UsePythonVersion/main.ts
@@ -7,7 +7,6 @@ import { getPlatform, usePythonVersion } from './usepythonversion';
         task.setResourcePath(path.join(__dirname, 'task.json'));
         await usePythonVersion({
             versionSpec: task.getInput('versionSpec', true),
-            outputVariable: task.getInput('outputVariable', true),
             addToPath: task.getBoolInput('addToPath', true)
         },
         getPlatform());

--- a/Tasks/UsePythonVersion/task.json
+++ b/Tasks/UsePythonVersion/task.json
@@ -51,6 +51,7 @@
     "messages": {
         "ListAvailableVersions": "Available versions:",
         "PlatformNotRecognized": "Platform not recognized",
+        "PrependPath": "Prepending PATH environment variable with directory: %s",
         "VersionNotFound": "Version spec %s did not match any version in the tool cache."
     }
 }

--- a/Tasks/UsePythonVersion/task.json
+++ b/Tasks/UsePythonVersion/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 133,
-        "Patch": 0
+        "Patch": 1
     },
     "preview": true,
     "demands": [],

--- a/Tasks/UsePythonVersion/task.json
+++ b/Tasks/UsePythonVersion/task.json
@@ -28,20 +28,18 @@
             "helpMarkDown": "Version range or exact version of a Python version to use."
         },
         {
-            "name": "outputVariable",
-            "type": "string",
-            "label": "Output variable",
-            "required": true,
-            "defaultValue": "",
-            "helpMarkDown": "Name for the variable that will be created to contain the directory of the installed Python distribution. Use this in subsequent tasks to access this installation of Python."
-        },
-        {
             "name": "addToPath",
             "type": "boolean",
             "label": "Add to PATH",
             "required": true,
             "defaultValue": "true",
             "helpMarkDown": "Whether to prepend the retrieved Python version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable."
+        }
+    ],
+    "outputVariables": [
+        {
+            "name": "pythonLocation",
+            "description": "The directory of the installed Python distribution. Use this in subsequent tasks to access this installation of Python."
         }
     ],
     "execution": {

--- a/Tasks/UsePythonVersion/task.json
+++ b/Tasks/UsePythonVersion/task.json
@@ -33,7 +33,7 @@
             "label": "Output variable",
             "required": true,
             "defaultValue": "",
-            "helpMarkDown": "Set a name for the variable that will contain the directory of the decompressed Python distribution. Use this in subsequent tasks to access this installation of Python."
+            "helpMarkDown": "Name for the variable that will be created to contain the directory of the installed Python distribution. Use this in subsequent tasks to access this installation of Python."
         },
         {
             "name": "addToPath",
@@ -41,7 +41,7 @@
             "label": "Add to PATH",
             "required": true,
             "defaultValue": "true",
-            "helpMarkDown": "Prepend the retrieved Python version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable."
+            "helpMarkDown": "Whether to prepend the retrieved Python version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable."
         }
     ],
     "execution": {

--- a/Tasks/UsePythonVersion/task.loc.json
+++ b/Tasks/UsePythonVersion/task.loc.json
@@ -51,6 +51,7 @@
   "messages": {
     "ListAvailableVersions": "ms-resource:loc.messages.ListAvailableVersions",
     "PlatformNotRecognized": "ms-resource:loc.messages.PlatformNotRecognized",
+    "PrependPath": "ms-resource:loc.messages.PrependPath",
     "VersionNotFound": "ms-resource:loc.messages.VersionNotFound"
   }
 }

--- a/Tasks/UsePythonVersion/task.loc.json
+++ b/Tasks/UsePythonVersion/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 133,
-    "Patch": 0
+    "Patch": 1
   },
   "preview": true,
   "demands": [],

--- a/Tasks/UsePythonVersion/task.loc.json
+++ b/Tasks/UsePythonVersion/task.loc.json
@@ -28,20 +28,18 @@
       "helpMarkDown": "ms-resource:loc.input.help.versionSpec"
     },
     {
-      "name": "outputVariable",
-      "type": "string",
-      "label": "ms-resource:loc.input.label.outputVariable",
-      "required": true,
-      "defaultValue": "",
-      "helpMarkDown": "ms-resource:loc.input.help.outputVariable"
-    },
-    {
       "name": "addToPath",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.addToPath",
       "required": true,
       "defaultValue": "true",
       "helpMarkDown": "ms-resource:loc.input.help.addToPath"
+    }
+  ],
+  "outputVariables": [
+    {
+      "name": "pythonLocation",
+      "description": "The directory of the installed Python distribution. Use this in subsequent tasks to access this installation of Python."
     }
   ],
   "execution": {

--- a/Tasks/UsePythonVersion/taskutil.ts
+++ b/Tasks/UsePythonVersion/taskutil.ts
@@ -1,0 +1,21 @@
+import * as task from 'vsts-task-lib/task';
+
+// TODO move this to vsts-task-lib 
+export enum Platform {
+    Windows,
+    MacOS,
+    Linux
+}
+
+/**
+ * Determine the operating system the build agent is running on.
+ * TODO move this to vsts-task-lib
+ */
+export function getPlatform(): Platform {
+    switch (process.platform) {
+        case 'win32': return Platform.Windows;
+        case 'darwin': return Platform.MacOS;
+        case 'linux': return Platform.Linux;
+        default: throw Error(task.loc('PlatformNotRecognized'));
+    }
+}

--- a/Tasks/UsePythonVersion/toolutil.ts
+++ b/Tasks/UsePythonVersion/toolutil.ts
@@ -1,0 +1,19 @@
+import * as path from 'path';
+
+import * as task from 'vsts-task-lib/task';
+
+/**
+ * Like `prependPath` from vsts-task-tool-lib, but does not check whether the directory exists.
+ * TODO move this to vsts-task-tool-lib
+ */
+export function prependPathSafe(toolPath: string) {
+    task.assertAgent('2.115.0');
+
+    console.log(task.loc('PrependPath', toolPath));
+    const newPath: string = toolPath + path.delimiter + process.env['PATH'];
+    task.debug('new Path: ' + newPath);
+    process.env['PATH'] = newPath;
+
+    // instruct the agent to set this path on future tasks
+    console.log('##vso[task.prependpath]' + toolPath);
+}

--- a/Tasks/UsePythonVersion/usepythonversion.ts
+++ b/Tasks/UsePythonVersion/usepythonversion.ts
@@ -72,7 +72,15 @@ export async function usePythonVersion(parameters: TaskParameters, platform: Pla
             const scriptsDir = path.join(installDir, 'Scripts');
             tool.prependPath(scriptsDir);
 
-            // TODO add --user directory once build image is updated
+            // Add --user directory
+            // `installDir` from tool cache should look like $AGENT_TOOLSDIRECTORY/Python/<semantic version>/x64/
+            // So if `findLocalTool` succeeded above, we must have a conformant `installDir`
+            const version = path.basename(path.dirname(installDir));
+            const major = semver.major(version);
+            const minor = semver.minor(version);
+
+            const userScriptsDir = path.join(process.env['APPDATA'], 'Python', `Python${major}${minor}`, 'Scripts');
+            tool.prependPath(userScriptsDir);
         }
     }
 }

--- a/Tasks/UsePythonVersion/usepythonversion.ts
+++ b/Tasks/UsePythonVersion/usepythonversion.ts
@@ -7,23 +7,8 @@ import * as semver from 'semver';
 import * as task from 'vsts-task-lib/task';
 import * as tool from 'vsts-task-tool-lib/tool';
 
-export enum Platform {
-    Windows,
-    MacOS,
-    Linux
-}
-
-/**
- * Determine the operating system the build agent is running on.
- */
-export function getPlatform(): Platform {
-    switch (process.platform) {
-        case 'win32': return Platform.Windows;
-        case 'darwin': return Platform.MacOS;
-        case 'linux': return Platform.Linux;
-        default: throw Error(task.loc('PlatformNotRecognized'));
-    }
-}
+import { Platform } from './taskutil';
+import * as toolUtil  from './toolutil';
 
 interface TaskParameters {
     readonly versionSpec: string,
@@ -54,7 +39,7 @@ export async function usePythonVersion(parameters: TaskParameters, platform: Pla
 
     task.setVariable('pythonLocation', installDir);
     if (parameters.addToPath) {
-        tool.prependPath(installDir);
+        toolUtil.prependPathSafe(installDir);
 
         // Python has "scripts" directories where command-line tools that come with packages are installed.
         // There are different directories for `pip install` and `pip install --user`.
@@ -69,7 +54,7 @@ export async function usePythonVersion(parameters: TaskParameters, platform: Pla
         //      (--user) %APPDATA%\Python\PythonXY\Scripts
         if (platform === Platform.Windows) {
             const scriptsDir = path.join(installDir, 'Scripts');
-            tool.prependPath(scriptsDir);
+            toolUtil.prependPathSafe(scriptsDir);
 
             // Add --user directory
             // `installDir` from tool cache should look like $AGENT_TOOLSDIRECTORY/Python/<semantic version>/x64/
@@ -79,7 +64,7 @@ export async function usePythonVersion(parameters: TaskParameters, platform: Pla
             const minor = semver.minor(version);
 
             const userScriptsDir = path.join(process.env['APPDATA'], 'Python', `Python${major}${minor}`, 'Scripts');
-            tool.prependPath(userScriptsDir);
+            toolUtil.prependPathSafe(userScriptsDir);
         }
     }
 }

--- a/Tasks/UsePythonVersion/usepythonversion.ts
+++ b/Tasks/UsePythonVersion/usepythonversion.ts
@@ -27,7 +27,6 @@ export function getPlatform(): Platform {
 
 interface TaskParameters {
     readonly versionSpec: string,
-    readonly outputVariable: string,
     readonly addToPath: boolean
 }
 
@@ -53,7 +52,7 @@ export async function usePythonVersion(parameters: TaskParameters, platform: Pla
         ].join(os.EOL));
     }
 
-    task.setVariable(parameters.outputVariable, installDir);
+    task.setVariable('pythonLocation', installDir);
     if (parameters.addToPath) {
         tool.prependPath(installDir);
 


### PR DESCRIPTION
* I didn't know there was built-in task support for output variables, so I am changing the task to use that instead of using a task parameter.
* Add the per-user scripts directory to PATH on Windows
