### PR TITLE
Fix codesign hangs when `Default Keychain` is selected.

### DIFF
--- a/Tasks/InstallAppleCertificate/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/InstallAppleCertificate/Strings/resources.resjson/en-US/resources.resjson
@@ -3,15 +3,16 @@
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=862067)",
   "loc.description": "Install an Apple certificate required to build on a macOS agent",
   "loc.instanceNameFormat": "Install an Apple certificate",
+  "loc.releaseNotes": "Fixes codesign hangs on a self hosted agent. Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",
   "loc.group.displayName.advanced": "Advanced",
   "loc.input.label.certSecureFile": "Certificate (P12)",
   "loc.input.help.certSecureFile": "Select the certificate (.p12) that was uploaded to `Secure Files` to install on the macOS agent.",
   "loc.input.label.certPwd": "Certificate (P12) password",
   "loc.input.help.certPwd": "Password to the Apple certificate (.p12). Use a new build variable with its lock enabled on the `Variables` tab to encrypt this value.",
   "loc.input.label.keychain": "Keychain",
-  "loc.input.help.keychain": "Select the keychain in which to install the Apple certificate. A temporary keychain will always be deleted after the build or release is complete.",
+  "loc.input.help.keychain": "Select the keychain in which to install the Apple certificate. For Microsoft hosted builds, use `Temporary Keychain`. A temporary keychain will always be deleted after the build or release is complete.",
   "loc.input.label.keychainPassword": "Keychain password",
-  "loc.input.help.keychainPassword": "Password to unlock the keychain. Use a new build variable with its lock enabled on the `Variables` tab to encrypt this value. A password is generated for the temporary keychain if not specified.",
+  "loc.input.help.keychainPassword": "Password to unlock the keychain. Use a new build variable with its lock enabled on the `Variables` tab to encrypt this value.",
   "loc.input.label.customKeychainPath": "Custom keychain path",
   "loc.input.help.customKeychainPath": "Full path to a custom keychain file. The keychain will be created if it does not exist.",
   "loc.input.label.deleteCert": "Delete certificate from keychain",
@@ -21,5 +22,8 @@
   "loc.input.label.signingIdentity": "Certificate signing identity",
   "loc.input.help.signingIdentity": "The Common Name of the subject in the signing certificate.  Will attempt to parse the Common Name if this is left empty.",
   "loc.messages.INVALID_P12": "Unable to find the certificate SHA1 hash and common name (CN). Verify that the certificate is a valid P12.",
-  "loc.messages.NoP12PwdWarning": "No P12 password supplied. If the P12 file requires a password, best practice is to supply it as process variable and mark it secret (lock icon)."
+  "loc.messages.NoP12PwdWarning": "No P12 password supplied. If the P12 file requires a password, best practice is to supply it as process variable and mark it secret (lock icon).",
+  "loc.messages.P12PrivateKeyNameNotFound": "Failed to identify the private key name: %s",
+  "loc.messages.SetKeyPartitionListCommandNotFound": "Skipping unnecessary keychain partition_id ACL assignment on older OS. The security command 'set-key-partition-list' was added in macOS Sierra (10.12).",
+  "loc.messages.SetKeyPartitionListCommandFailed": "Error setting partition_id ACL for private key. Check `Keychain password` is correct, or use `Temporary Keychain` instead."
 }

