### PR TITLE
Avoid crlf conversion for npm json files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,10 @@
 # Shell scripts should always use line feed not crlf
 *.sh text eol=lf
 
+# npm and friends use lf line endings even on Windows.
+*.json text eol=lf
+*.resjson text eol=lf
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #
@@ -20,14 +24,12 @@
 #
 # Merging from the command prompt will add diff markers to the files if there
 # are conflicts (Merging from VS is not affected by the settings below, in VS
-# the diff markers are never inserted). Diff markers may cause the following 
+# the diff markers are never inserted). Diff markers may cause the following
 # file extensions to fail to load in VS. An alternative would be to treat
 # these files as binary and thus will always conflict and require user
 # intervention with every merge. To do so, just uncomment the entries below
 ###############################################################################
 *.js         text
-*.json       text
-*.resjson    text
 *.htm        text
 *.html       text
 *.xml        text
@@ -70,9 +72,9 @@
 
 ###############################################################################
 # diff behavior for common document formats
-# 
+#
 # Convert binary document formats to text before diffing them. This feature
-# is only available from the command line. Turn it on by uncommenting the 
+# is only available from the command line. Turn it on by uncommenting the
 # entries below.
 ###############################################################################
 *.doc   diff=astextplain


### PR DESCRIPTION
Without this change you get false changes when you run "git diff" following a build on Windows. A Windows developer could run `git config --global core.autocrlf input` before cloning the repo, but I think addressing this in .gitignore makes it easier for Windows developers to contribute.
