### PR TITLE
Use Python Version: let user select architecture as an advanced option

### DIFF
--- a/Tasks/UsePythonVersion/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UsePythonVersion/Strings/resources.resjson/en-US/resources.resjson
@@ -3,6 +3,7 @@
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=871498)",
   "loc.description": "Retrieves the specified version of Python from the tool cache. Optionally add it to PATH.",
   "loc.instanceNameFormat": "Use Python $(versionSpec)",
+  "loc.group.displayName.advanced": "Advanced",
   "loc.input.label.versionSpec": "Version spec",
   "loc.input.help.versionSpec": "Version range or exact version of a Python version to use.",
   "loc.input.label.addToPath": "Add to PATH",

--- a/Tasks/UsePythonVersion/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UsePythonVersion/Strings/resources.resjson/en-US/resources.resjson
@@ -7,6 +7,8 @@
   "loc.input.help.versionSpec": "Version range or exact version of a Python version to use.",
   "loc.input.label.addToPath": "Add to PATH",
   "loc.input.help.addToPath": "Whether to prepend the retrieved Python version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable.",
+  "loc.input.label.architecture": "Architecture",
+  "loc.input.help.architecture": "The target architecture (x86, x64) of the Python interpeter.",
   "loc.messages.ListAvailableVersions": "Available versions:",
   "loc.messages.PlatformNotRecognized": "Platform not recognized",
   "loc.messages.PrependPath": "Prepending PATH environment variable with directory: %s",

