### PR TITLE
Case sensitive file name bug fix

### DIFF
--- a/Tasks/AzureRmWebAppDeployment/deploymentProvider/PublishProfileWebAppDeploymentProvider.ts
+++ b/Tasks/AzureRmWebAppDeployment/deploymentProvider/PublishProfileWebAppDeploymentProvider.ts
@@ -10,7 +10,7 @@ import path = require('path');
 
 var packageUtility = require('webdeployment-common/packageUtility.js');
 var deployUtility = require('webdeployment-common/utility.js');
-var msDeployUtility = require('webdeployment-common/msDeployUtility.js');
+var msDeployUtility = require('webdeployment-common/msdeployutility.js');
 
 const DEFAULT_RETRY_COUNT = 3;
 

--- a/Tasks/AzureRmWebAppDeployment/task.json
+++ b/Tasks/AzureRmWebAppDeployment/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 4,
         "Minor": 1,
-        "Patch": 1
+        "Patch": 2
     },
     "releaseNotes": "What's new in version 4.* (preview)<br />Supports Kudu Zip Deploy<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more Information.",
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeployment/task.loc.json
+++ b/Tasks/AzureRmWebAppDeployment/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 1,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",


### PR DESCRIPTION
The AzureRMWebappDeployment task is failing on Linux agent because the filename in linux is case sensitive, which is not the case in windows. So the task was working perfectly on windows agent but not on linux agent.