### PR TITLE
Fixed helpMarkDown typo in DotNetCoreCLI task

### DIFF
--- a/Tasks/DotNetCoreCLI/task.json
+++ b/Tasks/DotNetCoreCLI/task.json
@@ -103,7 +103,7 @@
             "defaultValue": "",
             "visibleRule": "command = build || command = restore || command = run || command = test || command = custom || publishWebProjects = false",
             "required": false,
-            "helpMarkDown": "The path to the csproj file(s) to use. You can use wildcards (e.g. **/.csproj for all .csproj files in all subfolders)."
+            "helpMarkDown": "The path to the csproj file(s) to use. You can use wildcards (e.g. **/*.csproj for all .csproj files in all subfolders)."
         },
         {
             "name": "custom",


### PR DESCRIPTION
The csproj wildcard path is missing an * character. It should be **/*.csproj.