### PR TITLE
fixed add-build-task link in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Tasks are simply tool runners.  They know how to run MSBuild, VSTest, etc... in 
 
 For uploading custom tasks to VSTS use the [TFS Cross Platform Command Line utility](https://github.com/Microsoft/tfs-cli).
 
-Tasks can also be deployed with a Visual Studio Team Services extension. See [this tutorial](https://www.visualstudio.com/en-us/docs/integrate/extensions/develop/add-build-task) for how to package tasks inside an extension.
+Tasks can also be deployed with a Visual Studio Team Services extension. See [this tutorial](https://docs.microsoft.com/en-us/vsts/extend/develop/add-build-task) for how to package tasks inside an extension.
 
 ## Contributing
 We take contributions.  [Read here](docs/contribute.md) how to contribute.


### PR DESCRIPTION
Former link was https://www.visualstudio.com/en-us/docs/integrate/extensions/develop/add-build-task results in 404
Changed it to https://docs.microsoft.com/en-us/vsts/extend/develop/add-build-task