### PR TITLE
Stop writing temp files in the Xcode tests.

### DIFF
--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -207,7 +207,7 @@ export async function installProvisioningProfile(provProfilePath: string) : Prom
     if (provProfileDetails) {
         //write the provisioning profile to a plist
         tmpPlist = '_xcodetasktmp.plist';
-        fs.writeFileSync(tmpPlist, provProfileDetails);
+        tl.writeFile(tmpPlist, provProfileDetails);
     } else {
         throw tl.loc('ProvProfileDetailsNotFound', provProfilePath);
     }
@@ -284,7 +284,7 @@ export async function getProvisioningProfileName(provProfilePath: string) {
     if (provProfileDetails) {
         //write the provisioning profile to a plist
         tmpPlist = '_xcodetasktmp.plist';
-        fs.writeFileSync(tmpPlist, provProfileDetails);
+        tl.writeFile(tmpPlist, provProfileDetails);
     } else {
         throw tl.loc('ProvProfileDetailsNotFound', provProfilePath);
     }
@@ -328,7 +328,7 @@ export async function getiOSProvisioningProfileType(provProfilePath: string) {
         if (provProfileDetails) {
             //write the provisioning profile to a plist
             tmpPlist = '_xcodetasktmp.plist';
-            fs.writeFileSync(tmpPlist, provProfileDetails);
+            tl.writeFile(tmpPlist, provProfileDetails);
         } else {
             throw tl.loc('ProvProfileDetailsNotFound', provProfilePath);
         }
@@ -396,7 +396,7 @@ export async function getmacOSProvisioningProfileType(provProfilePath: string) {
         if (provProfileDetails) {
             //write the provisioning profile to a plist
             tmpPlist = '_xcodetasktmp.plist';
-            fs.writeFileSync(tmpPlist, provProfileDetails);
+            tl.writeFile(tmpPlist, provProfileDetails);
         } else {
             throw tl.loc('ProvProfileDetailsNotFound', provProfilePath);
         }

--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -1,5 +1,3 @@
-import fs = require('fs');
-import path = require('path');
 import Q = require('q');
 import tl = require('vsts-task-lib/task');
 import { ToolRunner } from 'vsts-task-lib/toolrunner';
@@ -467,7 +465,7 @@ async function printFromPlist(itemToPrint: string, plistPath: string) {
  * @param keychainPath
  */
 export async function deleteKeychain(keychainPath: string) {
-    if (fs.existsSync(keychainPath)) {
+    if (tl.exist(keychainPath)) {
         let deleteKeychainCommand: ToolRunner = tl.tool(tl.which('security', true));
         deleteKeychainCommand.arg(['delete-keychain', keychainPath]);
         await deleteKeychainCommand.exec();
@@ -493,7 +491,7 @@ export async function unlockKeychain(keychainPath: string, keychainPwd: string) 
 export async function deleteProvisioningProfile(uuid: string) {
     let provProfilePath: string = getProvisioningProfilePath(uuid);
     tl.warning('Deleting provisioning profile: ' + provProfilePath);
-    if (fs.existsSync(provProfilePath)) {
+    if (tl.exist(provProfilePath)) {
         let deleteProfileCommand: ToolRunner = tl.tool(tl.which('rm', true));
         deleteProfileCommand.arg(['-f', provProfilePath]);
         await deleteProfileCommand.exec();

--- a/Tasks/InstallAppleCertificate/Tests/L0DeleteTempKeychain.ts
+++ b/Tasks/InstallAppleCertificate/Tests/L0DeleteTempKeychain.ts
@@ -13,11 +13,6 @@ process.env['VSTS_TASKVARIABLE_APPLE_CERTIFICATE_KEYCHAIN'] = '/build/temp/ios_s
 process.env['HOME'] = '/users/test';
 
 tr.registerMock('fs', {
-    existsSync: function (filePath) {
-        if (filePath === '/build/temp/ios_signing_temp.keychain') {
-            return true;
-        }
-    },
     readFileSync: fs.readFileSync,
     statSync: fs.statSync,
     writeFileSync: function (filePath, contents) {
@@ -28,6 +23,9 @@ tr.registerMock('fs', {
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "security": "/usr/bin/security"
+    },
+    "exist": {
+        "/build/temp/ios_signing_temp.keychain": true
     },
     "checkPath": {
         "/usr/bin/security": true

--- a/Tasks/InstallAppleCertificate/Tests/L0InstallCertWithEmptyPassword.ts
+++ b/Tasks/InstallAppleCertificate/Tests/L0InstallCertWithEmptyPassword.ts
@@ -19,11 +19,6 @@ let secureFileHelperMock = require('securefiles-common/securefiles-common-mock')
 tr.registerMock('securefiles-common/securefiles-common', secureFileHelperMock);
 
 tr.registerMock('fs', {
-    existsSync: function (filePath) {
-        if (filePath === '/build/temp/ios_signing_temp.keychain') {
-            return false;
-        }
-    },
     writeFileSync: function (filePath, contents) {
     }
 });

--- a/Tasks/InstallAppleCertificate/Tests/L0InstallDefaultKeychain.ts
+++ b/Tasks/InstallAppleCertificate/Tests/L0InstallDefaultKeychain.ts
@@ -19,11 +19,6 @@ let secureFileHelperMock = require('securefiles-common/securefiles-common-mock')
 tr.registerMock('securefiles-common/securefiles-common', secureFileHelperMock);
 
 tr.registerMock('fs', {
-    existsSync: function (filePath) {
-        if (filePath === '/usr/lib/login.keychain') {
-            return true;
-        }
-    },
     writeFileSync: function (filePath, contents) {
     }
 });

--- a/Tasks/InstallAppleCertificate/Tests/L0InstallTempKeychain.ts
+++ b/Tasks/InstallAppleCertificate/Tests/L0InstallTempKeychain.ts
@@ -19,11 +19,6 @@ let secureFileHelperMock = require('securefiles-common/securefiles-common-mock')
 tr.registerMock('securefiles-common/securefiles-common', secureFileHelperMock);
 
 tr.registerMock('fs', {
-    existsSync: function (filePath) {
-        if (filePath === '/build/temp/ios_signing_temp.keychain') {
-            return false;
-        }
-    },
     writeFileSync: function (filePath, contents) {
     }
 });

--- a/Tasks/InstallAppleCertificate/Tests/L0UserSupplyCN.ts
+++ b/Tasks/InstallAppleCertificate/Tests/L0UserSupplyCN.ts
@@ -20,11 +20,6 @@ let secureFileHelperMock = require('securefiles-common/securefiles-common-mock')
 tr.registerMock('securefiles-common/securefiles-common', secureFileHelperMock);
 
 tr.registerMock('fs', {
-    existsSync: function (filePath) {
-        if (filePath === '/usr/lib/login.keychain') {
-            return true;
-        }
-    },
     writeFileSync: function (filePath, contents) {
     }
 });

--- a/Tasks/InstallAppleCertificate/task.json
+++ b/Tasks/InstallAppleCertificate/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 131,
+        "Minor": 134,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallAppleCertificate/task.loc.json
+++ b/Tasks/InstallAppleCertificate/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 131,
+    "Minor": 134,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfile/Tests/L0RemoveProfile.ts
+++ b/Tasks/InstallAppleProvisioningProfile/Tests/L0RemoveProfile.ts
@@ -13,12 +13,6 @@ process.env['VSTS_TASKVARIABLE_APPLE_PROV_PROFILE_UUID'] = 'testuuid';
 process.env['HOME'] = '/users/test';
 
 tr.registerMock('fs', {
-    existsSync: function (pathToCheck) {
-        if (pathToCheck === '/users/test/Library/MobileDevice/Provisioning Profiles/testuuid.mobileprovision') {
-            return true;
-        }
-        return false;
-    },
     writeFileSync: function (filePath, contents) {
     },
     statSync: fs.statSync,

--- a/Tasks/InstallAppleProvisioningProfile/task.json
+++ b/Tasks/InstallAppleProvisioningProfile/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 133,
+        "Minor": 134,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfile/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfile/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 133,
+    "Minor": 134,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
Running the Xcode L0 tests would leave behind a _xcodetasktmp.plist file, which you had to avoid committing with the rest of your changes. There must have been a fs.writeFileSync that wasn't mocked.

tl.writeFile is equivalent to fs.writeFileSync (see https://github.com/Microsoft/vsts-task-lib/blob/master/node/task.ts).  And it's always mocked (see https://github.com/Microsoft/vsts-task-lib/blob/master/node/mock-task.ts).