### PR TITLE
Multiple fixes to the CLT tasks (QuickPerfTestV1|RunLoadTestV1|RunJMeterLoadTestV1)

### DIFF
--- a/Tasks/QuickPerfTestV1/CltTasksUtility.ps1
+++ b/Tasks/QuickPerfTestV1/CltTasksUtility.ps1
@@ -157,11 +157,6 @@ function ValidateInputs($websiteUrl, $tfsCollectionUrl, $connectedServiceName, $
 		throw "Website Url is not well formed."
 	}
 	
-	if([string]::IsNullOrWhiteSpace($connectedServiceName) -and $tfsCollectionUrl -notlike "*VISUALSTUDIO.COM*" -and $tfsCollectionUrl -notlike "*TFSALLIN.NET*")
-	{
-		throw "VS Team Services Connection is mandatory for using performance test tasks on non hosted TFS builds.Please specify a VS Team Services connection and try again "
-	}
-
     # validate load test name
     # code taken from definitionNameInvalid    
     $invalidPattern1 = "(^\\.$|^\\.\\.$|^-$|^_$)"

--- a/Tasks/QuickPerfTestV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/QuickPerfTestV1/Strings/resources.resjson/en-US/resources.resjson
@@ -16,6 +16,10 @@
   "loc.input.label.geoLocation": "Load Location",
   "loc.input.help.geoLocation": "Geographical region to generate the load from.",
   "loc.input.label.machineType": "Run load test using",
+  "loc.input.label.resourceGroupName": "Resource group rig",
+  "loc.input.help.resourceGroupName": "Name of Resource group hosting the self-provisioned rig of load test agents.",
+  "loc.input.label.numOfSelfProvisionedAgents": "No. of agents to use",
+  "loc.input.help.numOfSelfProvisionedAgents": "Number of self provisioned agents to use for this test.",
   "loc.input.label.avgResponseTimeThreshold": "Fail test if Avg.Response Time(ms) exceeds",
   "loc.input.help.avgResponseTimeThreshold": "Average response time above which the load test outcome is considered unsuccessful."
 }

--- a/Tasks/QuickPerfTestV1/task.json
+++ b/Tasks/QuickPerfTestV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 28
+        "Patch": 29
     },
     "demands": [
         "msbuild",
@@ -88,21 +88,23 @@
             "defaultValue": "Default",
             "options": {
                 "Default": "Default",
-                "East US": "East US (Virginia)",
-                "East US 2": "East US 2 (Virginia)",
+                "Australia East": "Australia East (New South Wales)",
+                "Australia Southeast": "Australia Southeast (Victoria)",
+                "Brazil South": "Brazil South (Sao Paulo State)",
+                "Central India": "Central India (Pune)",
                 "Central US": "Central US (Iowa)",
-                "West US": "West US (California)",
-                "North Central US": "North Central US (Illinois)",
-                "South Central US": "South Central US (Texas)",
-                "North Europe": "North Europe (Ireland)",
-                "West Europe": "West Europe (Netherlands)",
-                "Southeast Asia": "Southeast Asia (Singapore)",
                 "East Asia": "East Asia (Hong Kong)",
+                "East US 2": "East US 2 (Virginia)",
+                "East US": "East US (Virginia)",
                 "Japan East": "Japan East (Saitama Prefecture)",
                 "Japan West": "Japan West (Osaka Prefecture)",
-                "Brazil South": "Brazil South (Sao Paulo State)",
-                "Australia East": "Australia East (New South Wales)",
-                "Australia Southeast": "Australia Southeast (Victoria)"
+                "North Central US": "North Central US (Illinois)",
+                "North Europe": "North Europe (Ireland)",
+                "South Central US": "South Central US (Texas)",
+                "South India": "South India (Chennai)",
+                "Southeast Asia": "Southeast Asia (Singapore)",
+                "West Europe": "West Europe (Netherlands)",
+                "West US": "West US (California)"
             },
             "properties": {
                 "EditableOptions": "True"
@@ -124,7 +126,7 @@
             "type": "string",
             "label": "Resource group rig",
             "required": false,
-            "defaultValue": "",
+            "defaultValue": "default",
             "visibleRule": "machineType == 2",
             "helpMarkDown": "Name of Resource group hosting the self-provisioned rig of load test agents."
         },
@@ -133,7 +135,7 @@
             "type": "int",
             "label": "No. of agents to use",
             "required": false,
-            "defaultValue": "",
+            "defaultValue": 1,
             "visibleRule": "machineType == 2",
             "helpMarkDown": "Number of self provisioned agents to use for this test."
         },