--- a/Tasks/InstallAppleCertificate/Tests/L0.ts
+++ b/Tasks/InstallAppleCertificate/Tests/L0.ts
@@ -21,7 +21,7 @@ describe('InstallAppleCertificate Suite', function () {
 
         assert(tr.ran('/usr/bin/security import /build/temp/mySecureFileId.filename -P mycertPwd -A -t cert -f pkcs12 -k /build/temp/ios_signing_temp.keychain'),
             'certificate should have been installed in the keychain');
-        assert(tr.ran('/usr/bin/security create-keychain -p mykeychainPwd /build/temp/ios_signing_temp.keychain'),
+        assert(tr.ran('/usr/bin/security create-keychain -p 115 /build/temp/ios_signing_temp.keychain'),
             'temp keychain should have been created.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -39,7 +39,7 @@ describe('InstallAppleCertificate Suite', function () {
 
         assert(tr.ran('/usr/bin/security import /build/temp/mySecureFileId.filename -P  -A -t cert -f pkcs12 -k /build/temp/ios_signing_temp.keychain'),
             'certificate should have been installed in the keychain');
-        assert(tr.ran('/usr/bin/security create-keychain -p mykeychainPwd /build/temp/ios_signing_temp.keychain'),
+        assert(tr.ran('/usr/bin/security create-keychain -p 115 /build/temp/ios_signing_temp.keychain'),
             'temp keychain should have been created.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');

--- a/Tasks/InstallAppleCertificate/Tests/L0InstallCertWithEmptyPassword.ts
+++ b/Tasks/InstallAppleCertificate/Tests/L0InstallCertWithEmptyPassword.ts
@@ -9,7 +9,6 @@ let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 tr.setInput('certSecureFile', 'mySecureFileId');
 tr.setInput('certPwd', '');
 tr.setInput('keychain', 'temp');
-tr.setInput('keychainPassword', 'mykeychainPwd');
 
 process.env['AGENT_VERSION'] = '2.116.0';
 process.env['AGENT_TEMPDIRECTORY'] = '/build/temp';
@@ -23,15 +22,22 @@ tr.registerMock('fs', {
     }
 });
 
+// Mock Math.random() to always return the same value for our tests.
+Math.random = function (): number {
+    return 1337;
+}
+
 // provide answers for task mock
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "openssl": "/usr/bin/openssl",
-        "security": "/usr/bin/security"
+        "security": "/usr/bin/security",
+        "grep": "/usr/bin/grep"
     },
     "checkPath": {
         "/usr/bin/openssl": true,
-        "/usr/bin/security": true
+        "/usr/bin/security": true,
+        "/usr/bin/grep": true
     },
     "exist": {
         "/build/temp/mySecureFileId.filename": true,
@@ -46,7 +52,11 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C"
         },
-        "/usr/bin/security create-keychain -p mykeychainPwd /build/temp/ios_signing_temp.keychain": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass: -passout pass:115 | /usr/bin/grep friendlyName": {
+            "code": 0,
+            "stdout": "MAC verified OK\n    friendlyName: iOS Developer: Madhuri Gummalla (Madhuri Gummalla)"
+        },
+        "/usr/bin/security create-keychain -p 115 /build/temp/ios_signing_temp.keychain": {
             "code": 0,
             "stdout": "keychain created"
         },
@@ -54,13 +64,17 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "keychain settings"
         },
-        "/usr/bin/security unlock-keychain -p mykeychainPwd /build/temp/ios_signing_temp.keychain": {
+        "/usr/bin/security unlock-keychain -p 115 /build/temp/ios_signing_temp.keychain": {
             "code": 0,
             "stdout": "keychain unlocked"
         },
         "/usr/bin/security import /build/temp/mySecureFileId.filename -P  -A -t cert -f pkcs12 -k /build/temp/ios_signing_temp.keychain": {
             "code": 0,
             "stdout": "cert installed"
+        },
+        "/usr/bin/security set-key-partition-list -S apple-tool:,apple: -s -l iOS Developer: Madhuri Gummalla (Madhuri Gummalla) -k 115 /build/temp/ios_signing_temp.keychain": {
+            "code": 0,
+            "stdout": "private key dump"
         },
         "/usr/bin/security list-keychain -d user": {
             "code": 0,

--- a/Tasks/InstallAppleCertificate/Tests/L0InstallDefaultKeychain.ts
+++ b/Tasks/InstallAppleCertificate/Tests/L0InstallDefaultKeychain.ts
@@ -27,11 +27,13 @@ tr.registerMock('fs', {
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "openssl": "/usr/bin/openssl",
-        "security": "/usr/bin/security"
+        "security": "/usr/bin/security",
+        "grep": "/usr/bin/grep"
     },
     "checkPath": {
         "/usr/bin/openssl": true,
-        "/usr/bin/security": true
+        "/usr/bin/security": true,
+        "/usr/bin/grep": true
     },
     "exist": {
         "/build/temp/mySecureFileId.filename": true,
@@ -46,6 +48,10 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C"
         },
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass:mycertPwd -passout pass:mycertPwd | /usr/bin/grep friendlyName": {
+            "code": 0,
+            "stdout": "MAC verified OK\n    friendlyName: iOS Developer: Madhuri Gummalla (Madhuri Gummalla)"
+        },
         "/usr/bin/security default-keychain": {
             "code": 0,
             "stdout": "/usr/lib/login.keychain"
@@ -57,6 +63,10 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/usr/bin/security import /build/temp/mySecureFileId.filename -P mycertPwd -A -t cert -f pkcs12 -k /usr/lib/login.keychain": {
             "code": 0,
             "stdout": "cert installed"
+        },
+        "/usr/bin/security set-key-partition-list -S apple-tool:,apple: -s -l iOS Developer: Madhuri Gummalla (Madhuri Gummalla) -k mykeychainPwd /usr/lib/login.keychain": {
+            "code": 0,
+            "stdout": "private key dump"
         },
         "/usr/bin/security list-keychain -d user": {
             "code": 0,

--- a/Tasks/InstallAppleCertificate/Tests/L0InstallTempKeychain.ts
+++ b/Tasks/InstallAppleCertificate/Tests/L0InstallTempKeychain.ts
@@ -9,7 +9,6 @@ let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 tr.setInput('certSecureFile', 'mySecureFileId');
 tr.setInput('certPwd', 'mycertPwd');
 tr.setInput('keychain', 'temp');
-tr.setInput('keychainPassword', 'mykeychainPwd');
 
 process.env['AGENT_VERSION'] = '2.116.0';
 process.env['AGENT_TEMPDIRECTORY'] = '/build/temp';
@@ -23,15 +22,22 @@ tr.registerMock('fs', {
     }
 });
 
+// Mock Math.random() to always return the same value for our tests.
+Math.random = function (): number {
+    return 1337;
+}
+
 // provide answers for task mock
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "openssl": "/usr/bin/openssl",
-        "security": "/usr/bin/security"
+        "security": "/usr/bin/security",
+        "grep": "/usr/bin/grep"
     },
     "checkPath": {
         "/usr/bin/openssl": true,
-        "/usr/bin/security": true
+        "/usr/bin/security": true,
+        "/usr/bin/grep": true
     },
     "exist": {
         "/build/temp/mySecureFileId.filename": true,
@@ -46,7 +52,11 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C"
         },
-        "/usr/bin/security create-keychain -p mykeychainPwd /build/temp/ios_signing_temp.keychain": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass:mycertPwd -passout pass:mycertPwd | /usr/bin/grep friendlyName": {
+            "code": 0,
+            "stdout": "MAC verified OK\n    friendlyName: iOS Developer: Madhuri Gummalla (Madhuri Gummalla)"
+        },
+        "/usr/bin/security create-keychain -p 115 /build/temp/ios_signing_temp.keychain": {
             "code": 0,
             "stdout": "keychain created"
         },
@@ -54,13 +64,17 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "keychain settings"
         },
