### PR TITLE
Updating test selector package to fix build api calls issue

### DIFF
--- a/Tasks/VsTest/make.json
+++ b/Tasks/VsTest/make.json
@@ -2,7 +2,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://testselectorv2.blob.core.windows.net/testselector/5717050/TestSelector.zip",
+                "url": "https://testselectorv2.blob.core.windows.net/testselector/5792911/TestSelector.zip",
                 "dest": "./"
             },
             {

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 5,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 5,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Issue: Test Impact analysis is broken for external git systems due to project id requirement in build APIs with m133.

This change fixes the API calls to send project id.