--- a/Tasks/UsePythonVersion/Tests/L0.ts
+++ b/Tasks/UsePythonVersion/Tests/L0.ts
@@ -103,7 +103,7 @@ describe('UsePythonVersion L0 Suite', function () {
         mockery.registerMock('vsts-task-lib/task', mockTask);
         mockery.registerMock('vsts-task-tool-lib/tool', {
             findLocalTool: () => null,
-            findLocalToolVersions: () => ['2.7.13']
+            findLocalToolVersions: () => ['2.6.0', '2.7.13']
         });
 
         const uut = reload();
@@ -119,7 +119,9 @@ describe('UsePythonVersion L0 Suite', function () {
             const expectedMessage = [
                 'loc_mock_VersionNotFound 3.x',
                 'loc_mock_ListAvailableVersions',
+                '2.6.0 (x86)',
                 '2.7.13 (x86)',
+                '2.6.0 (x64)',
                 '2.7.13 (x64)'
             ].join(EOL);
 
@@ -138,14 +140,14 @@ describe('UsePythonVersion L0 Suite', function () {
         };
         mockery.registerMock('vsts-task-lib/task', Object.assign({}, mockTask, mockBuildVariables));
 
-        const toolPathx86 = path.join('/', 'Python', '3.6.4', 'x86');
-        const toolPathx64 = path.join('/', 'Python', '3.6.4', 'x64');
+        const x86ToolPath = path.join('/', 'Python', '3.6.4', 'x86');
+        const x64ToolPath = path.join('/', 'Python', '3.6.4', 'x64');
         mockery.registerMock('vsts-task-tool-lib/tool', {
             findLocalTool: (toolName: string, versionSpec: string, arch?: string) => {
                 if (arch === 'x86') {
-                    return toolPathx86;
+                    return x86ToolPath;
                 } else {
-                    return toolPathx64;
+                    return x64ToolPath;
                 }
             }
         });
@@ -160,7 +162,7 @@ describe('UsePythonVersion L0 Suite', function () {
         assert.strictEqual(buildVariables['pythonLocation'], undefined);
 
         await uut.usePythonVersion(parameters, Platform.Linux);
-        assert.strictEqual(buildVariables['pythonLocation'], toolPathx86);
+        assert.strictEqual(buildVariables['pythonLocation'], x86ToolPath);
     });
 
     it('sets PATH correctly on Linux', async function () {

--- a/Tasks/UsePythonVersion/Tests/L0.ts
+++ b/Tasks/UsePythonVersion/Tests/L0.ts
@@ -90,7 +90,8 @@ describe('UsePythonVersion L0 Suite', function () {
         const uut = reload();
         const parameters = {
             versionSpec: '3.6',
-            addToPath: false
+            addToPath: false,
+            architecture: 'x64'
         };
 
         assert.strictEqual(buildVariables['pythonLocation'], undefined);
@@ -109,7 +110,8 @@ describe('UsePythonVersion L0 Suite', function () {
         const uut = reload();
         const parameters = {
             versionSpec: '3.x',
-            addToPath: false
+            addToPath: false,
+            architecture: 'x64'
         };
 
         try {
@@ -183,7 +185,8 @@ describe('UsePythonVersion L0 Suite', function () {
         const uut = reload();
         const parameters = {
             versionSpec: '3.6',
-            addToPath: true
+            addToPath: true,
+            architecture: 'x64'
         };
 
         await uut.usePythonVersion(parameters, Platform.Linux);
@@ -210,7 +213,8 @@ describe('UsePythonVersion L0 Suite', function () {
         const uut = reload();
         const parameters = {
             versionSpec: '3.6',
-            addToPath: true
+            addToPath: true,
+            architecture: 'x64'
         };
 
         await uut.usePythonVersion(parameters, Platform.Windows);

--- a/Tasks/UsePythonVersion/main.ts
+++ b/Tasks/UsePythonVersion/main.ts
@@ -8,7 +8,8 @@ import { usePythonVersion } from './usepythonversion';
         task.setResourcePath(path.join(__dirname, 'task.json'));
         await usePythonVersion({
             versionSpec: task.getInput('versionSpec', true),
-            addToPath: task.getBoolInput('addToPath', true)
+            addToPath: task.getBoolInput('addToPath', true),
+            architecture: task.getInput('architecture', true)
         },
         getPlatform());
         task.setResult(task.TaskResult.Succeeded, "");

--- a/Tasks/UsePythonVersion/task.json
+++ b/Tasks/UsePythonVersion/task.json
@@ -34,6 +34,19 @@
             "required": true,
             "defaultValue": "true",
             "helpMarkDown": "Whether to prepend the retrieved Python version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable."
+        },
+        {
+            "name": "architecture",
+            "type": "pickList",
+            "label": "Architecture",
+            "defaultValue": "x64",
+            "required": false,
+            "helpMarkDown": "The target architecture (x86, x64) of the Python interpeter.",
+            "groupName": "advanced",
+            "options": {
+                "x86": "x86",
+                "x64": "x64"
+            }
         }
     ],
     "outputVariables": [

--- a/Tasks/UsePythonVersion/task.json
+++ b/Tasks/UsePythonVersion/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 133,
-        "Patch": 2
+        "Minor": 134,
+        "Patch": 0
     },
     "preview": true,
     "demands": [],

--- a/Tasks/UsePythonVersion/task.json
+++ b/Tasks/UsePythonVersion/task.json
@@ -18,6 +18,13 @@
     "preview": true,
     "demands": [],
     "instanceNameFormat": "Use Python $(versionSpec)",
+    "groups": [
+        {
+            "name": "advanced",
+            "displayName": "Advanced",
+            "isExpanded": false
+        }
+    ],
     "inputs": [
         {
             "name": "versionSpec",

--- a/Tasks/UsePythonVersion/task.json
+++ b/Tasks/UsePythonVersion/task.json
@@ -47,7 +47,7 @@
             "type": "pickList",
             "label": "Architecture",
             "defaultValue": "x64",
-            "required": false,
+            "required": true,
             "helpMarkDown": "The target architecture (x86, x64) of the Python interpeter.",
             "groupName": "advanced",
             "options": {

--- a/Tasks/UsePythonVersion/task.loc.json
+++ b/Tasks/UsePythonVersion/task.loc.json
@@ -18,6 +18,13 @@
   "preview": true,
   "demands": [],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
+  "groups": [
+    {
+      "name": "advanced",
+      "displayName": "ms-resource:loc.group.displayName.advanced",
+      "isExpanded": false
+    }
+  ],
   "inputs": [
     {
       "name": "versionSpec",

--- a/Tasks/UsePythonVersion/task.loc.json
+++ b/Tasks/UsePythonVersion/task.loc.json
@@ -47,7 +47,7 @@
       "type": "pickList",
       "label": "ms-resource:loc.input.label.architecture",
       "defaultValue": "x64",
-      "required": false,
+      "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.architecture",
       "groupName": "advanced",
       "options": {

--- a/Tasks/UsePythonVersion/task.loc.json
+++ b/Tasks/UsePythonVersion/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 133,
-    "Patch": 2
+    "Minor": 134,
+    "Patch": 0
   },
   "preview": true,
   "demands": [],

--- a/Tasks/UsePythonVersion/task.loc.json
+++ b/Tasks/UsePythonVersion/task.loc.json
@@ -34,6 +34,19 @@
       "required": true,
       "defaultValue": "true",
       "helpMarkDown": "ms-resource:loc.input.help.addToPath"
+    },
+    {
+      "name": "architecture",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.architecture",
+      "defaultValue": "x64",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.architecture",
+      "groupName": "advanced",
+      "options": {
+        "x86": "x86",
+        "x64": "x64"
+      }
     }
   ],
   "outputVariables": [

--- a/Tasks/UsePythonVersion/usepythonversion.ts
+++ b/Tasks/UsePythonVersion/usepythonversion.ts
@@ -11,8 +11,9 @@ import { Platform } from './taskutil';
 import * as toolUtil  from './toolutil';
 
 interface TaskParameters {
-    readonly versionSpec: string,
-    readonly addToPath: boolean
+    versionSpec: string,
+    addToPath: boolean,
+    architecture: string
 }
 
 export function pythonVersionToSemantic(versionSpec: string) {
@@ -20,14 +21,14 @@ export function pythonVersionToSemantic(versionSpec: string) {
     return versionSpec.replace(prereleaseVersion, '$1-$2');
 }
 
-export async function usePythonVersion(parameters: TaskParameters, platform: Platform): Promise<void> {
+export async function usePythonVersion(parameters: Readonly<TaskParameters>, platform: Platform): Promise<void> {
     // Python's prelease versions look like `3.7.0b2`.
     // This is the one part of Python versioning that does not look like semantic versioning, which specifies `3.7.0-b2`.
     // If the version spec contains prerelease versions, we need to convert them to the semantic version equivalent
     const semanticVersionSpec = pythonVersionToSemantic(parameters.versionSpec);
     task.debug(`Semantic version spec of ${parameters.versionSpec} is ${semanticVersionSpec}`);
 
-    const installDir: string | null = tool.findLocalTool('Python', semanticVersionSpec);
+    const installDir: string | null = tool.findLocalTool('Python', semanticVersionSpec, parameters.architecture);
     if (!installDir) {
         // Fail and list available versions
         const x86Versions = tool.findLocalToolVersions('Python', 'x86')

--- a/Tasks/UsePythonVersion/usepythonversion.ts
+++ b/Tasks/UsePythonVersion/usepythonversion.ts
@@ -30,10 +30,19 @@ export async function usePythonVersion(parameters: TaskParameters, platform: Pla
     const installDir: string | null = tool.findLocalTool('Python', semanticVersionSpec);
     if (!installDir) {
         // Fail and list available versions
+        const x86Versions = tool.findLocalToolVersions('Python', 'x86')
+            .map(s => `${s} (x86)`)
+            .join(os.EOL);
+
+        const x64Versions = tool.findLocalToolVersions('Python', 'x64')
+            .map(s => `${s} (x64)`)
+            .join(os.EOL);
+
         throw new Error([
             task.loc('VersionNotFound', parameters.versionSpec),
             task.loc('ListAvailableVersions'),
-            tool.findLocalToolVersions('Python')
+            x86Versions,
+            x64Versions
         ].join(os.EOL));
     }
 


### PR DESCRIPTION
The hosted agents only have 64-bit versions of Python installed, but users are able to install 32-bit versions on private agents.  They can also install 32-bit versions on hosted Windows agents from NuGet using the 3rd party "Install Python" task.

Since hosted agents only have 64-bit, I am putting this setting under the "Advanced" tab with a default value of x64.  When the task fails to find a version, it will now list versions _with architectures_ available to the agent.

Testing:
- L0
- Manually with private Windows agent