### PR TITLE
Fixed 'Use Web Deploy' option not working on Windows

### DIFF
--- a/Tasks/Common/webdeployment-common/utility.ts
+++ b/Tasks/Common/webdeployment-common/utility.ts
@@ -69,7 +69,7 @@ export function copySetParamFileIfItExists(setParametersFile: string) : string {
  */
 export function canUseWebDeploy(useWebDeploy: boolean) {
     var win = tl.osType().match(/^Win/);
-    return (useWebDeploy || win);
+    return (useWebDeploy && win);
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vsts-tasks/issues/4722

The "Use Web Deploy" option would always forcefully return true on Windows.