### PR TITLE
[AzureCLITask] Support being able to change subscription name

### DIFF
--- a/Tasks/AzureCLIV1/azureclitask.ts
+++ b/Tasks/AzureCLIV1/azureclitask.ts
@@ -100,12 +100,12 @@ export class azureclitask {
         var servicePrincipalId: string = tl.getEndpointAuthorizationParameter(connectedService, "serviceprincipalid", false);
         var servicePrincipalKey: string = tl.getEndpointAuthorizationParameter(connectedService, "serviceprincipalkey", false);
         var tenantId: string = tl.getEndpointAuthorizationParameter(connectedService, "tenantid", false);
-        var subscriptionName: string = tl.getEndpointDataParameter(connectedService, "SubscriptionName", true);
+        var subscriptionId: string = tl.getEndpointDataParameter(connectedService, "SubscriptionID", true);
         //login using svn
         this.throwIfError(tl.execSync("az", "login --service-principal -u \"" + servicePrincipalId + "\" -p \"" + servicePrincipalKey + "\" --tenant \"" + tenantId + "\""));
         this.isLoggedIn = true;
         //set the subscription imported to the current subscription
-        this.throwIfError(tl.execSync("az", "account set --subscription \"" + subscriptionName + "\""));
+        this.throwIfError(tl.execSync("az", "account set --subscription \"" + subscriptionId + "\""));
     }
 
     private static logoutAzure() {


### PR DESCRIPTION
Subscription names can be changed and cause this task to fail swapping to id will fix this problem

We currently recieve the following error on our release server:

[error]Script failed with error: ERROR: The subscription of 'oldname' doesn't exist in cloud 'AzureCloud'.