--- a/Tasks/QuickPerfTestV1/task.loc.json
+++ b/Tasks/QuickPerfTestV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 27
+    "Patch": 29
   },
   "demands": [
     "msbuild",
@@ -56,6 +56,9 @@
         "50": "50",
         "100": "100",
         "250": "250"
+      },
+      "properties": {
+        "EditableOptions": "True"
       }
     },
     {
@@ -71,6 +74,9 @@
         "180": "180",
         "240": "240",
         "300": "300"
+      },
+      "properties": {
+        "EditableOptions": "True"
       }
     },
     {
@@ -82,21 +88,26 @@
       "defaultValue": "Default",
       "options": {
         "Default": "Default",
-        "East US": "East US (Virginia)",
-        "East US 2": "East US 2 (Virginia)",
+        "Australia East": "Australia East (New South Wales)",
+        "Australia Southeast": "Australia Southeast (Victoria)",
+        "Brazil South": "Brazil South (Sao Paulo State)",
+        "Central India": "Central India (Pune)",
         "Central US": "Central US (Iowa)",
-        "West US": "West US (California)",
-        "North Central US": "North Central US (Illinois)",
-        "South Central US": "South Central US (Texas)",
-        "North Europe": "North Europe (Ireland)",
-        "West Europe": "West Europe (Netherlands)",
-        "Southeast Asia": "Southeast Asia (Singapore)",
         "East Asia": "East Asia (Hong Kong)",
+        "East US 2": "East US 2 (Virginia)",
+        "East US": "East US (Virginia)",
         "Japan East": "Japan East (Saitama Prefecture)",
         "Japan West": "Japan West (Osaka Prefecture)",
-        "Brazil South": "Brazil South (Sao Paulo State)",
-        "Australia East": "Australia East (New South Wales)",
-        "Australia Southeast": "Australia Southeast (Victoria)"
+        "North Central US": "North Central US (Illinois)",
+        "North Europe": "North Europe (Ireland)",
+        "South Central US": "South Central US (Texas)",
+        "South India": "South India (Chennai)",
+        "Southeast Asia": "Southeast Asia (Singapore)",
+        "West Europe": "West Europe (Netherlands)",
+        "West US": "West US (California)"
+      },
+      "properties": {
+        "EditableOptions": "True"
       }
     },
     {
@@ -109,6 +120,24 @@
         "0": "Automatically provisioned agents",
         "2": "Self-provisioned agents"
       }
+    },
+    {
+      "name": "resourceGroupName",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.resourceGroupName",
+      "required": false,
+      "defaultValue": "default",
+      "visibleRule": "machineType == 2",
+      "helpMarkDown": "ms-resource:loc.input.help.resourceGroupName"
+    },
+    {
+      "name": "numOfSelfProvisionedAgents",
+      "type": "int",
+      "label": "ms-resource:loc.input.label.numOfSelfProvisionedAgents",
+      "required": false,
+      "defaultValue": 1,
+      "visibleRule": "machineType == 2",
+      "helpMarkDown": "ms-resource:loc.input.help.numOfSelfProvisionedAgents"
     },
     {
       "name": "avgResponseTimeThreshold",

--- a/Tasks/RunJMeterLoadTestV1/CltTasksUtility.ps1
+++ b/Tasks/RunJMeterLoadTestV1/CltTasksUtility.ps1
@@ -7,24 +7,29 @@ function InvokeRestMethod($headers, $contentType, $uri , $method= "Get", $body)
     return $result
 }
 
