### PR TITLE
Add provisioningProfileName input alongside provisioningProfileUuid.

### DIFF
--- a/Tasks/Common/ios-signing-common/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Common/ios-signing-common/Strings/resources.resjson/en-US/resources.resjson
@@ -2,5 +2,6 @@
   "loc.messages.SignIdNotFound": "Failed to find iOS signing identity. Verify the signing and provisioning information provided.",
   "loc.messages.TempKeychainSetupFailed": "Failed to add the temporary keychain to the keychains search path.",
   "loc.messages.ProvProfileDetailsNotFound": "Failed to find the details for provisioning profile: %s",
-  "loc.messages.ProvProfileUUIDNotFound": "Failed to find provisioning profile UUID for provisioning profile: %s"
+  "loc.messages.ProvProfileUUIDNotFound": "Failed to find provisioning profile UUID for provisioning profile: %s",
+  "loc.messages.ProvProfileNameNotFound": "Failed to find provisioning profile name for provisioning profile: %s"
 }

--- a/Tasks/Common/ios-signing-common/module.json
+++ b/Tasks/Common/ios-signing-common/module.json
@@ -3,6 +3,7 @@
     "SignIdNotFound": "Failed to find iOS signing identity. Verify the signing and provisioning information provided.",
     "TempKeychainSetupFailed": "Failed to add the temporary keychain to the keychains search path.",
     "ProvProfileDetailsNotFound": "Failed to find the details for provisioning profile: %s",
-    "ProvProfileUUIDNotFound": "Failed to find provisioning profile UUID for provisioning profile: %s"
+    "ProvProfileUUIDNotFound": "Failed to find provisioning profile UUID for provisioning profile: %s",
+    "ProvProfileNameNotFound": "Failed to find provisioning profile name for provisioning profile: %s"
   }
 }

