### PR TITLE
Create NuGet package per task.

### DIFF
--- a/ci/ci-util.js
+++ b/ci/ci-util.js
@@ -25,8 +25,6 @@ var aggregatePackageName = 'Mseng.MS.TF.Build.Tasks';
 var aggregateNuspecPath = path.join(packagePath, 'Mseng.MS.TF.Build.Tasks.nuspec');
 var publishLayoutPath = path.join(packagePath, 'publish-layout');
 var publishPushCmdPath = path.join(packagePath, 'publish-layout', 'push.cmd');
-var perTaskLayoutPath = path.join(packagePath, 'per-task-layout'); // TODO: Is this being used?
-var perTaskPublishPath = path.join(packagePath, 'per-task-publish'); // TODO: Is this being used?
 
 exports.buildTasksPath = buildTasksPath;
 exports.packagePath = packagePath;
@@ -46,8 +44,6 @@ exports.aggregatePackageName = aggregatePackageName;
 exports.aggregateNuspecPath = aggregateNuspecPath;
 exports.publishLayoutPath = publishLayoutPath;
 exports.publishPushCmdPath = publishPushCmdPath;
-exports.perTaskLayoutPath = perTaskLayoutPath;
-exports.perTaskPublishPath = perTaskPublishPath;
 
 //------------------------------------------------------------------------------
 // generic functions
@@ -233,11 +229,6 @@ var linkAggregateLayoutContent = function (sourceRoot, destRoot, release, commit
             var sourceVersion = `${sourceTask.version.Major}.${sourceTask.version.Minor}.${sourceTask.version.Patch}`;
             var destVersion = `${destTask.version.Major}.${destTask.version.Minor}.${destTask.version.Patch}`;
             if (semver.gt(sourceVersion, destVersion)) {
-                console.log(`Source path: ${taskSourcePath}`);
-                console.log(`Source version: ${sourceVersion}`);
-                console.log(`Destination path: ${taskDestPath}`);
-                console.log(`Destination version: ${destVersion}`);
-
                 throw new Error(`Expected minor+patch version for task already in the aggregate layout, to be greater or equal than non-aggregate layout being merged. Source task: ${taskSourcePath}`);
             }
         }

