### PR TITLE
Use Python Version: each version in the Linux tools cache gets its own 'bin' directory

### DIFF
--- a/Tasks/UsePythonVersion/Tests/L0.ts
+++ b/Tasks/UsePythonVersion/Tests/L0.ts
@@ -190,7 +190,7 @@ describe('UsePythonVersion L0 Suite', function () {
         };
 
         await uut.usePythonVersion(parameters, Platform.Linux);
-        assert.strictEqual(`${toolPath}:`, mockPath);
+        assert.strictEqual(`${path.join(toolPath, 'bin')}:${toolPath}:`, mockPath);
     });
 
     it('sets PATH correctly on Windows', async function () {

--- a/Tasks/UsePythonVersion/task.json
+++ b/Tasks/UsePythonVersion/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 134,
-        "Patch": 0
+        "Patch": 1
     },
     "preview": true,
     "demands": [],

--- a/Tasks/UsePythonVersion/task.loc.json
+++ b/Tasks/UsePythonVersion/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 134,
-    "Patch": 0
+    "Patch": 1
   },
   "preview": true,
   "demands": [],

--- a/Tasks/UsePythonVersion/usepythonversion.ts
+++ b/Tasks/UsePythonVersion/usepythonversion.ts
@@ -55,16 +55,17 @@ export async function usePythonVersion(parameters: Readonly<TaskParameters>, pla
         // Python has "scripts" or "bin" directories where command-line tools that come with packages are installed.
         // This is where pip is, along with anything that pip installs.
         // There is a seperate directory for `pip install --user`.
+        //
+        // For reference, these directories are as follows:
+        //   macOS / Linux:
+        //      <sys.prefix>/bin (by default /usr/local/bin, but not on hosted agents -- see the `else`)
+        //      (--user) ~/.local/bin
+        //   Windows:
+        //      <Python installation dir>\Scripts
+        //      (--user) %APPDATA%\Python\PythonXY\Scripts
+        // See https://docs.python.org/3/library/sysconfig.html
         if (platform === Platform.Windows) {
             // On Windows, these directories do not get added to PATH, so we will add them ourselves.
-            // For reference, these directories are as follows:
-            //   macOS / Linux:
-            //      <sys.prefix>/bin (by default /usr/local/bin, but not on hosted agents -- see the `else`)
-            //      (--user) ~/.local/bin
-            //   Windows:
-            //      <Python installation dir>\Scripts
-            //      (--user) %APPDATA%\Python\PythonXY\Scripts
-            // See https://docs.python.org/3/library/sysconfig.html
             const scriptsDir = path.join(installDir, 'Scripts');
             toolUtil.prependPathSafe(scriptsDir);
 
@@ -80,7 +81,7 @@ export async function usePythonVersion(parameters: Readonly<TaskParameters>, pla
         } else {
             // On Linux and macOS, tools cache should be set up so that each Python version has its own "bin" directory.
             // We do this so that the tool cache can just be dropped on an agent with minimal installation (no copying to /usr/local).
-            // This also keeps us open to side-by-siding the same minor version of Python (since Python uses /usr/local/lib/python3.6, etc.).
+            // This allows us side-by-side the same minor version of Python with different patch versions or architectures (since Python uses /usr/local/lib/python3.6, etc.).
             toolUtil.prependPathSafe(path.join(installDir, 'bin'));
 
             // On Linux and macOS, pip will create the --user directory and add it to PATH as needed.


### PR DESCRIPTION
**TL;DR** I thought we could use `/usr/local/bin` for Pip installs on Linux, but we can't.

**Long version**
By default on Linux, running Pip for Python X.Y will install its command line tools to `/usr/local/bin/pythonX.Y`.

Python in the tools cache should not work this -- this won't work for having both x86 and x64 versions of Python X.Y, for example.

So, I have set up Python in the tools cache to install to its own `lib` and `bin` directories alongside it in the tools cache.  This means that Pip also installs its command line tools next to Python in the tools cache.  We need to add this directory to PATH when you "Use Python Version" X.Y.

This is not an issue on Windows, which already gets set up this way by default.