### PR TITLE
Simplify repetitive YAML of 'PublishBuildArtifacts' using default values

### DIFF
--- a/Tasks/PublishBuildArtifacts/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishBuildArtifacts/Strings/resources.resjson/en-US/resources.resjson
@@ -6,7 +6,7 @@
   "loc.input.label.PathtoPublish": "Path to publish",
   "loc.input.help.PathtoPublish": "The folder or file path to publish. This can be a fully-qualified path or a path relative to the root of the repository. Wildcards are not supported. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) are supported. Example: $(Build.ArtifactStagingDirectory)",
   "loc.input.label.ArtifactName": "Artifact name",
-  "loc.input.help.ArtifactName": "The name of the artifact to create in the publish location",
+  "loc.input.help.ArtifactName": "The name of the artifact to create in the publish location.",
   "loc.input.label.ArtifactType": "Artifact publish location",
   "loc.input.help.ArtifactType": "Choose whether to store the artifact in Visual Studio Team Services/TFS, or to copy it to a file share that must be accessible from the build agent.",
   "loc.input.label.TargetPath": "File share path",

--- a/Tasks/PublishBuildArtifacts/task.json
+++ b/Tasks/PublishBuildArtifacts/task.json
@@ -29,9 +29,9 @@
       "name": "ArtifactName",
       "type": "string",
       "label": "Artifact name",
-      "defaultValue": "artifact",
+      "defaultValue": "drop",
       "required": true,
-      "helpMarkDown": "The name of the artifact to create in the publish location"
+      "helpMarkDown": "The name of the artifact to create in the publish location."
     },
     {
       "name": "ArtifactType",

--- a/Tasks/PublishBuildArtifacts/task.json
+++ b/Tasks/PublishBuildArtifacts/task.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 133,
+    "Minor": 135,
     "Patch": 0
   },
   "demands": [],
@@ -21,7 +21,7 @@
       "name": "PathtoPublish",
       "type": "filePath",
       "label": "Path to publish",
-      "defaultValue": "",
+      "defaultValue": "$(Build.ArtifactStagingDirectory)",
       "required": true,
       "helpMarkDown": "The folder or file path to publish. This can be a fully-qualified path or a path relative to the root of the repository. Wildcards are not supported. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) are supported. Example: $(Build.ArtifactStagingDirectory)"
     },
@@ -29,7 +29,7 @@
       "name": "ArtifactName",
       "type": "string",
       "label": "Artifact name",
-      "defaultValue": "",
+      "defaultValue": "artifact",
       "required": true,
       "helpMarkDown": "The name of the artifact to create in the publish location"
     },
@@ -38,7 +38,7 @@
       "aliases": [ "publishLocation" ],
       "type": "pickList",
       "label": "Artifact publish location",
-      "defaultValue": "",
+      "defaultValue": "Container",
       "required": true,
       "helpMarkDown": "Choose whether to store the artifact in Visual Studio Team Services/TFS, or to copy it to a file share that must be accessible from the build agent.",
       "options": {

--- a/Tasks/PublishBuildArtifacts/task.loc.json
+++ b/Tasks/PublishBuildArtifacts/task.loc.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 133,
+    "Minor": 135,
     "Patch": 0
   },
   "demands": [],
@@ -21,7 +21,7 @@
       "name": "PathtoPublish",
       "type": "filePath",
       "label": "ms-resource:loc.input.label.PathtoPublish",
-      "defaultValue": "",
+      "defaultValue": "$(Build.ArtifactStagingDirectory)",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.PathtoPublish"
     },
@@ -29,7 +29,7 @@
       "name": "ArtifactName",
       "type": "string",
       "label": "ms-resource:loc.input.label.ArtifactName",
-      "defaultValue": "",
+      "defaultValue": "artifact",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.ArtifactName"
     },
@@ -40,7 +40,7 @@
       ],
       "type": "pickList",
       "label": "ms-resource:loc.input.label.ArtifactType",
-      "defaultValue": "",
+      "defaultValue": "Container",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.ArtifactType",
       "options": {

--- a/Tasks/PublishBuildArtifacts/task.loc.json
+++ b/Tasks/PublishBuildArtifacts/task.loc.json
@@ -29,7 +29,7 @@
       "name": "ArtifactName",
       "type": "string",
       "label": "ms-resource:loc.input.label.ArtifactName",
-      "defaultValue": "artifact",
+      "defaultValue": "drop",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.ArtifactName"
     },


### PR DESCRIPTION
Each of [our YAML templates](https://github.com/Microsoft/vsts-tasks/tree/master/templates/ci) has to repeat this common block:

```yaml
- task: PublishBuildArtifacts@1
  inputs:
    pathToPublish: '$(build.artifactStagingDirectory)'
    publishLocation: 'container'
    artifactName: 'artifact'
```

All of the above inputs are required.  This PR simplifies them by adding default values.  I don't think this is a change in behavior that calls for a major version bump.  The resulting YAML looks like:

```yaml
- task: PublishBuildArtifacts@1
```