### PR TITLE
User feedback on Python template

### DIFF
--- a/templates/ci/python-package.yml
+++ b/templates/ci/python-package.yml
@@ -40,8 +40,8 @@ phases:
       versionSpec: '3.6'
       architecture: 'x64'
       addToPath: 'true'
-  - script: python -m pip install --upgrade pip && pip install wheel && python setup.py bdist_wheel
-    displayName: Build Wheel
+  - script: python setup.py sdist
+    displayName: Build sdist
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifacts'
     inputs:

--- a/templates/ci/python-package.yml
+++ b/templates/ci/python-package.yml
@@ -10,8 +10,6 @@ phases:
     matrix:
       Python27:
         PYTHON_VERSION: '2.7'
-      Python34:
-        PYTHON_VERSION: '3.4'
       Python35:
         PYTHON_VERSION: '3.5'
       Python36:

--- a/templates/ci/python-package.yml
+++ b/templates/ci/python-package.yml
@@ -46,7 +46,7 @@ phases:
     displayName: 'Publish artifacts'
     inputs:
       pathToPublish: 'dist'
-      artifactName: 'artifact'
+      artifactName: 'dist'
       artifactType: 'container'
   # - task: PyPIPublisher@0
   #   inputs:


### PR DESCRIPTION
Implementing some feedback from @zooba:

- Remove Python 3.4 (relatively old version; still on the hosted agents but we should exclude from the template)
- Build sdist instead of wheel (wheels won't work cross-platform)
- Rename artifact to 'dist' (conventional in Python)