### PR TITLE
Only split "commands" on semicolon 

### DIFF
--- a/Tasks/SshV0/ssh.ts
+++ b/Tasks/SshV0/ssh.ts
@@ -53,8 +53,12 @@ async function run() {
         var scriptFile : string;
         var args : string;
 
-        if(runOptions === 'commands') {
-            commands = tl.getDelimitedInput('commands', '\n', true);
+        if (runOptions === 'commands') {
+            // Split on '\n' and ';', flatten, and remove empty entries
+            commands = tl.getDelimitedInput('commands', '\n', true)
+                         .map(s => s.split(';'))
+                         .reduce((a, b) => a.concat(b))
+                         .filter(s => s.length > 0);
         } else if (runOptions === 'inline') {
             var inlineScript: string = tl.getInput('inline', true);
             const scriptHeader:string = '#!';

--- a/Tasks/SshV0/task.json
+++ b/Tasks/SshV0/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 121,
+        "Minor": 135,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/SshV0/task.loc.json
+++ b/Tasks/SshV0/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 121,
+    "Minor": 135,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
The SSH task can execute a set of commands, a script file, or an inline script.  When running the first option, it would split the input on newlines and then send those lines to a method that split them again on semicolons and finally send each string separately as a command.  To run the latter two, the task would create a command to run a file like, "<script path> <args>", and then it would then pass this to the same method that used above.  So if "args" had a semi colon in it, the task would incorrectly split on that semicolon.

The fix here is to only split on semicolons in the first case, so I moved the splitting out from the helper method to the only place that uses it.