### PR TITLE
Allow NpmAuthenticate to hanle scoped registries

### DIFF
--- a/Tasks/NpmAuthenticate/npmauth.ts
+++ b/Tasks/NpmAuthenticate/npmauth.ts
@@ -112,7 +112,7 @@ function clearFileOfReferences(npmrc: string, file: string[], url: URL.Url) {
     let redoneFile = file;
     let warned = false;
     for (let i = 0; i < redoneFile.length; i++) {
-        if (file[i].indexOf(url.host) != -1 && file[i].indexOf('registry=') == -1) {
+        if (file[i].indexOf(url.host) != -1 && file[i].indexOf(url.path) != -1 && file[i].indexOf('registry=') == -1) {
             if (!warned) {
                 tl.warning(tl.loc('CheckedInCredentialsOverriden', url.host));
             }

--- a/Tasks/NpmAuthenticate/package-lock.json
+++ b/Tasks/NpmAuthenticate/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-npm-authenticate-task",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Tasks/NpmAuthenticate/package.json
+++ b/Tasks/NpmAuthenticate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-npm-authenticate-task",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "VSTS npm Authenticate Task",
   "main": "npmauth.js",
   "scripts": {

--- a/Tasks/NpmAuthenticate/task.json
+++ b/Tasks/NpmAuthenticate/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NpmAuthenticate/task.loc.json
+++ b/Tasks/NpmAuthenticate/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 1
+    "Patch": 2
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
If multiple scoped registries are against the same account the authenticate step does not get credentials for all scopes because it is only checking host not path.