### PR TITLE
SourceDefinitions to DataSourceBindings

### DIFF
--- a/Tasks/DownloadBuildArtifacts/task.json
+++ b/Tasks/DownloadBuildArtifacts/task.json
@@ -148,12 +148,15 @@
     {
       "endpointId": "tfs:teamfoundation",
       "target": "definition",
-      "endpointUrl": "{{endpoint.url}}/{{project}}/_apis/build/definitions?$top=1000",
+      "endpointUrl": "{{endpoint.url}}/{{project}}/_apis/build/definitions?api-version=3.0-preview&$top=1000&continuationToken={{{continuationToken}}}&queryOrder=2",
       "resultSelector": "jsonpath:$.value[?(@.quality=='definition')]",
       "parameters": {
           "project": "$(project)"
       },
-      "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{name}}}\" }"
+      "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{name}}}\" }",
+      "callbackContextTemplate": "{\"continuationToken\" : \"{{{headers.x-ms-continuationtoken}}}\"}",
+      "callbackRequiredTemplate": "{{{#headers.x-ms-continuationtoken}}}true{{{/headers.x-ms-continuationtoken}}}",
+      "initialContextTemplate":"{\"continuationToken\" : \"{{{system.utcNow}}}\"}"
     },
     {
       "endpointId": "tfs:teamfoundation",

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -462,26 +462,26 @@
             "visibleRule": "rerunFailedTests = true"
         }
     ],
-    "sourceDefinitions": [
+    "dataSourceBindings": [
         {
             "target": "testPlan",
-            "endpoint": "/$(system.teamProject)/_apis/test/plans?filterActivePlans=true&api-version=3.0-preview.2",
-            "selector": "jsonpath:$.value[*].name",
-            "keySelector": "jsonpath:$.value[*].id",
-            "authKey": "tfs:teamfoundation"
+            "endpointId": "tfs:teamfoundation",
+            "endpointUrl": "{{endpoint.url}}/{{system.teamProject}}/_apis/test/plans?filterActivePlans=true&api-version=3.0-preview.2",
+            "resultSelector": "jsonpath:$.value[*]",
+            "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{name}}}\" }"
         },
         {
             "target": "testConfiguration",
-            "endpoint": "/$(system.teamProject)/_apis/test/configurations?api-version=3.0-preview.1",
-            "selector": "jsonpath:$.value[*].name",
-            "keySelector": "jsonpath:$.value[*].id",
-            "authKey": "tfs:teamfoundation"
+            "endpointId": "tfs:teamfoundation",
+            "endpointUrl": "{{endpoint.url}}/{{system.teamProject}}/_apis/test/configurations?api-version=3.0-preview.1",
+            "resultSelector": "jsonpath:$.value[*]",
+            "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{name}}}\" }"
         },
         {
             "target": "testSuite",
-            "endpoint": "/$(system.teamProject)/_apis/test/plans/$(testPlan)/suites?$asTreeView=true&api-version=3.0-preview.2",
-            "selector": "jsonpath:$.value[*]",
-            "authKey": "tfs:teamfoundation"
+            "endpointId": "tfs:teamfoundation",
+            "endpointUrl": "{{endpoint.url}}/{{system.teamProject}}/_apis/test/plans/{{testPlan}}/suites?$asTreeView=true&api-version=3.0-preview.2",
+            "resultSelector": "jsonpath:$.value[*]"
         }
     ],
     "instanceNameFormat": "VsTest - $(testSelector)",

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -466,9 +466,12 @@
         {
             "target": "testPlan",
             "endpointId": "tfs:teamfoundation",
-            "endpointUrl": "{{endpoint.url}}/{{system.teamProject}}/_apis/test/plans?filterActivePlans=true&api-version=3.0-preview.2",
+            "endpointUrl": "{{endpoint.url}}/{{system.teamProject}}/_apis/test/plans?filterActivePlans=true&api-version=3.0-preview.2&$skip={{skip}}&$top=1000",
             "resultSelector": "jsonpath:$.value[*]",
-            "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{name}}}\" }"
+            "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{name}}}\" }",
+            "callbackContextTemplate": "{\"skip\": \"{{add skip 1000}}\"}",
+            "callbackRequiredTemplate": "{{compareValueWithTop result.resultSize 1000}}",
+            "initialContextTemplate": "{\"skip\": \"0\"}"
         },
         {
             "target": "testConfiguration",

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -468,9 +468,9 @@
             "endpointId": "tfs:teamfoundation",
             "endpointUrl": "{{endpoint.url}}/{{system.teamProject}}/_apis/test/plans?filterActivePlans=true&api-version=3.0-preview.2&$skip={{skip}}&$top=1000",
             "resultSelector": "jsonpath:$.value[*]",
-            "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{name}}}\" }",
+            "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{id}}} - {{{name}}}\" }",
             "callbackContextTemplate": "{\"skip\": \"{{add skip 1000}}\"}",
-            "callbackRequiredTemplate": "{{compareValueWithTop result.resultSize 1000}}",
+            "callbackRequiredTemplate": "{{isEqualNumber result.count 1000}}",
             "initialContextTemplate": "{\"skip\": \"0\"}"
         },
         {


### PR DESCRIPTION
Updating the vstest task to define dataSourceBindings instead of sourceDefinitions as per the new pattern

This is needed to support pagination in the test plan data source