--- a/ci/ci-util.js
+++ b/ci/ci-util.js
@@ -24,7 +24,9 @@ var aggregatePackSourceContentsZipPath = path.join(packagePath, 'aggregate-pack-
 var aggregatePackageName = 'Mseng.MS.TF.Build.Tasks';
 var aggregateNuspecPath = path.join(packagePath, 'Mseng.MS.TF.Build.Tasks.nuspec');
 var publishLayoutPath = path.join(packagePath, 'publish-layout');
-var publishPushCmdPath = path.join(packagePath, 'publish-layout', 'push.cmd');
+var perTaskLayoutPath = path.join(packagePath, 'per-task-layout'); // TODO: Is this being used?
+var perTaskPublishPath = path.join(packagePath, 'per-task-publish'); // TODO: Is this being used?
+
 exports.buildTasksPath = buildTasksPath;
 exports.packagePath = packagePath;
 exports.tasksLayoutPath = tasksLayoutPath;
@@ -42,7 +44,8 @@ exports.aggregatePackSourceContentsZipPath = aggregatePackSourceContentsZipPath;
 exports.aggregatePackageName = aggregatePackageName;
 exports.aggregateNuspecPath = aggregateNuspecPath;
 exports.publishLayoutPath = publishLayoutPath;
-exports.publishPushCmdPath = publishPushCmdPath;
+exports.perTaskLayoutPath = perTaskLayoutPath;
+exports.perTaskPublishPath = perTaskPublishPath;
 
 //------------------------------------------------------------------------------
 // generic functions
@@ -228,6 +231,11 @@ var linkAggregateLayoutContent = function (sourceRoot, destRoot, release, commit
             var sourceVersion = `${sourceTask.version.Major}.${sourceTask.version.Minor}.${sourceTask.version.Patch}`;
             var destVersion = `${destTask.version.Major}.${destTask.version.Minor}.${destTask.version.Patch}`;
             if (semver.gt(sourceVersion, destVersion)) {
+                console.log(`Source path: ${taskSourcePath}`);
+                console.log(`Source version: ${sourceVersion}`);
+                console.log(`Destination path: ${taskDestPath}`);
+                console.log(`Destination version: ${destVersion}`);
+
                 throw new Error(`Expected minor+patch version for task already in the aggregate layout, to be greater or equal than non-aggregate layout being merged. Source task: ${taskSourcePath}`);
             }
         }

--- a/ci/ci-util.js
+++ b/ci/ci-util.js
@@ -24,6 +24,7 @@ var aggregatePackSourceContentsZipPath = path.join(packagePath, 'aggregate-pack-
 var aggregatePackageName = 'Mseng.MS.TF.Build.Tasks';
 var aggregateNuspecPath = path.join(packagePath, 'Mseng.MS.TF.Build.Tasks.nuspec');
 var publishLayoutPath = path.join(packagePath, 'publish-layout');
+var publishPushCmdPath = path.join(packagePath, 'publish-layout', 'push.cmd');
 var perTaskLayoutPath = path.join(packagePath, 'per-task-layout'); // TODO: Is this being used?
 var perTaskPublishPath = path.join(packagePath, 'per-task-publish'); // TODO: Is this being used?
 
@@ -44,6 +45,7 @@ exports.aggregatePackSourceContentsZipPath = aggregatePackSourceContentsZipPath;
 exports.aggregatePackageName = aggregatePackageName;
 exports.aggregateNuspecPath = aggregateNuspecPath;
 exports.publishLayoutPath = publishLayoutPath;
+exports.publishPushCmdPath = publishPushCmdPath;
 exports.perTaskLayoutPath = perTaskLayoutPath;
 exports.perTaskPublishPath = perTaskPublishPath;
 

--- a/ci/ci-util.js
+++ b/ci/ci-util.js
@@ -25,7 +25,6 @@ var aggregatePackageName = 'Mseng.MS.TF.Build.Tasks';
 var aggregateNuspecPath = path.join(packagePath, 'Mseng.MS.TF.Build.Tasks.nuspec');
 var publishLayoutPath = path.join(packagePath, 'publish-layout');
 var publishPushCmdPath = path.join(packagePath, 'publish-layout', 'push.cmd');
-
 exports.buildTasksPath = buildTasksPath;
 exports.packagePath = packagePath;
 exports.tasksLayoutPath = tasksLayoutPath;

--- a/ci/publish-steps.yml
+++ b/ci/publish-steps.yml
@@ -60,6 +60,18 @@ steps:
     artifactName: TaskPackage
     publishLocation: container
 
+# Stage per task NuGet package
+- script: npm run layout
+  displayName: npm run layout
+
+# Publish per task NuGet package artifact
+- task: PublishBuildArtifacts@1
+  displayName: Publish per task NuGet package artifact
+  inputs:
+    pathToPublish: _package/per-task-publish # is this still correct with the new local build?
+    artifactName: PerTaskPackages
+    publishLocation: container
+
 # Publish milestone package
 - task: NuGetCommand@2
   displayName: Publish milestone package

--- a/ci/publish-steps.yml
+++ b/ci/publish-steps.yml
@@ -69,7 +69,7 @@ steps:
   displayName: Publish per task NuGet package artifact
   inputs:
     pathToPublish: _package/nuget-packages
-    artifactName: PerTaskPackages
+    artifactName: IndividualNuGetPackages
     publishLocation: container
 
 # Publish milestone package

--- a/ci/publish-steps.yml
+++ b/ci/publish-steps.yml
@@ -61,8 +61,8 @@ steps:
     publishLocation: container
 
 # Stage per task NuGet package
-- script: npm run layout
-  displayName: npm run layout
+- script: npm run package
+  displayName: npm run package
 
 # Publish per task NuGet package artifact
 - task: PublishBuildArtifacts@1

--- a/ci/publish-steps.yml
+++ b/ci/publish-steps.yml
@@ -68,7 +68,7 @@ steps:
 - task: PublishBuildArtifacts@1
   displayName: Publish per task NuGet package artifact
   inputs:
-    pathToPublish: _package/artifacts
+    pathToPublish: _package/nuget-packages
     artifactName: PerTaskPackages
     publishLocation: container
 

--- a/ci/publish-steps.yml
+++ b/ci/publish-steps.yml
@@ -68,7 +68,7 @@ steps:
 - task: PublishBuildArtifacts@1
   displayName: Publish per task NuGet package artifact
   inputs:
-    pathToPublish: _package/per-task-publish # is this still correct with the new local build?
+    pathToPublish: _package/artifacts
     artifactName: PerTaskPackages
     publishLocation: container
 

--- a/make-util.js
+++ b/make-util.js
@@ -1223,15 +1223,16 @@ exports.createNonAggregatedZip = createNonAggregatedZip;
  * 
  * Within the function we create an artifacts folder, this is what gets uploaded when we are done.
  * The contents look something like:
- * /AndroidSigningV2
+ * /artifacts
+ *  /AndroidSigningV2
  *      /Mseng.MS.TF.DistributedTask.Tasks.AndroidSigningV2.2.135.0.nupkg
  *      /push.cmd
  *  /AnotherTask
  *      /Mseng.MS.TF.DistributedTask.Tasks.AnotherTaskV1.1.0.0.nupkg
- *     /push.cmd
- * push.cmd * Root push.cmd that runs all nested push.cmd's.
- * servicing.xml * Convenience file. Generates all XML to update servicing configuration for tasks.
- * unified_deps.xml * Convenience file. Generates all XML to update unified dependencies file.
+ *      /push.cmd
+ *  /push.cmd * Root push.cmd that runs all nested push.cmd's.
+ *  /servicing.xml * Convenience file. Generates all XML to update servicing configuration for tasks.
+ *  /unified_deps.xml * Convenience file. Generates all XML to update unified dependencies file.
  * 
  * @param {*} packagePath Path of _packages folder.
  * @param {*} layoutPath Path that has task layouts.
@@ -1293,7 +1294,7 @@ var createNugetPackagePerTask = function (packagePath, /*nonAggregatedLayoutPath
             mkdir('-p', taskZipPath);
             console.log('root task folder: ' + taskZipPath);
 
-            // TOOD: This is probably slow. Check other code to do hard sync?
+            // TOOD: This is probably slow. Maybe look into a way to do it faster.
             fs.copyFileSync(path.join(taskLayoutPath, 'task.zip'), path.join(taskZipPath, 'task.zip'));
 
             // Write layout version file. This will help us if we change the structure of the individual NuGet packages in the future.

--- a/make-util.js
+++ b/make-util.js
@@ -1309,7 +1309,7 @@ var createNugetPackagePerTask = function (packagePath, /*nonAggregatedLayoutPath
         });
 
     console.log();
-    console.log('> Creating root push.cmd')
+    console.log('> Creating root push.cmd');
     createRootPushCmd(nugetPackagesPath);
 
     // Write file that has XML for unified dependencies, makes it easier to setup that file.

--- a/make-util.js
+++ b/make-util.js
@@ -1210,29 +1210,32 @@ var createNonAggregatedZip = function (buildPath, packagePath) {
 }
 exports.createNonAggregatedZip = createNonAggregatedZip;
 
-// Overview:
-// 
-// Create a NuGet package per task. This function assumes the tasks are already laid out on disk.
-// 
-// When running locally, layoutPath is something like: _package\non-aggregated-layout
-// Within this folder we have one of these folders per task:
-//  /CmdLineV2
-//      /Strings
-//      /task.json
-//      /task.loc.json
-//      /task.zip
-// 
-// Within the function we create an artifacts folder, this is what gets uploaded when we are done.
-// The contents look something like:
-//  /AndroidSigningV2
-//      /Mseng.MS.TF.DistributedTask.Tasks.AndroidSigningV2.2.135.0.nupkg
-//      /push.cmd
-//  /AnotherTask
-//      /Mseng.MS.TF.DistributedTask.Tasks.AnotherTaskV1.1.0.0.nupkg
-//      /push.cmd
-// push.cmd * Root push.cmd that runs all nested push.cmd's.
-// servicing.xml * Convenience file. Generates all XML to update servicing configuration for tasks.
-// unified_deps.xml * Convenience file. Generates all XML to update unified dependencies file.
+/**
+ * Create a NuGet package per task. This function assumes the tasks are already laid out on disk.
+ * 
+ * When running locally, layoutPath is something like: _package\non-aggregated-layout
+ * Within this folder we have one of these folders per task:
+ *  /CmdLineV2
+ *      /Strings
+ *      /task.json
+ *      /task.loc.json
+ *      /task.zip
+ * 
+ * Within the function we create an artifacts folder, this is what gets uploaded when we are done.
+ * The contents look something like:
+ * /AndroidSigningV2
+ *      /Mseng.MS.TF.DistributedTask.Tasks.AndroidSigningV2.2.135.0.nupkg
+ *      /push.cmd
+ *  /AnotherTask
+ *      /Mseng.MS.TF.DistributedTask.Tasks.AnotherTaskV1.1.0.0.nupkg
+ *     /push.cmd
+ * push.cmd * Root push.cmd that runs all nested push.cmd's.
+ * servicing.xml * Convenience file. Generates all XML to update servicing configuration for tasks.
+ * unified_deps.xml * Convenience file. Generates all XML to update unified dependencies file.
+ * 
+ * @param {*} packagePath Path of _packages folder.
+ * @param {*} layoutPath Path that has task layouts.
+ */
 var createNugetPackagePerTask = function (packagePath, /*nonAggregatedLayoutPath*/layoutPath) {
     console.log();
     console.log('> Creating NuGet package per task')

--- a/make.js
+++ b/make.js
@@ -486,6 +486,7 @@ target.layout = function() {
     var layoutPath = util.createNonAggregatedZip(buildPath, packagePath);
 
     console.log('layout path: ' + layoutPath);
+    // TODO: What is the layout path when running in CI?
     util.createNugetPackagePerTask(packagePath, layoutPath);
 
     // These methods are to help with the migration to NuGet package per task.

--- a/make.js
+++ b/make.js
@@ -474,12 +474,11 @@ target.testLegacy = function() {
 }
 
 // 
-// node make.js layout
+// node make.js package
 // This will take the built tasks and create the files we need to publish them.
 // 
-target.layout = function() {
-    banner('Starting layout process...')
-
+target.package = function() {
+    banner('Starting package process...')
 
     // START LOCAL CONFIG
     // console.log('> Cleaning packge path');
@@ -495,42 +494,8 @@ target.layout = function() {
 
     // These methods are to help with the migration to NuGet package per task.
     // Get rid of them after transition is done.
-    //renameFoldersFromAggregate('E:\\AllTaskMajorVersions');
-    //generatePerTaskForLegacyPackages('E:\\AllTaskMajorVersions');
-}
-
-// Rename task folders that are created from the aggregate. Allows NuGet generation from aggregate using same process as normal.
-function renameFoldersFromAggregate(pathWithLegacyFolders) {
-    // Rename folders
-    fs.readdirSync(pathWithLegacyFolders)
-        .forEach(function (taskFolderName) {
-            if (taskFolderName.charAt(taskFolderName.length-1) === taskFolderName.charAt(taskFolderName.length-1)
-                && taskFolderName.charAt(taskFolderName.length-2) === taskFolderName.charAt(taskFolderName.length-4))
-            {
-                var currentPath = path.join(pathWithLegacyFolders, taskFolderName);
-                var newPath = path.join(pathWithLegacyFolders, taskFolderName.substring(0, taskFolderName.length - 2));
-
-                fs.renameSync(currentPath, newPath);
-            }
-
-            // var currentPath = path.join('E:\\AllTaskMajorVersions', taskFolderName);
-            // var s = taskFolderName.split('__');
-            // var newFolderName = s[0] + s[1].toUpperCase();
-            // var newPath = path.join('E:\\AllTaskMajorVersions', newFolderName);
-            
-            // fs.renameSync(currentPath, newPath);
-        });
-}
-
-// Use the main layout process on Task folders that were extracted from the aggregate.
-// This is what we use to seed packaging with older major versions.
-function generatePerTaskForLegacyPackages(pathWithLegacyFolders) {
-    // Generate NuGet package per task for legacy packages.
-    var legacyPath = path.join(__dirname, '_packageLegacy');
-    if (test('-d', legacyPath)) {
-        rm('-rf', legacyPath);
-    }
-    util.createNugetPackagePerTask(legacyPath, pathWithLegacyFolders);
+    //util.renameFoldersFromAggregate('E:\\AllTaskMajorVersions');
+    //util.generatePerTaskForLegacyPackages('E:\\AllTaskMajorVersions');
 }
 
 // used by CI that does official publish

--- a/make.js
+++ b/make.js
@@ -473,56 +473,56 @@ target.testLegacy = function() {
     run('mocha ' + testsSpecPath, /*inheritStreams:*/true);
 }
 
-target.package = function() {
-    // clean
+// 
+// node make.js layout
+// This will take the built tasks and create the files we need to publish them.
+// 
+target.layout = function() {
+    banner('Starting layout process...')
+
+    console.log('> Cleaning packge path');
     rm('-Rf', packagePath);
 
-    // create the non-aggregated layout
-    util.createNonAggregatedZip(buildPath, packagePath);
+    var layoutPath = util.createNonAggregatedZip(buildPath, packagePath);
 
-    // if task specified, create hotfix layout and short-circuit
-    if (options.task) {
-        util.createHotfixLayout(packagePath, options.task);
-        return;
+    console.log('layout path: ' + layoutPath);
+    util.createNugetPackagePerTask(packagePath, layoutPath);
+
+    // These methods are to help with the migration to NuGet package per task.
+    // Get rid of them after transition is done.
+    //renameFoldersFromAggregate('E:\\AllTaskMajorVersions');
+    //generatePerTaskForLegacyPackages('E:\\AllTaskMajorVersions');
+}
+
+function renameFoldersFromAggregate(pathWithLegacyFolders) {
+    // Rename folders
+    fs.readdirSync('E:\\AllTaskMajorVersions')
+        .forEach(function (taskFolderName) {
+            if (taskFolderName.charAt(taskFolderName.length-1) === taskFolderName.charAt(taskFolderName.length-1)
+                && taskFolderName.charAt(taskFolderName.length-2) === taskFolderName.charAt(taskFolderName.length-4))
+            {
+                var currentPath = path.join(pathWithLegacyFolders, taskFolderName);
+                var newPath = path.join(pathWithLegacyFolders, taskFolderName.substring(0, taskFolderName.length - 2));
+
+                fs.renameSync(currentPath, newPath);
+            }
+
+            // var currentPath = path.join('E:\\AllTaskMajorVersions', taskFolderName);
+            // var s = taskFolderName.split('__');
+            // var newFolderName = s[0] + s[1].toUpperCase();
+            // var newPath = path.join('E:\\AllTaskMajorVersions', newFolderName);
+            
+            // fs.renameSync(currentPath, newPath);
+        });
+}
+
+function generatePerTaskForLegacyPackages(pathWithLegacyFolders) {
+    // Generate NuGet package per task for legacy packages.
+    var legacyPath = path.join(__dirname, '_packageLegacy');
+    if (test('-d', legacyPath)) {
+        rm('-rf', legacyPath);
     }
-
-    // create the aggregated tasks layout
-    util.createAggregatedZip(packagePath);
-
-    // nuspec
-    var version = options.version;
-    if (!version) {
-        console.warn('Skipping nupkg creation. Supply version with --version.');
-        return;
-    }
-
-    if (!semver.valid(version)) {
-        fail('invalid semver version: ' + version);
-    }
-
-    var pkgName = 'Mseng.MS.TF.Build.Tasks';
-    console.log();
-    console.log('> Generating .nuspec file');
-    var contents = '<?xml version="1.0" encoding="utf-8"?>' + os.EOL;
-    contents += '<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">' + os.EOL;
-    contents += '   <metadata>' + os.EOL;
-    contents += '      <id>' + pkgName + '</id>' + os.EOL;
-    contents += '      <version>' + version + '</version>' + os.EOL;
-    contents += '      <authors>bigbldt</authors>' + os.EOL;
-    contents += '      <owners>bigbldt,Microsoft</owners>' + os.EOL;
-    contents += '      <requireLicenseAcceptance>false</requireLicenseAcceptance>' + os.EOL;
-    contents += '      <description>For VSS internal use only</description>' + os.EOL;
-    contents += '      <tags>VSSInternal</tags>' + os.EOL;
-    contents += '   </metadata>' + os.EOL;
-    contents += '</package>' + os.EOL;
-    var nuspecPath = path.join(packagePath, 'pack-source', pkgName + '.nuspec');
-    fs.writeFileSync(nuspecPath, contents);
-
-    // package
-    ensureTool('nuget.exe');
-    var nupkgPath = path.join(packagePath, 'pack-target', `${pkgName}.${version}.nupkg`);
-    mkdir('-p', path.dirname(nupkgPath));
-    run(`nuget.exe pack ${nuspecPath} -OutputDirectory ${path.dirname(nupkgPath)}`);
+    util.createNugetPackagePerTask(legacyPath, pathWithLegacyFolders);
 }
 
 // used by CI that does official publish

--- a/make.js
+++ b/make.js
@@ -480,8 +480,11 @@ target.testLegacy = function() {
 target.layout = function() {
     banner('Starting layout process...')
 
-    console.log('> Cleaning packge path');
-    rm('-Rf', packagePath);
+    var files = getAllFiles(path.join(__dirname, '_package'));
+    files.forEach((x) => console.log(x));
+
+    // console.log('> Cleaning packge path');
+    // rm('-Rf', packagePath);
 
     var layoutPath = util.createNonAggregatedZip(buildPath, packagePath);
 
@@ -494,6 +497,19 @@ target.layout = function() {
     //renameFoldersFromAggregate('E:\\AllTaskMajorVersions');
     //generatePerTaskForLegacyPackages('E:\\AllTaskMajorVersions');
 }
+
+/**
+ * Find all files inside a dir, recursively.
+ * @function getAllFiles
+ * @param  {string} dir Dir path string.
+ * @return {string[]} Array with all file names that are inside the directory.
+ */
+const getAllFiles = dir =>
+  fs.readdirSync(dir).reduce((files, file) => {
+    const name = path.join(dir, file);
+    const isDirectory = fs.statSync(name).isDirectory();
+    return isDirectory ? [...files, ...getAllFiles(name)] : [...files, name];
+  }, []);
 
 function renameFoldersFromAggregate(pathWithLegacyFolders) {
     // Rename folders

--- a/make.js
+++ b/make.js
@@ -486,10 +486,13 @@ target.layout = function() {
     // console.log('> Cleaning packge path');
     // rm('-Rf', packagePath);
 
-    var layoutPath = util.createNonAggregatedZip(buildPath, packagePath);
+    // TODO: Only need this when we run locally
+    //var layoutPath = util.createNonAggregatedZip(buildPath, packagePath);
+    var layoutPath = path.join(packagePath, 'milestone-layout');
 
     console.log('layout path: ' + layoutPath);
     // TODO: What is the layout path when running in CI?
+    
     util.createNugetPackagePerTask(packagePath, layoutPath);
 
     // These methods are to help with the migration to NuGet package per task.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "node make.js build",
     "test": "node make.js test",
     "testLegacy": "node make.js testLegacy",
-    "layout": "node make.js layout"
+    "package": "node make.js package"
   },
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/Microsoft/vsts-tasks",
   "devDependencies": {
-    "adm-zip": "0.4.11",
+    "adm-zip": "0.4.7",
     "gulp": "3.9.0",
     "gulp-util": "3.0.4",
     "markdown-toc": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "node make.js build",
     "test": "node make.js test",
-    "testLegacy": "node make.js testLegacy"
+    "testLegacy": "node make.js testLegacy",
+    "layout": "node make.js layout"
   },
   "repository": {
     "type": "git",
@@ -27,7 +28,7 @@
   },
   "homepage": "https://github.com/Microsoft/vsts-tasks",
   "devDependencies": {
-    "adm-zip": "0.4.7",
+    "adm-zip": "0.4.11",
     "gulp": "3.9.0",
     "gulp-util": "3.0.4",
     "markdown-toc": "^1.2.0",


### PR DESCRIPTION
This change allows us to build a NuGet package per task. The code will run side by side with creating an aggregate until we have fully moved to the new system.

The main change is to run 'npm run layout' in CI then push the artifacts. This change has been designed to run both locally and in CI. There are some places in the code that are a little quirky to make this run side by side. That's due to the complexity of building in CI right now with slices. Once we can get rid of that this code will become simpler and we will be able to do the entire build/layout process locally as well as remotely.

Tested end to end using a local NuGet server with several variations of no tasks from NuGet package per task, a few, and all.