-function ComposeTestDropJson($name, $duration, $homepage, $vu, $geoLocation)
+function ComposeTestDropJson($name, $agentCount, $duration, $geoLocation)
 {
+    $coresPerAgent = 2
+    $coreCount = $agentCount*$coresPerAgent
     $tdjson = @"
     {
-        "dropType": "InplaceDrop",
+        "dropType": "TestServiceBlobDrop",
         "loadTestDefinition":{
             "loadTestName":"$name",
+            "agentCount":$agentCount,
             "runDuration":$duration,
-            "urls":["$homepage"],
-            "browserMixs":[
-                {"browserName":"Internet Explorer 11.0","browserPercentage":60.0},
-                {"browserName":"Chrome 2","browserPercentage":40.0}
-            ],
-            "loadPatternName":"Constant",
-            "maxVusers":$vu,
             "loadGenerationGeoLocations":[
                 {"Location":"$geoLocation","Percentage":100}
-            ]
+            ],
+
+            "coresPerAgent": $coresPerAgent,
+            "coreCount": $coreCount,
+            "samplingRate": 15,
+            "thinkTime": 0,
+            "urls": [],
+            "browserMixs": [],
+            "loadPatternName": "Constant",
+            "maxVusers": -1
         }
     }
 "@
@@ -32,10 +37,10 @@ function ComposeTestDropJson($name, $duration, $homepage, $vu, $geoLocation)
     return $tdjson
 }
 
-function CreateTestDrop($headers, $CltAccountUrl)
+function CreateTestDrop($headers, $dropjson, $CltAccountUrl)
 {
     $uri = [String]::Format("{0}/_apis/clt/testdrops?{1}", $CltAccountUrl, $global:apiVersion)
-    $drop = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers -method Post -body "{ ""dropType"": ""TestServiceBlobDrop"" }"
+    $drop = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers -method Post -body $dropJson
     return $drop
 }
 

--- a/Tasks/RunJMeterLoadTestV1/Start-ApacheJMeterTest.ps1
+++ b/Tasks/RunJMeterLoadTestV1/Start-ApacheJMeterTest.ps1
@@ -18,6 +18,8 @@ $LoadTest,
 $agentCount,
 [String] [Parameter(Mandatory = $true)]
 $runDuration,
+[String] [Parameter(Mandatory = $true)]
+$geoLocation,
 [String] [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()]
 $machineType
 )
@@ -86,6 +88,7 @@ import-module "Microsoft.TeamFoundation.DistributedTask.Task.DevTestLabs"
 
 Write-Output "Test drop = $TestDrop"
 Write-Output "Load test = $LoadTest"
+Write-Output "Load location = $geoLocation"
 Write-Output "Load generator machine type = $machineType"
 Write-Output "Run source identifier = build/$env:SYSTEM_DEFINITIONID/$env:BUILD_BUILDID"
 
@@ -116,7 +119,10 @@ Write-Output "CLT account Url = $CltAccountUrl" -Verbose
 
 #Upload the test drop
 $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