-        "/usr/bin/security unlock-keychain -p mykeychainPwd /build/temp/ios_signing_temp.keychain": {
+        "/usr/bin/security unlock-keychain -p 115 /build/temp/ios_signing_temp.keychain": {
             "code": 0,
             "stdout": "keychain unlocked"
         },
         "/usr/bin/security import /build/temp/mySecureFileId.filename -P mycertPwd -A -t cert -f pkcs12 -k /build/temp/ios_signing_temp.keychain": {
             "code": 0,
             "stdout": "cert installed"
+        },
+        "/usr/bin/security set-key-partition-list -S apple-tool:,apple: -s -l iOS Developer: Madhuri Gummalla (Madhuri Gummalla) -k 115 /build/temp/ios_signing_temp.keychain": {
+            "code": 0,
+            "stdout": "dumped keychain key"
         },
         "/usr/bin/security list-keychain -d user": {
             "code": 0,

--- a/Tasks/InstallAppleCertificate/Tests/L0UserSupplyCN.ts
+++ b/Tasks/InstallAppleCertificate/Tests/L0UserSupplyCN.ts
@@ -28,11 +28,13 @@ tr.registerMock('fs', {
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "openssl": "/usr/bin/openssl",
-        "security": "/usr/bin/security"
+        "security": "/usr/bin/security",
+        "grep": "/usr/bin/grep"
     },
     "checkPath": {
         "/usr/bin/openssl": true,
-        "/usr/bin/security": true
+        "/usr/bin/security": true,
+        "/usr/bin/grep": true
     },
     "exist": {
         "/build/temp/mySecureFileId.filename": true,
@@ -47,6 +49,10 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C"
         },
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass:mycertPwd -passout pass:mycertPwd | /usr/bin/grep friendlyName": {
+            "code": 0,
+            "stdout": "MAC verified OK\n    friendlyName: iOS Developer: Madhuri Gummalla (Madhuri Gummalla)"
+        },
         "/usr/bin/security default-keychain": {
             "code": 0,
             "stdout": "/usr/lib/login.keychain"
@@ -58,6 +64,10 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/usr/bin/security import /build/temp/mySecureFileId.filename -P mycertPwd -A -t cert -f pkcs12 -k /usr/lib/login.keychain": {
             "code": 0,
             "stdout": "cert installed"
+        },
+        "/usr/bin/security set-key-partition-list -S apple-tool:,apple: -s -l iOS Developer: Madhuri Gummalla (Madhuri Gummalla) -k mykeychainPwd /usr/lib/login.keychain": {
+            "code": 0,
+            "stdout": "private key dump"
         },
         "/usr/bin/security list-keychain -d user": {
             "code": 0,

--- a/Tasks/InstallAppleCertificate/preinstallcert.ts
+++ b/Tasks/InstallAppleCertificate/preinstallcert.ts
@@ -21,7 +21,7 @@ async function run() {
 
         // get the P12 details - SHA1 hash and common name (CN)
         let p12Hash: string = await sign.getP12SHA1Hash(certPath, certPwd);
-        // give user an option to override the CN as a workaround if we can't parse the certificate
+        // give user an option to override the CN as a workaround if we can't parse the certificate's subject.
         let p12CN: string = tl.getInput('certSigningIdentity', false);
         if (!p12CN) {
             p12CN = await sign.getP12CommonName(certPath, certPwd);
@@ -41,10 +41,9 @@ async function run() {
         let keychainPath: string;
         if (keychain === 'temp') {
             keychainPath = sign.getTempKeychainPath();
-            if (!keychainPwd) {
-                // generate a keychain password for the temporary keychain since user did not provide one
-                keychainPwd = Math.random().toString(36);
-            }
+            // generate a keychain password for the temporary keychain
+            // overriding any value we may have read because keychainPassword is hidden in the designer for 'temp'.
+            keychainPwd = Math.random().toString(36);
         } else if (keychain === 'default') {
             keychainPath = await sign.getDefaultKeychainPath();
         } else if (keychain === 'custom') {

--- a/Tasks/InstallAppleCertificate/task.json
+++ b/Tasks/InstallAppleCertificate/task.json
@@ -11,10 +11,11 @@
     ],
     "author": "Microsoft Corporation",
     "version": {
-        "Major": 1,
+        "Major": 2,
         "Minor": 134,
         "Patch": 0
     },
+    "releaseNotes": "Fixes codesign hangs on a self hosted agent. Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",
     "runsOn": [
         "Agent",
         "DeploymentGroup"
@@ -58,15 +59,16 @@
                 "temp": "Temporary Keychain",
                 "custom": "Custom Keychain"
             },
-            "helpMarkDown": "Select the keychain in which to install the Apple certificate. A temporary keychain will always be deleted after the build or release is complete.",
+            "helpMarkDown": "Select the keychain in which to install the Apple certificate. For Microsoft hosted builds, use `Temporary Keychain`. A temporary keychain will always be deleted after the build or release is complete.",
             "groupName": "advanced"
         },
         {
             "name": "keychainPassword",
             "type": "string",
             "label": "Keychain password",
-            "required": false,
-            "helpMarkDown": "Password to unlock the keychain. Use a new build variable with its lock enabled on the `Variables` tab to encrypt this value. A password is generated for the temporary keychain if not specified.",
+            "required": true,
+            "helpMarkDown": "Password to unlock the keychain. Use a new build variable with its lock enabled on the `Variables` tab to encrypt this value.",
+            "visibleRule": "keychain = custom || keychain = default",
             "groupName": "advanced"
         },
         {
@@ -129,6 +131,9 @@
     },
     "messages": {
         "INVALID_P12": "Unable to find the certificate SHA1 hash and common name (CN). Verify that the certificate is a valid P12.",
-        "NoP12PwdWarning": "No P12 password supplied. If the P12 file requires a password, best practice is to supply it as process variable and mark it secret (lock icon)."
+        "NoP12PwdWarning": "No P12 password supplied. If the P12 file requires a password, best practice is to supply it as process variable and mark it secret (lock icon).",
+        "P12PrivateKeyNameNotFound": "Failed to identify the private key name: %s",
+        "SetKeyPartitionListCommandNotFound": "Skipping unnecessary keychain partition_id ACL assignment on older OS. The security command 'set-key-partition-list' was added in macOS Sierra (10.12).",
+        "SetKeyPartitionListCommandFailed": "Error setting partition_id ACL for private key. Check `Keychain password` is correct, or use `Temporary Keychain` instead."
     }
 }

--- a/Tasks/InstallAppleCertificate/task.loc.json
+++ b/Tasks/InstallAppleCertificate/task.loc.json
@@ -11,10 +11,11 @@
   ],
   "author": "Microsoft Corporation",
   "version": {
-    "Major": 1,
+    "Major": 2,
     "Minor": 134,
     "Patch": 0
   },
+  "releaseNotes": "ms-resource:loc.releaseNotes",
   "runsOn": [
     "Agent",
     "DeploymentGroup"
@@ -65,8 +66,9 @@
       "name": "keychainPassword",
       "type": "string",
       "label": "ms-resource:loc.input.label.keychainPassword",
-      "required": false,
+      "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.keychainPassword",
+      "visibleRule": "keychain = custom || keychain = default",
       "groupName": "advanced"
     },
     {
@@ -129,6 +131,9 @@
   },
   "messages": {
     "INVALID_P12": "ms-resource:loc.messages.INVALID_P12",
-    "NoP12PwdWarning": "ms-resource:loc.messages.NoP12PwdWarning"
+    "NoP12PwdWarning": "ms-resource:loc.messages.NoP12PwdWarning",
+    "P12PrivateKeyNameNotFound": "ms-resource:loc.messages.P12PrivateKeyNameNotFound",
+    "SetKeyPartitionListCommandNotFound": "ms-resource:loc.messages.SetKeyPartitionListCommandNotFound",
+    "SetKeyPartitionListCommandFailed": "ms-resource:loc.messages.SetKeyPartitionListCommandFailed"
   }
 }

--- a/definitions/ios-signing-common.d.ts
+++ b/definitions/ios-signing-common.d.ts
@@ -3,58 +3,93 @@
 declare module 'ios-signing-common/ios-signing-common' {
 
     /**
+     * Gets the path to the temporary keychain path used during build or release
+    */
+    export function getTempKeychainPath(): string;
+
+    /**
      * Creates a temporary keychain and installs the P12 cert in the temporary keychain
-     * @param keychainPath, the path to the keychain file
-     * @param keychainPwd, the password to use for unlocking the keychain
-     * @param p12CertPath, the P12 cert to be installed in the keychain
-     * @param p12Pwd, the password for the P12 cert
+     * @param keychainPath the path to the keychain file
+     * @param keychainPwd the password to use for unlocking the keychain
+     * @param p12CertPath the P12 cert to be installed in the keychain
+     * @param p12Pwd the password for the P12 cert
+     * @param useKeychainIfExists Pass false to delete and recreate a preexisting keychain
      */
-    export function installCertInTemporaryKeychain(keychainPath : string, keychainPwd: string, p12CertPath : string, p12Pwd: string);
+    export function installCertInTemporaryKeychain(keychainPath: string, keychainPwd: string, p12CertPath: string, p12Pwd: string, useKeychainIfExists: boolean): Promise<void>;
 
     /**
     * Finds an iOS codesigning identity in the specified keychain
     * @param keychainPath
     * @returns {string} signing identity found
     */
-    export function findSigningIdentity(keychainPath: string) : string;
+    export function findSigningIdentity(keychainPath: string): string;
 
     /**
      * Find the UUID and Name of the provisioning profile and install the profile
      * @param provProfilePath
      * @returns { provProfileUUID, provProfileName }
      */
-    export function installProvisioningProfile(provProfilePath: string) : Promise<{ provProfileUUID: string, provProfileName: string }>;
+    export function installProvisioningProfile(provProfilePath: string): Promise<{ provProfileUUID: string, provProfileName: string }>;
 
     /**
      * Find the type of the provisioning profile - development, app-store or ad-hoc
      * @param provProfilePath
      * @returns {string} type
      */
-    export function getProvisioningProfileType(provProfilePath: string) : string;
+    export function getProvisioningProfileType(provProfilePath: string): string;
 
     /**
      * Delete specified iOS keychain
      * @param keychainPath
      */
-    export function deleteKeychain(keychainPath: string);
+    export function deleteKeychain(keychainPath: string): Promise<void>;
 
     /**
      * Unlock specified iOS keychain
      * @param keychainPath
      * @param keychainPwd
      */
-    export function unlockKeychain(keychainPath: string, keychainPwd: string);
+    export function unlockKeychain(keychainPath: string, keychainPwd: string): Promise<void>;
+
+
+    /**
+     * Delete certificate with specified SHA1 hash (thumbprint) from a keychain.
+     * @param keychainPath
+     * @param certSha1Hash
+     */
+    export function deleteCert(keychainPath: string, certSha1Hash: string): Promise<void>;
 
     /**
      * Delete provisioning profile with specified UUID in the user's profiles directory
      * @param uuid
      */
-    export function deleteProvisioningProfile(uuid: string);
+    export function deleteProvisioningProfile(uuid: string): Promise<void>;
 
     /**
      * Gets the path to the iOS default keychain
      */
-    export function getDefaultKeychainPath() : string;
+    export function getDefaultKeychainPath(): string;
+
+    /**
+     * Get the SHA1 hash (thumbprint) for the certificate in a P12 file.
+     * @param p12Path Path to the P12 file
+     * @param p12Pwd Password for the P12 file
+     */
+    export function getP12SHA1Hash(p12Path: string, p12Pwd: string): Promise<string>;
+
+    /**
+     * Get the common name from the certificate in a P12 file, with 'CN=' removed.
+     * @param p12Path Path to the P12 file
+     * @param p12Pwd Password for the P12 file
+     */
+    export function getP12CommonName(p12Path: string, p12Pwd: string): Promise<string>;
+
+    /**
+     * Get the friendly name from the private key in a P12 file.
+     * @param p12Path Path to the P12 file
+     * @param p12Pwd Password for the P12 file
+     */
+    export function getP12PrivateKeyName(p12Path: string, p12Pwd: string): Promise<string>;
 
     /**
      * Get Cloud entitlement type Production or Development according to the export method - if entitlement doesn't exists in provisioning profile returns null
@@ -62,5 +97,5 @@ declare module 'ios-signing-common/ios-signing-common' {
      * @param exportMethod
      * @returns {string}
      */
-    export function getCloudEntitlement(provisioningProfilePath: string, exportMethod: string): Promise<string>
+    export function getCloudEntitlement(provisioningProfilePath: string, exportMethod: string): Promise<string>;
 }


### PR DESCRIPTION
If the user provides a valid password, a partition_id ACL for codesign
("apple:") will be added to the private key. Otherwise Install Apple
Certificate will fail fast. Issue #5701 