### PR TITLE
Trim default values from use of PublishBuildArtifacts

### DIFF
--- a/templates/ci/.net-desktop.yml
+++ b/templates/ci/.net-desktop.yml
@@ -36,7 +36,3 @@ steps:
     targetFolder: '$(build.artifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'

--- a/templates/ci/android.yml
+++ b/templates/ci/android.yml
@@ -16,10 +16,6 @@ steps:
     targetFolder: '$(build.artifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'
 
 # Next steps:
 # Test apps on real devices with the App Center Test task: https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AppCenterTest

--- a/templates/ci/ant.yml
+++ b/templates/ci/ant.yml
@@ -15,7 +15,3 @@ steps:
     targetFolder: '$(build.artifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'

--- a/templates/ci/asp.net-core-.net-framework.yml
+++ b/templates/ci/asp.net-core-.net-framework.yml
@@ -32,7 +32,3 @@ steps:
     searchPattern: '**/bin/$(buildConfiguration)/*.pdb'
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'

--- a/templates/ci/asp.net-core.yml
+++ b/templates/ci/asp.net-core.yml
@@ -28,9 +28,4 @@ steps:
 #  inputs:
 #    command: 'publish'
 #    arguments: '--configuration $(buildConfiguration) --output $(build.artifactStagingDirectory)'
-
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathtoPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'
+#- task: PublishBuildArtifacts@1

--- a/templates/ci/asp.net.yml
+++ b/templates/ci/asp.net.yml
@@ -32,7 +32,3 @@ steps:
     searchPattern: '**/bin/$(buildConfiguration)/*.pdb'
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'

--- a/templates/ci/gcc-c.yml
+++ b/templates/ci/gcc-c.yml
@@ -13,7 +13,3 @@ steps:
     targetFolder: '$(build.artifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'

--- a/templates/ci/gcc-cpp.yml
+++ b/templates/ci/gcc-cpp.yml
@@ -13,7 +13,3 @@ steps:
     targetFolder: '$(build.artifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'

--- a/templates/ci/go.yml
+++ b/templates/ci/go.yml
@@ -23,7 +23,3 @@ steps:
     includeRootFolder: false
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'

--- a/templates/ci/gradle.yml
+++ b/templates/ci/gradle.yml
@@ -16,7 +16,3 @@ steps:
     targetFolder: '$(build.artifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'

--- a/templates/ci/maven.yml
+++ b/templates/ci/maven.yml
@@ -16,7 +16,3 @@ steps:
     targetFolder: '$(build.artifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'

--- a/templates/ci/node.js-with-grunt.yml
+++ b/templates/ci/node.js-with-grunt.yml
@@ -20,7 +20,3 @@ steps:
     includeRootFolder: false
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'

--- a/templates/ci/node.js-with-gulp.yml
+++ b/templates/ci/node.js-with-gulp.yml
@@ -20,7 +20,3 @@ steps:
     includeRootFolder: false
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'

--- a/templates/ci/universal-windows-platform.yml
+++ b/templates/ci/universal-windows-platform.yml
@@ -26,5 +26,3 @@ steps:
 - task: PublishBuildArtifacts@1
   inputs:
     pathToPublish: '$(appxPackageDir)'
-    publishLocation: 'container'
-    artifactName: 'artifact'

--- a/templates/ci/xamarin.android.yml
+++ b/templates/ci/xamarin.android.yml
@@ -4,7 +4,6 @@
 
 queue: 'Hosted VS2017'
 variables:
-  apkFiles: '$(outputDirectory)'
   buildConfiguration: 'Release'
   outputDirectory: '$(build.binariesDirectory)/$(buildConfiguration)'
 steps:
@@ -23,9 +22,7 @@ steps:
 
 - task: PublishBuildArtifacts@1
   inputs:
-    pathtoPublish: '$(apkFiles)'
-    publishLocation: 'container'
-    artifactName: 'artifact'
+    pathtoPublish: '$(outputDirectory)'
 
 # Next steps:
 # Test apps on real devices with the App Center Test task: https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AppCenterTest

--- a/templates/ci/xamarin.ios.yml
+++ b/templates/ci/xamarin.ios.yml
@@ -17,10 +17,6 @@ steps:
     targetFolder: '$(build.artifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'
 
 # Next steps:
 # Test apps on real devices with the App Center Test task: https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AppCenterTest

--- a/templates/ci/xcode.yml
+++ b/templates/ci/xcode.yml
@@ -34,10 +34,6 @@ steps:
     targetFolder: '$(build.artifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1
-  inputs:
-    pathtoPublish: '$(build.artifactStagingDirectory)'
-    publishLocation: 'container'
-    artifactName: 'artifact'
 
 # Next steps:
 # Test apps on real devices with the App Center Test task: https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AppCenterTest


### PR DESCRIPTION
PR #7101 added default values to the Publish Build Artifacts task.  This PR removes those default values from the YAML templates (where possible) to make them more succinct.