-$drop = CreateTestDrop $headers $CltAccountUrl
+
+$dropjson = ComposeTestDropJson $LoadTest $agentCount $runDuration $geoLocation
+
+$drop = CreateTestDrop $headers $dropjson $CltAccountUrl
 
 if ($drop.dropType -eq "TestServiceBlobDrop")
 {
@@ -159,7 +165,7 @@ if ($drop.dropType -eq "TestServiceBlobDrop")
 	Remove-Item $resultsMDFolder\$resultFilePattern -Exclude $excludeFilePattern -Force
 	$summaryFile =  ("{0}\ApacheJMeterTestResults_{1}_{2}_{3}_{4}.md" -f $resultsMDFolder, $env:AGENT_ID, $env:SYSTEM_DEFINITIONID, $env:BUILD_BUILDID, $run.id)
 
-	$summary = ('[Test Run: {0}]({1}) using {2}.<br/>' -f  $run.runNumber, $webResultsUrl , $run.name)
+	$summary = ('<a href="{1}" target="_blank">Test Run: {0}</a> using {2}.' -f  $run.runNumber, $webResultsUrl , $run.name)
 	
 	('<p>{0}</p>' -f $summary) | Out-File  $summaryFile -Encoding ascii -Append
 	UploadSummaryMdReport $summaryFile

--- a/Tasks/RunJMeterLoadTestV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/RunJMeterLoadTestV1/Strings/resources.resjson/en-US/resources.resjson
@@ -13,5 +13,7 @@
   "loc.input.help.agentCount": "Number of test agents (dual-core) used in the run.",
   "loc.input.label.runDuration": "Run Duration (sec)",
   "loc.input.help.runDuration": "Load test run duration in seconds.",
+  "loc.input.label.geoLocation": "Load Location",
+  "loc.input.help.geoLocation": "Geographical region to generate the load from.",
   "loc.input.label.machineType": "Run load test using"
 }

--- a/Tasks/RunJMeterLoadTestV1/task.json
+++ b/Tasks/RunJMeterLoadTestV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 19
+        "Patch": 20
     },
     "demands": [
         "azureps"
@@ -71,6 +71,37 @@
                 "180": "180",
                 "240": "240",
                 "300": "300"
+            }
+        },
+        {
+            "name": "geoLocation",
+            "type": "pickList",
+            "label": "Load Location",
+            "required": false,
+            "helpMarkDown": "Geographical region to generate the load from.",
+            "defaultValue": "Default",
+            "options": {
+                "Default": "Default",
+                "Australia East": "Australia East (New South Wales)",
+                "Australia Southeast": "Australia Southeast (Victoria)",
+                "Brazil South": "Brazil South (Sao Paulo State)",
+                "Central India": "Central India (Pune)",
+                "Central US": "Central US (Iowa)",
+                "East Asia": "East Asia (Hong Kong)",
+                "East US 2": "East US 2 (Virginia)",
+                "East US": "East US (Virginia)",
+                "Japan East": "Japan East (Saitama Prefecture)",
+                "Japan West": "Japan West (Osaka Prefecture)",
+                "North Central US": "North Central US (Illinois)",
+                "North Europe": "North Europe (Ireland)",
+                "South Central US": "South Central US (Texas)",
+                "South India": "South India (Chennai)",
+                "Southeast Asia": "Southeast Asia (Singapore)",
+                "West Europe": "West Europe (Netherlands)",
+                "West US": "West US (California)"
+            },
+            "properties": {
+                "EditableOptions": "True"
             }
         },
         {

--- a/Tasks/RunJMeterLoadTestV1/task.loc.json
+++ b/Tasks/RunJMeterLoadTestV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 19
+    "Patch": 20
   },
   "demands": [
     "azureps"
@@ -71,6 +71,37 @@
         "180": "180",
         "240": "240",
         "300": "300"
+      }
+    },
+    {
+      "name": "geoLocation",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.geoLocation",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.geoLocation",
+      "defaultValue": "Default",
+      "options": {
+        "Default": "Default",
+        "Australia East": "Australia East (New South Wales)",
+        "Australia Southeast": "Australia Southeast (Victoria)",
+        "Brazil South": "Brazil South (Sao Paulo State)",
+        "Central India": "Central India (Pune)",
+        "Central US": "Central US (Iowa)",
+        "East Asia": "East Asia (Hong Kong)",
+        "East US 2": "East US 2 (Virginia)",
+        "East US": "East US (Virginia)",
+        "Japan East": "Japan East (Saitama Prefecture)",
+        "Japan West": "Japan West (Osaka Prefecture)",
+        "North Central US": "North Central US (Illinois)",
+        "North Europe": "North Europe (Ireland)",
+        "South Central US": "South Central US (Texas)",
+        "South India": "South India (Chennai)",
+        "Southeast Asia": "Southeast Asia (Singapore)",
+        "West Europe": "West Europe (Netherlands)",
+        "West US": "West US (California)"
+      },
+      "properties": {
+        "EditableOptions": "True"
       }
     },
     {

--- a/Tasks/RunLoadTestV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/RunLoadTestV1/Strings/resources.resjson/en-US/resources.resjson
@@ -19,5 +19,9 @@
   "loc.input.help.TestSettings": "The testsettings file name to be used from the load test folder specified above or a full path. <ul><li><b>Build Example:</b><br /> $(System.DefaultWorkingDirectory)\\LoadTestproject\\bin\\$(BuildConfiguration)\\load.testsettings </li><li><b>Release Example:</b><br /> $(System.DefaultWorkingDirectory)\\SourceCI\\drop\\LoadTestproject\\bin\\Release\\load.testsettings <br />where SourceCI is the source alias and drop is artifact name</li></ul>",
   "loc.input.label.ThresholdLimit": "Number of permissible threshold violations",
   "loc.input.help.ThresholdLimit": "Number of threshold violations above which the load test outcome is considered unsuccessful.",
-  "loc.input.label.MachineType": "Run load test using"
+  "loc.input.label.MachineType": "Run load test using",
+  "loc.input.label.resourceGroupName": "Resource group rig",
+  "loc.input.help.resourceGroupName": "Name of Resource group hosting the self-provisioned rig of load test agents.",
+  "loc.input.label.numOfSelfProvisionedAgents": "No. of agents to use",
+  "loc.input.help.numOfSelfProvisionedAgents": "Number of self provisioned agents to use for this test."
 }