--- a/Tasks/Common/securefiles-common/package-lock.json
+++ b/Tasks/Common/securefiles-common/package-lock.json
@@ -57,9 +57,9 @@
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
-      "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
+      "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
       "requires": {
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
@@ -76,13 +76,12 @@
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "vso-node-api": {
-      "version": "6.1.2-preview",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.1.2-preview.tgz",
-      "integrity": "sha1-qrNUbfJFHs2JTgcbuZtd8Zxfp48=",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
+      "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
       "requires": {
-        "q": "1.5.1",
         "tunnel": "0.0.4",
-        "typed-rest-client": "0.9.0",
+        "typed-rest-client": "0.12.0",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/Common/securefiles-common/package.json
+++ b/Tasks/Common/securefiles-common/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/Microsoft/vsts-tasks#readme",
   "dependencies": {
     "vsts-task-lib": "^2.0.3-preview",
-    "vso-node-api": "^6.1.2-preview"
+    "vso-node-api": "^6.5"
   }
 }

--- a/Tasks/Common/securefiles-common/securefiles-common.ts
+++ b/Tasks/Common/securefiles-common/securefiles-common.ts
@@ -17,17 +17,18 @@ export class SecureFileHelpers {
 
     /**
      * Download secure file contents to a temporary location for the build
-     * @param secureFileId 
+     * @param secureFileId
      */
     async downloadSecureFile(secureFileId: string) {
-        let tempDownloadPath: string = this.getSecureFileTempDownloadPath(secureFileId);
+        const tempDownloadPath: string = this.getSecureFileTempDownloadPath(secureFileId);
 
         tl.debug('Downloading secure file contents to: ' + tempDownloadPath);
-        let file: NodeJS.WritableStream = fs.createWriteStream(tempDownloadPath);
+        const file: NodeJS.WritableStream = fs.createWriteStream(tempDownloadPath);
 
-        let stream = (await this.serverConnection.getTaskAgentApi().downloadSecureFile(
+        const agentApi = await this.serverConnection.getTaskAgentApi();
+        const stream = (await agentApi.downloadSecureFile(
             tl.getVariable('SYSTEM.TEAMPROJECT'), secureFileId, tl.getSecureFileTicket(secureFileId), false)).pipe(file);
-        let defer = Q.defer();
+        const defer = Q.defer();
         stream.on('finish', () => {
             defer.resolve();
         });
@@ -38,7 +39,7 @@ export class SecureFileHelpers {
 
     /**
      * Delete secure file from the temporary location for the build
-     * @param secureFileId 
+     * @param secureFileId
      */
     deleteSecureFile(secureFileId: string) {
         let tempDownloadPath: string = this.getSecureFileTempDownloadPath(secureFileId);
@@ -50,7 +51,7 @@ export class SecureFileHelpers {
 
     /**
      * Returns the temporary download location for the secure file
-     * @param secureFileId 
+     * @param secureFileId
      */
     getSecureFileTempDownloadPath(secureFileId: string) {
         let fileName: string = tl.getSecureFileName(secureFileId);

--- a/Tasks/InstallAppleCertificate/package-lock.json
+++ b/Tasks/InstallAppleCertificate/package-lock.json
@@ -50,7 +50,7 @@
     "securefiles-common": {
       "version": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
       "requires": {
-        "vso-node-api": "6.1.2-preview",
+        "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.0.5"
       }
     },
@@ -70,9 +70,9 @@
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
-      "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
+      "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
       "requires": {
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
@@ -89,13 +89,12 @@
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "vso-node-api": {
-      "version": "6.1.2-preview",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.1.2-preview.tgz",
-      "integrity": "sha1-qrNUbfJFHs2JTgcbuZtd8Zxfp48=",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
+      "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
       "requires": {
-        "q": "1.5.1",
         "tunnel": "0.0.4",
-        "typed-rest-client": "0.9.0",
+        "typed-rest-client": "0.12.0",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/InstallAppleProvisioningProfile/Tests/L0SecureFile.ts
+++ b/Tasks/InstallAppleProvisioningProfile/Tests/L0SecureFile.ts
@@ -46,6 +46,10 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "testuuid"
         },
+        "/usr/libexec/PlistBuddy -c Print Name _xcodetasktmp.plist": {
+            "code": 0,
+            "stdout": "testprovname"
+        },
         "/bin/cp -f /build/temp/mySecureFileId.filename /users/test/Library/MobileDevice/Provisioning Profiles/testuuid.mobileprovision": {
             "code": 0,
             "stdout": "provisioning profile copied"

--- a/Tasks/InstallAppleProvisioningProfile/Tests/L0SourceRepository.ts
+++ b/Tasks/InstallAppleProvisioningProfile/Tests/L0SourceRepository.ts
@@ -51,6 +51,10 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "testuuid"
         },
+        "/usr/libexec/PlistBuddy -c Print Name _xcodetasktmp.plist": {
+            "code": 0,
+            "stdout": "testprovname"
+        },
         "/bin/cp -f /build/source/myprovisioningprofile.moblieprovision /users/test/Library/MobileDevice/Provisioning Profiles/testuuid.mobileprovision": {
             "code": 0,
             "stdout": "provisioning profile copied"

--- a/Tasks/InstallAppleProvisioningProfile/installprovprofile.ts
+++ b/Tasks/InstallAppleProvisioningProfile/installprovprofile.ts
@@ -16,15 +16,16 @@ async function run() {
             let provProfilePath: string = tl.getInput('provProfileSourceRepository', true);
 
             if (tl.filePathSupplied('provProfileSourceRepository') && tl.exist(provProfilePath) && tl.stats(provProfilePath).isFile()) {
-                let UUID: string = await sign.getProvisioningProfileUUID(provProfilePath);
-                tl.setTaskVariable('APPLE_PROV_PROFILE_UUID', UUID);
+                const info = await sign.installProvisioningProfile(provProfilePath);
+                tl.setTaskVariable('APPLE_PROV_PROFILE_UUID', info.provProfileUUID);
 
                 // set the provisioning profile output variable.
-                tl.setVariable('provisioningProfileUuid', UUID);
+                tl.setVariable('provisioningProfileUuid', info.provProfileUUID);
+                tl.setVariable('provisioningProfileName', info.provProfileName);
 
                 // Set the legacy variable that doesn't use the task's refName, unlike our output variables.
                 // If there are multiple InstallAppleCertificate tasks, the last one wins.
-                tl.setVariable('APPLE_PROV_PROFILE_UUID', UUID);                
+                tl.setVariable('APPLE_PROV_PROFILE_UUID', info.provProfileUUID);
             } else {
                 throw tl.loc('InputProvisioningProfileNotFound', provProfilePath);
             }

--- a/Tasks/InstallAppleProvisioningProfile/package-lock.json
+++ b/Tasks/InstallAppleProvisioningProfile/package-lock.json
@@ -25,6 +25,7 @@
     },
     "ios-signing-common": {
       "version": "file:../../_build/Tasks/Common/ios-signing-common-1.0.0.tgz",
+      "integrity": "sha512-Hwh5qjF1Nh9fAsJx5Y5OW1UtN1GVsUKlTXj60v/w0OfgjvwItsZffc3/WIwTH5c26CVUZDc5kFc75Wk5Tw1xcg==",
       "requires": {
         "vsts-task-lib": "2.2.1"
       }
@@ -49,8 +50,9 @@
     },
     "securefiles-common": {
       "version": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
+      "integrity": "sha512-DvJ2JgZX1Sz3hGIMCp5mToJNtMzFB/l5oy2sPEJEQCA7VhI3mWbhC8D8xqQttYZP2dD60xAx3gkdFWQoo8APSA==",
       "requires": {
-        "vso-node-api": "6.1.2-preview",
+        "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.2.1"
       }
     },
@@ -70,9 +72,9 @@
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
-      "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
+      "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
       "requires": {
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
@@ -89,13 +91,12 @@
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "vso-node-api": {
-      "version": "6.1.2-preview",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.1.2-preview.tgz",
-      "integrity": "sha1-qrNUbfJFHs2JTgcbuZtd8Zxfp48=",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
+      "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
       "requires": {
-        "q": "1.5.1",
         "tunnel": "0.0.4",
-        "typed-rest-client": "0.9.0",
+        "typed-rest-client": "0.12.0",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/InstallAppleProvisioningProfile/preinstallprovprofile.ts
+++ b/Tasks/InstallAppleProvisioningProfile/preinstallprovprofile.ts
@@ -19,15 +19,16 @@ async function run() {
             let provProfilePath: string = await secureFileHelpers.downloadSecureFile(secureFileId);
 
             if (tl.exist(provProfilePath)) {
-                let UUID: string = await sign.getProvisioningProfileUUID(provProfilePath);
-                tl.setTaskVariable('APPLE_PROV_PROFILE_UUID', UUID);
+                const info = await sign.installProvisioningProfile(provProfilePath);
+                tl.setTaskVariable('APPLE_PROV_PROFILE_UUID', info.provProfileUUID);
 
                 // set the provisioning profile output variable.
-                tl.setVariable('provisioningProfileUuid', UUID);
+                tl.setVariable('provisioningProfileUuid', info.provProfileUUID);
+                tl.setVariable('provisioningProfileName', info.provProfileName);
 
                 // Set the legacy variable that doesn't use the task's refName, unlike our output variables.
                 // If there are multiple InstallAppleCertificate tasks, the last one wins.
-                tl.setVariable('APPLE_PROV_PROFILE_UUID', UUID);
+                tl.setVariable('APPLE_PROV_PROFILE_UUID', info.provProfileUUID);
             }
         }
 

--- a/Tasks/InstallAppleProvisioningProfile/task.json
+++ b/Tasks/InstallAppleProvisioningProfile/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 131,
+        "Minor": 133,
         "Patch": 0
     },
     "runsOn": [
@@ -67,7 +67,11 @@
     "outputVariables": [
         {
             "name": "provisioningProfileUuid",
-            "description": "The resolved UUID for the selected provisioning profile."
+            "description": "The UUID property for the selected provisioning profile."
+        },
+        {
+            "name": "provisioningProfileName",
+            "description": "The Name property for the selected provisioning profile."
         }
     ],
     "prejobexecution": {

--- a/Tasks/InstallAppleProvisioningProfile/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfile/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 131,
+    "Minor": 133,
     "Patch": 0
   },
   "runsOn": [
@@ -67,7 +67,11 @@
   "outputVariables": [
     {
       "name": "provisioningProfileUuid",
-      "description": "The resolved UUID for the selected provisioning profile."
+      "description": "The UUID property for the selected provisioning profile."
+    },
+    {
+      "name": "provisioningProfileName",
+      "description": "The Name property for the selected provisioning profile."
     }
   ],
   "prejobexecution": {

--- a/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
@@ -44,6 +44,8 @@
   "loc.input.help.signingIdentity": "(Optional) Enter a signing identity override with which to sign the build. This may require unlocking the default keychain on the agent machine. If no value is entered, the Xcode project's setting will be used.",
   "loc.input.label.provisioningProfileUuid": "Provisioning profile UUID",
   "loc.input.help.provisioningProfileUuid": "(Optional) Enter the UUID of an installed provisioning profile to be used for this build. Use separate build tasks with different schemes or targets to specify separate provisioning profiles by target in a single workspace (iOS, tvOS, watchOS).",
+  "loc.input.label.provisioningProfileName": "Provisioning profile name",
+  "loc.input.help.provisioningProfileName": "(Optional) Enter the name of an installed provisioning profile to be used for this build. If specified, this takes precedence over the provisioning profile UUID. Use separate build tasks with different schemes or targets to specify separate provisioning profiles by target in a single workspace (iOS, tvOS, watchOS).",
   "loc.input.label.teamId": "Team ID",
   "loc.input.help.teamId": "(Optional, unless you are a member of multiple development teams.) Specify the 10-character development team ID.",
   "loc.input.label.destinationPlatformOption": "Destination platform",

--- a/Tasks/Xcode/Tests/L0.ts
+++ b/Tasks/Xcode/Tests/L0.ts
@@ -172,12 +172,12 @@ describe('Xcode L0 Suite', function () {
         //build
         assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
             '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build ' +
-            'CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid'),
+            'CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid PROVISIONING_PROFILE_SPECIFIER='),
             'xcodebuild for building the ios project/workspace should have been run.');
         //archive
         assert(tr.ran('/home/bin/xcodebuild -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme ' +
             'archive -sdk $(SDK) -configuration $(Configuration) -archivePath /user/build/testScheme ' +
-            'CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid'),
+            'CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid PROVISIONING_PROFILE_SPECIFIER='),
             'xcodebuild archive should have been run to create the .xcarchive.');
         //export
         assert(tr.ran('/home/bin/xcodebuild -exportArchive ' +
@@ -560,7 +560,7 @@ describe('Xcode L0 Suite', function () {
         done();
     });
 
-    
+
 
     it('macOS auto export', function (done: MochaDone) {
         this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);

--- a/Tasks/Xcode/Tests/L0CreateIpaWithCodeSigningIdentifiers.ts
+++ b/Tasks/Xcode/Tests/L0CreateIpaWithCodeSigningIdentifiers.ts
@@ -74,11 +74,11 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Xcode 7.3.1"
         },
-        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid": {
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid PROVISIONING_PROFILE_SPECIFIER=": {
             "code": 0,
             "stdout": "xcodebuild output here"
         },
-        "/home/bin/xcodebuild -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme archive -sdk $(SDK) -configuration $(Configuration) -archivePath /user/build/testScheme CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid": {
+        "/home/bin/xcodebuild -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme testScheme archive -sdk $(SDK) -configuration $(Configuration) -archivePath /user/build/testScheme CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid PROVISIONING_PROFILE_SPECIFIER=": {
             "code": 0,
             "stdout": "xcodebuild archive output here"
         },

--- a/Tasks/Xcode/package-lock.json
+++ b/Tasks/Xcode/package-lock.json
@@ -32,7 +32,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.11"
       }

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 5,
         "Minor": 133,
-        "Patch": 3
+        "Patch": 4
     },
     "preview": true,
     "releaseNotes": "This version of the task is compatible with Xcode 8 and Xcode 9. Features that were there solely to maintain compat with Xcode 7 have been removed. The task has better options to work with the Hosted macOS pool.",
@@ -219,6 +219,15 @@
             "label": "Provisioning profile UUID",
             "required": false,
             "helpMarkDown": "(Optional) Enter the UUID of an installed provisioning profile to be used for this build. Use separate build tasks with different schemes or targets to specify separate provisioning profiles by target in a single workspace (iOS, tvOS, watchOS).",
+            "groupName": "sign",
+            "visibleRule": "signingOption = manual"
+        },
+        {
+            "name": "provisioningProfileName",
+            "type": "string",
+            "label": "Provisioning profile name",
+            "required": false,
+            "helpMarkDown": "(Optional) Enter the name of an installed provisioning profile to be used for this build. If specified, this takes precedence over the provisioning profile UUID. Use separate build tasks with different schemes or targets to specify separate provisioning profiles by target in a single workspace (iOS, tvOS, watchOS).",
             "groupName": "sign",
             "visibleRule": "signingOption = manual"
         },

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 5,
     "Minor": 133,
-    "Patch": 3
+    "Patch": 4
   },
   "preview": true,
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -219,6 +219,15 @@
       "label": "ms-resource:loc.input.label.provisioningProfileUuid",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.provisioningProfileUuid",
+      "groupName": "sign",
+      "visibleRule": "signingOption = manual"
+    },
+    {
+      "name": "provisioningProfileName",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.provisioningProfileName",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.provisioningProfileName",
       "groupName": "sign",
       "visibleRule": "signingOption = manual"
     },

--- a/Tasks/Xcode/xcode.ts
+++ b/Tasks/Xcode/xcode.ts
@@ -170,6 +170,7 @@ async function run() {
         let xcode_otherCodeSignFlags: string;
         let xcode_codeSignIdentity: string;
         let xcode_provProfile: string;
+        let xcode_provProfileSpecifier: string;
         let xcode_devTeam: string;
 
         if (signingOption === 'nosign') {
@@ -178,15 +179,29 @@ async function run() {
         else if (signingOption === 'manual') {
             xcode_codeSignStyle = 'CODE_SIGN_STYLE=Manual';
 
-            let signIdentity: string = tl.getInput('signingIdentity');
+            const signIdentity: string = tl.getInput('signingIdentity');
             if (signIdentity) {
                 xcode_codeSignIdentity = 'CODE_SIGN_IDENTITY=' + signIdentity;
             }
 
             let provProfileUUID: string = tl.getInput('provisioningProfileUuid');
-            if (provProfileUUID) {
-                xcode_provProfile = 'PROVISIONING_PROFILE=' + provProfileUUID;
+            let provProfileName: string = tl.getInput('provisioningProfileName');
+
+            if (!provProfileUUID) {
+                provProfileUUID = "";
             }
+
+            if (!provProfileName) {
+                provProfileName = "";
+            }
+
+            // PROVISIONING_PROFILE_SPECIFIER takes predence over PROVISIONING_PROFILE,
+            // so it's important to pass it to Xcode even if it's empty. That way Xcode
+            // will ignore any specifier in the project file and honor the specifier
+            // or uuid we passed on the commandline. If the user wants to use the specifier
+            // in the project file, they should choose the "Project Defaults" signing style.
+            xcode_provProfile = `PROVISIONING_PROFILE=${provProfileUUID}`;
+            xcode_provProfileSpecifier = `PROVISIONING_PROFILE_SPECIFIER=${provProfileName}`;
         }
         else if (signingOption === 'auto') {
             xcode_codeSignStyle = 'CODE_SIGN_STYLE=Automatic';
@@ -201,6 +216,7 @@ async function run() {
         xcb.argIf(xcode_codeSignStyle, xcode_codeSignStyle);
         xcb.argIf(xcode_codeSignIdentity, xcode_codeSignIdentity);
         xcb.argIf(xcode_provProfile, xcode_provProfile);
+        xcb.argIf(xcode_provProfileSpecifier, xcode_provProfileSpecifier);
         xcb.argIf(xcode_devTeam, xcode_devTeam);
 
         //--- Enable Xcpretty formatting ---
@@ -276,6 +292,7 @@ async function run() {
             xcodeArchive.argIf(xcode_codeSignStyle, xcode_codeSignStyle);
             xcodeArchive.argIf(xcode_codeSignIdentity, xcode_codeSignIdentity);
             xcodeArchive.argIf(xcode_provProfile, xcode_provProfile);
+            xcodeArchive.argIf(xcode_provProfileSpecifier, xcode_provProfileSpecifier);
             xcodeArchive.argIf(xcode_devTeam, xcode_devTeam);
             if (args) {
                 xcodeArchive.line(args);

--- a/Tests-Legacy/L0/Xcode/_suite.ts
+++ b/Tests-Legacy/L0/Xcode/_suite.ts
@@ -207,7 +207,7 @@ describe('Xcode Suite', function() {
             tr.run()
                 .then(() => {
                     assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
-                    assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid'),
+                    assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid PROVISIONING_PROFILE_SPECIFIER='),
                         'xcodebuild for building the ios project/workspace should have been run with signing options.');
                     assert(tr.resultWasSet, 'task should have set a result');
                     assert(tr.stderr.length == 0, 'should not have written to stderr');
@@ -247,8 +247,8 @@ describe('Xcode Suite', function() {
             tr.run()
                 .then(() => {
                     assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
-                    assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q)'),
-                        'xcodebuild for building the ios project/workspace should have been run with signing options with P12 only, no provisioning profile.');
+                    assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE= PROVISIONING_PROFILE_SPECIFIER='),
+                        'xcodebuild for building the ios project/workspace should have been run with signing options with P12 signing identity, and empty provisioning profile/specifier values that override any values in the pbxproj file.');
                     assert(tr.resultWasSet, 'task should have set a result');
                     assert(tr.stderr.length == 0, 'should not have written to stderr');
                     assert(tr.succeeded, 'task should have succeeded');
@@ -282,7 +282,7 @@ describe('Xcode Suite', function() {
         tr.run()
             .then(() => {
                 assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
-                assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE=testuuid'),
+                assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE=testuuid PROVISIONING_PROFILE_SPECIFIER='),
                     'xcodebuild for building the ios project/workspace should have been run with signing options with provisioning profile only.');
                 assert(tr.resultWasSet, 'task should have set a result');
                 assert(tr.stderr.length == 0, 'should not have written to stderr');
@@ -317,7 +317,7 @@ describe('Xcode Suite', function() {
         tr.run()
             .then(() => {
                 assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
-                assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=testSignIdentity PROVISIONING_PROFILE=testUUID'),
+                assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=testSignIdentity PROVISIONING_PROFILE=testUUID PROVISIONING_PROFILE_SPECIFIER='),
                     'xcodebuild for building the ios project/workspace should have been run with signing options.');
                 assert(tr.resultWasSet, 'task should have set a result');
                 assert(tr.stderr.length == 0, 'should not have written to stderr');

--- a/Tests-Legacy/L0/Xcode/responseSigningFile.json
+++ b/Tests-Legacy/L0/Xcode/responseSigningFile.json
@@ -31,15 +31,15 @@
       "code": 0,
       "stdout": "Xcode 7.3.1"
     },
-    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid": {
+    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE=testuuid PROVISIONING_PROFILE_SPECIFIER=": {
       "code": 0,
       "stdout": "xcodebuild output here"
     },
-    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q)": {
+    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=iPhone Developer: XcodeTask Tester (HE432Y3E2Q) PROVISIONING_PROFILE= PROVISIONING_PROFILE_SPECIFIER=": {
       "code": 0,
       "stdout": "xcodebuild output here"
     },
-    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE=testuuid": {
+    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE=testuuid PROVISIONING_PROFILE_SPECIFIER=": {
       "code": 0,
       "stdout": "xcodebuild output here"
     },

--- a/Tests-Legacy/L0/Xcode/responseSigningId.json
+++ b/Tests-Legacy/L0/Xcode/responseSigningId.json
@@ -21,7 +21,7 @@
       "code": 0,
       "stdout": "Xcode 7.3.1"
     },
-    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=testSignIdentity PROVISIONING_PROFILE=testUUID": {
+    "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme fun build CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=testSignIdentity PROVISIONING_PROFILE=testUUID PROVISIONING_PROFILE_SPECIFIER=": {
       "code": 0,
       "stdout": "xcodebuild output here"
     },

--- a/definitions/ios-signing-common.d.ts
+++ b/definitions/ios-signing-common.d.ts
@@ -19,11 +19,11 @@ declare module 'ios-signing-common/ios-signing-common' {
     export function findSigningIdentity(keychainPath: string) : string;
 
     /**
-     * Find the UUID of the provisioning profile and install the profile
+     * Find the UUID and Name of the provisioning profile and install the profile
      * @param provProfilePath
-     * @returns {string} UUID
+     * @returns { provProfileUUID, provProfileName }
      */
-    export function getProvisioningProfileUUID(provProfilePath: string) : string;
+    export function installProvisioningProfile(provProfilePath: string) : Promise<{ provProfileUUID: string, provProfileName: string }>;
 
     /**
      * Find the type of the provisioning profile - development, app-store or ad-hoc
@@ -57,10 +57,10 @@ declare module 'ios-signing-common/ios-signing-common' {
     export function getDefaultKeychainPath() : string;
 
     /**
-     * Get Cloud entitlement type Production or Development according to the export method - if entitlement doesn't exists in provisioning profile returns null 
+     * Get Cloud entitlement type Production or Development according to the export method - if entitlement doesn't exists in provisioning profile returns null
      * @param provisioningProfilePath
      * @param exportMethod
-     * @returns {string} 
+     * @returns {string}
      */
     export function getCloudEntitlement(provisioningProfilePath: string, exportMethod: string): Promise<string>
 }


### PR DESCRIPTION
If a user wants to sign with different manual signing assets than those
referenced by their project, they need to override PROVISIONING_PROFILE_SPECIFIER.
Overriding just PROVISIONING_PROFILE isn't sufficient because 
PROVISIONING_PROFILE_SPECIFIER takes precedence. This change 
makes that easier. This may be useful for AppCenter, who are overriding 
the signing configuration in the Xcode project files.