### PR TITLE
Changed Remove-Item logic for temp log folder.

### DIFF
--- a/Tasks/Common/RemoteDeployer/RemoteDeployer.Utility.ps1
+++ b/Tasks/Common/RemoteDeployer/RemoteDeployer.Utility.ps1
@@ -80,7 +80,7 @@ function Get-TemporaryLogsFolder {
         $tempFolderName = [Guid]::NewGuid().ToString()
         $tempLogsFolder = [System.IO.Path]::Combine($agentTempDirectory, $tempFolderName)
         if((Test-Path -LiteralPath $tempLogsFolder -PathType 'Container') -eq $true) {
-            Remove-Item -LiteralPath $tempLogsFolder -Force
+            Get-ChildItem -Path $tempLogsFolder -Force -Recurse | Sort-Object -Property FullName -Descending | Remove-Item -Recurse -Force
         }
         $tempLogsFolder = (New-Item -Path $agentTempDirectory -Name $tempFolderName -ItemType 'Container').FullName
         return $tempLogsFolder


### PR DESCRIPTION
Errors in RemoteDeployer when run as part of the PowerShellOnTargetMachineV3 task. Could not run more than one task in the release pipeline without getting the "Remove-Item : Windows PowerShell is in NonInteractive mode. Read and Prompt functionality is not available." error. This changes Remove-Item to work as in a similar issue listed here: https://stackoverflow.com/questions/34632351/remove-item-errors-when-run-at-end-of-tfs-build. Have confirmed I can now run multiple PowerShellOnTargetMachineV3 tasks in sequence.