--- a/Tasks/RunLoadTestV1/task.json
+++ b/Tasks/RunLoadTestV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 27
+        "Patch": 28
     },
     "demands": [
         "msbuild",
@@ -110,7 +110,7 @@
             "type": "string",
             "label": "Resource group rig",
             "required": false,
-            "defaultValue": "",
+            "defaultValue": "default",
             "visibleRule": "MachineType == 2",
             "helpMarkDown": "Name of Resource group hosting the self-provisioned rig of load test agents."
         },
@@ -119,7 +119,7 @@
             "type": "int",
             "label": "No. of agents to use",
             "required": false,
-            "defaultValue": "",
+            "defaultValue": 1,
             "visibleRule": "MachineType == 2",
             "helpMarkDown": "Number of self provisioned agents to use for this test."
         }

--- a/Tasks/RunLoadTestV1/task.loc.json
+++ b/Tasks/RunLoadTestV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 27
+    "Patch": 28
   },
   "demands": [
     "msbuild",
@@ -104,6 +104,24 @@
         "0": "Automatically provisioned agents",
         "2": "Self-provisioned agents"
       }
+    },
+    {
+      "name": "resourceGroupName",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.resourceGroupName",
+      "required": false,
+      "defaultValue": "default",
+      "visibleRule": "MachineType == 2",
+      "helpMarkDown": "ms-resource:loc.input.help.resourceGroupName"
+    },
+    {
+      "name": "numOfSelfProvisionedAgents",
+      "type": "int",
+      "label": "ms-resource:loc.input.label.numOfSelfProvisionedAgents",
+      "required": false,
+      "defaultValue": 1,
+      "visibleRule": "MachineType == 2",
+      "helpMarkDown": "ms-resource:loc.input.help.numOfSelfProvisionedAgents"
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
(ported the commit 4286d1d)

Fixes:

1) Fixed a new domain issue with the quick web test task
Removed a check for hosted account where we were using hard coded URLs.
We are not doing any validation for hosted now – which is the case with other two tasks already.

2) Fixed an issue with the default values for self-provisioned rig option
Without default values for agent group and agent count the quick web test\load test tasks do fail
Defaults values --> agent group = default, number of agents = 1

3) Fixed a broken link issue with the JMeter result link on build summary, markdown fixed
It was already fixed for other two tasks earlier

Changes:

4) Geo location list for tasks is updated to add India locations –- South India, Central India

5) Added geo location input in the JMeter task –- it was not present earlier

6) The geo location list is now sorted -- it was not sorted earlier