### PR TITLE
Remove preview from tasks

### DIFF
--- a/Tasks/BashV3/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/BashV3/Strings/resources.resjson/en-US/resources.resjson
@@ -1,9 +1,9 @@
 {
   "loc.friendlyName": "Bash",
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613738)",
-  "loc.description": "This is an early preview. Run a Bash script on macOS, Linux, or Windows",
+  "loc.description": "Run a Bash script on macOS, Linux, or Windows",
   "loc.instanceNameFormat": "Bash Script",
-  "loc.releaseNotes": "This is an early preview. Script task consistency. Added support for multiple lines and added support for Windows.",
+  "loc.releaseNotes": "Script task consistency. Added support for multiple lines and added support for Windows.",
   "loc.group.displayName.advanced": "Advanced",
   "loc.input.label.targetType": "Type",
   "loc.input.help.targetType": "Target script type: File Path or Inline",

--- a/Tasks/BashV3/task.json
+++ b/Tasks/BashV3/task.json
@@ -2,7 +2,7 @@
     "id": "6C731C3C-3C68-459A-A5C9-BDE6E6595B5B",
     "name": "Bash",
     "friendlyName": "Bash",
-    "description": "This is an early preview. Run a Bash script on macOS, Linux, or Windows",
+    "description": "Run a Bash script on macOS, Linux, or Windows",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613738)",
     "category": "Utility",
     "visibility": [
@@ -16,10 +16,10 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 135,
-        "Patch": 1
+        "Minor": 136,
+        "Patch": 0
     },
-    "releaseNotes": "This is an early preview. Script task consistency. Added support for multiple lines and added support for Windows.",
+    "releaseNotes": "Script task consistency. Added support for multiple lines and added support for Windows.",
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "Bash Script",
     "showEnvironmentVariables": true,

--- a/Tasks/BashV3/task.loc.json
+++ b/Tasks/BashV3/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 135,
-    "Patch": 1
+    "Minor": 136,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.115.0",

--- a/Tasks/CmdLineV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CmdLineV2/Strings/resources.resjson/en-US/resources.resjson
@@ -1,9 +1,9 @@
 {
   "loc.friendlyName": "Command Line",
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613735)",
-  "loc.description": "This is an early preview. Run a command line script using cmd.exe on Windows and bash on macOS and Linux.",
+  "loc.description": "Run a command line script using cmd.exe on Windows and bash on macOS and Linux.",
   "loc.instanceNameFormat": "Command Line Script",
-  "loc.releaseNotes": "This is an early preview. Script task consistency. Added support for multiple lines.",
+  "loc.releaseNotes": "Script task consistency. Added support for multiple lines.",
   "loc.group.displayName.advanced": "Advanced",
   "loc.input.label.script": "Script",
   "loc.input.label.workingDirectory": "Working Directory",

--- a/Tasks/CmdLineV2/task.json
+++ b/Tasks/CmdLineV2/task.json
@@ -2,7 +2,7 @@
     "id": "D9BAFED4-0B18-4F58-968D-86655B4D2CE9",
     "name": "CmdLine",
     "friendlyName": "Command Line",
-    "description": "This is an early preview. Run a command line script using cmd.exe on Windows and bash on macOS and Linux.",
+    "description": "Run a command line script using cmd.exe on Windows and bash on macOS and Linux.",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613735)",
     "category": "Utility",
     "visibility": [
@@ -16,10 +16,10 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 135,
+        "Minor": 136,
         "Patch": 0
     },
-    "releaseNotes": "This is an early preview. Script task consistency. Added support for multiple lines.",
+    "releaseNotes": "Script task consistency. Added support for multiple lines.",
     "showEnvironmentVariables": true,
     "groups": [
         {

--- a/Tasks/CmdLineV2/task.loc.json
+++ b/Tasks/CmdLineV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 135,
+    "Minor": 136,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/CondaEnvironmentV0/Tests/package-lock.json
+++ b/Tasks/CondaEnvironmentV0/Tests/package-lock.json
@@ -79,11 +79,11 @@
       "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
-        "lolex": "^2.3.2",
-        "path-to-regexp": "^1.7.0",
-        "text-encoding": "^0.6.4"
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.3.2",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
       }
     },
     "path-to-regexp": {
@@ -107,13 +107,13 @@
       "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.1.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.2.0",
-        "nise": "^1.2.0",
-        "supports-color": "^5.1.0",
-        "type-detect": "^4.0.5"
+        "@sinonjs/formatio": "2.0.0",
+        "diff": "3.5.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.2",
+        "nise": "1.3.3",
+        "supports-color": "5.4.0",
+        "type-detect": "4.0.8"
       }
     },
     "supports-color": {
@@ -122,7 +122,7 @@
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "text-encoding": {

--- a/Tasks/CondaEnvironmentV0/package-lock.json
+++ b/Tasks/CondaEnvironmentV0/package-lock.json
@@ -24,7 +24,7 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "6.0.101"
       }
     },
     "balanced-match": {
@@ -37,7 +37,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -51,7 +51,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {
@@ -109,11 +109,11 @@
       "integrity": "sha512-AqKNrYw6ebzlaV6o09TTWE9LxcywQPanPeocss8BUJXJFEMLRYr3ZyzzjM+lvvsgcYth74VXoHtkBonBpx//Tg==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.2.1"
       }
     },
     "vsts-task-tool-lib": {
@@ -121,12 +121,12 @@
       "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.8.1.tgz",
       "integrity": "sha512-j8li9hCPnkMRyEihQyeCaNtZp0cSu6JaCOCeEXkgLMqLS3snGWTjbqX4gnzifjiTWT1noOeINq7VWuJYkeiygg==",
       "requires": {
-        "@types/semver": "^5.3.0",
-        "@types/uuid": "^3.0.1",
-        "semver": "^5.3.0",
-        "semver-compare": "^1.0.0",
+        "@types/semver": "5.5.0",
+        "@types/uuid": "3.4.3",
+        "semver": "5.5.0",
+        "semver-compare": "1.0.0",
         "typed-rest-client": "1.0.7",
-        "uuid": "^3.0.1",
+        "uuid": "3.2.1",
         "vsts-task-lib": "2.0.6"
       },
       "dependencies": {
@@ -135,12 +135,12 @@
           "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.6.tgz",
           "integrity": "sha1-9sqGS3sDsS23N8nV/2kThGNpEFY=",
           "requires": {
-            "minimatch": "^3.0.0",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
+            "minimatch": "3.0.4",
+            "mockery": "1.7.0",
+            "q": "1.5.1",
+            "semver": "5.5.0",
+            "shelljs": "0.3.0",
+            "uuid": "3.2.1"
           }
         }
       }

--- a/Tasks/CondaEnvironmentV0/task.json
+++ b/Tasks/CondaEnvironmentV0/task.json
@@ -12,10 +12,9 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 135,
+        "Minor": 136,
         "Patch": 0
     },
-    "preview": true,
     "demands": [],
     "instanceNameFormat": "Conda Environment $(environmentName)",
     "groups": [

--- a/Tasks/CondaEnvironmentV0/task.loc.json
+++ b/Tasks/CondaEnvironmentV0/task.loc.json
@@ -12,10 +12,9 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 135,
+    "Minor": 136,
     "Patch": 0
   },
-  "preview": true,
   "demands": [],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [

--- a/Tasks/InstallSSHKeyV0/package-lock.json
+++ b/Tasks/InstallSSHKeyV0/package-lock.json
@@ -43,25 +43,9 @@
     },
     "securefiles-common": {
       "version": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
-      "integrity": "sha1-14h8XFpcR5pfmMQG6/WwyK2Fs6Y=",
       "requires": {
-        "vso-node-api": "6.1.2-preview",
-        "vsts-task-lib": "2.2.1"
-      },
-      "dependencies": {
-        "vsts-task-lib": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.2.1.tgz",
-          "integrity": "sha512-FYllK73r1K7+sPUtWKZ4tihskJgpGB3YdNX4qr1YO0cmhFAWHm9FfEVxmKdlNeIyDtu3NyRb4wVUz0Gwi5LyGA==",
-          "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.5.1",
-            "semver": "5.5.0",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
-          }
-        }
+        "vso-node-api": "6.5.0",
+        "vsts-task-lib": "2.0.5"
       }
     },
     "semver": {
@@ -80,9 +64,9 @@
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
-      "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
+      "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
       "requires": {
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
@@ -99,13 +83,12 @@
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "vso-node-api": {
-      "version": "6.1.2-preview",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.1.2-preview.tgz",
-      "integrity": "sha1-qrNUbfJFHs2JTgcbuZtd8Zxfp48=",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
+      "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
       "requires": {
-        "q": "1.5.1",
         "tunnel": "0.0.4",
-        "typed-rest-client": "0.9.0",
+        "typed-rest-client": "0.12.0",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/InstallSSHKeyV0/task.json
+++ b/Tasks/InstallSSHKeyV0/task.json
@@ -9,11 +9,10 @@
         "Build",
         "Release"
     ],
-    "preview": true,
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 119,
+        "Minor": 136,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallSSHKeyV0/task.loc.json
+++ b/Tasks/InstallSSHKeyV0/task.loc.json
@@ -9,11 +9,10 @@
     "Build",
     "Release"
   ],
-  "preview": true,
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 119,
+    "Minor": 136,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -12,10 +12,9 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 134,
-        "Patch": 1
+        "Minor": 136,
+        "Patch": 0
     },
-    "preview": true,
     "satisfies": ["Java"],
     "demands": [],
     "groups": [

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -12,10 +12,9 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 134,
-    "Patch": 1
+    "Minor": 136,
+    "Patch": 0
   },
-  "preview": true,
   "satisfies": [
     "Java"
   ],

--- a/Tasks/PowerShellV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/en-US/resources.resjson
@@ -1,9 +1,9 @@
 {
   "loc.friendlyName": "PowerShell",
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613736)",
-  "loc.description": "This is an early preview. Run a PowerShell script on Windows, macOS, or Linux.",
+  "loc.description": "Run a PowerShell script on Windows, macOS, or Linux.",
   "loc.instanceNameFormat": "PowerShell Script",
-  "loc.releaseNotes": "This is an early preview. Script task consistency. Added support for macOS and Linux.",
+  "loc.releaseNotes": "Script task consistency. Added support for macOS and Linux.",
   "loc.group.displayName.advanced": "Advanced",
   "loc.input.label.targetType": "Type",
   "loc.input.help.targetType": "Target script type: File Path or Inline",

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -2,7 +2,7 @@
     "id": "E213FF0F-5D5C-4791-802D-52EA3E7BE1F1",
     "name": "PowerShell",
     "friendlyName": "PowerShell",
-    "description": "This is an early preview. Run a PowerShell script on Windows, macOS, or Linux.",
+    "description": "Run a PowerShell script on Windows, macOS, or Linux.",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613736)",
     "category": "Utility",
     "visibility": [
@@ -16,10 +16,10 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 135,
+        "Minor": 136,
         "Patch": 0
     },
-    "releaseNotes": "This is an early preview. Script task consistency. Added support for macOS and Linux.",
+    "releaseNotes": "Script task consistency. Added support for macOS and Linux.",
     "minimumAgentVersion": "2.115.0",
     "showEnvironmentVariables": true,
     "groups": [

--- a/Tasks/PowerShellV2/task.loc.json
+++ b/Tasks/PowerShellV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 135,
+    "Minor": 136,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/PythonScriptV0/package-lock.json
+++ b/Tasks/PythonScriptV0/package-lock.json
@@ -19,7 +19,7 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "6.0.110"
       }
     },
     "balanced-match": {
@@ -32,7 +32,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -46,7 +46,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {
@@ -80,11 +80,11 @@
       "integrity": "sha512-AqKNrYw6ebzlaV6o09TTWE9LxcywQPanPeocss8BUJXJFEMLRYr3ZyzzjM+lvvsgcYth74VXoHtkBonBpx//Tg==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.2.1"
       }
     }
   }

--- a/Tasks/PythonScriptV0/task.json
+++ b/Tasks/PythonScriptV0/task.json
@@ -16,10 +16,9 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 135,
+        "Minor": 136,
         "Patch": 0
     },
-    "preview": true,
     "demands": [],
     "instanceNameFormat": "Run Python script",
     "groups": [

--- a/Tasks/PythonScriptV0/task.loc.json
+++ b/Tasks/PythonScriptV0/task.loc.json
@@ -16,10 +16,9 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 135,
+    "Minor": 136,
     "Patch": 0
   },
-  "preview": true,
   "demands": [],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -12,10 +12,9 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 134,
-        "Patch": 2
+        "Minor": 136,
+        "Patch": 0
     },
-    "preview": true,
     "demands": [],
     "instanceNameFormat": "Use Python $(versionSpec)",
     "groups": [

--- a/Tasks/UsePythonVersionV0/task.loc.json
+++ b/Tasks/UsePythonVersionV0/task.loc.json
@@ -12,10 +12,9 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 134,
-    "Patch": 2
+    "Minor": 136,
+    "Patch": 0
   },
-  "preview": true,
   "demands": [],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [

--- a/Tasks/UseRubyVersionV0/task.json
+++ b/Tasks/UseRubyVersionV0/task.json
@@ -12,10 +12,9 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 134,
-        "Patch": 1
+        "Minor": 136,
+        "Patch": 0
     },
-    "preview": true,
     "demands": [],
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "Use Ruby $(versionSpec)",

--- a/Tasks/UseRubyVersionV0/task.loc.json
+++ b/Tasks/UseRubyVersionV0/task.loc.json
@@ -12,10 +12,9 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 134,
-    "Patch": 1
+    "Minor": 136,
+    "Patch": 0
   },
-  "preview": true,
   "demands": [],
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/XamariniOSV2/task.json
+++ b/Tasks/XamariniOSV2/task.json
@@ -11,10 +11,9 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 133,
+        "Minor": 136,
         "Patch": 0
     },
-    "preview": true,
     "releaseNotes": "iOS signing set up has been removed from the task. Use `Secure Files` with supporting tasks `Install Apple Certificate` and `Install Apple Provisioning Profile` to setup signing. Updated options to work better with `Visual Studio for Mac`.",
     "demands": [
         "Xamarin.iOS"

--- a/Tasks/XamariniOSV2/task.loc.json
+++ b/Tasks/XamariniOSV2/task.loc.json
@@ -11,10 +11,9 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 133,
+    "Minor": 136,
     "Patch": 0
   },
-  "preview": true,
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [
     "Xamarin.iOS"

--- a/Tasks/XcodeV5/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/XcodeV5/Strings/resources.resjson/en-US/resources.resjson
@@ -55,7 +55,7 @@
   "loc.input.label.destinationTypeOption": "Destination type",
   "loc.input.help.destinationTypeOption": "Choose the destination type to be used for UI testing. Devices must be connected to the Mac performing the build via a cable or network connection. See <strong>Devices and Simulators</strong> in Xcode.",
   "loc.input.label.destinationSimulators": "Simulator",
-  "loc.input.help.destinationSimulators": "Enter an Xcode simulator name to be used for UI testing. For example, enter `iPhone X` (iOS and watchOS) or `Apple TV 4K` (tvOS). A target OS version is optional and can be specified in the format 'OS=<i>versionNumber</i>', such as `iPhone X,OS=11.1`. A list of simulators installed on the <strong>Hosted macOS Preview</strong> agent can be [found here](https://docs.microsoft.com/en-us/mobile-center/build/software).",
+  "loc.input.help.destinationSimulators": "Enter an Xcode simulator name to be used for UI testing. For example, enter `iPhone X` (iOS and watchOS) or `Apple TV 4K` (tvOS). A target OS version is optional and can be specified in the format 'OS=<i>versionNumber</i>', such as `iPhone X,OS=11.1`. A list of simulators installed on the <strong>Hosted macOS</strong> agent can be [found here](https://docs.microsoft.com/en-us/mobile-center/build/software).",
   "loc.input.label.destinationDevices": "Device",
   "loc.input.help.destinationDevices": "Enter the name of the device to be used for UI testing, such as `Raisa's iPad`.",
   "loc.input.label.args": "Arguments",

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -11,10 +11,9 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 5,
-        "Minor": 135,
+        "Minor": 136,
         "Patch": 0
     },
-    "preview": true,
     "releaseNotes": "This version of the task is compatible with Xcode 8 and Xcode 9. Features that were there solely to maintain compat with Xcode 7 have been removed. The task has better options to work with the Hosted macOS pool.",
     "demands": [
         "xcode"
@@ -287,7 +286,7 @@
             "defaultValue": "iPhone 7",
             "required": false,
             "groupName": "devices",
-            "helpMarkDown": "Enter an Xcode simulator name to be used for UI testing. For example, enter `iPhone X` (iOS and watchOS) or `Apple TV 4K` (tvOS). A target OS version is optional and can be specified in the format 'OS=<i>versionNumber</i>', such as `iPhone X,OS=11.1`. A list of simulators installed on the <strong>Hosted macOS Preview</strong> agent can be [found here](https://docs.microsoft.com/en-us/mobile-center/build/software).",
+            "helpMarkDown": "Enter an Xcode simulator name to be used for UI testing. For example, enter `iPhone X` (iOS and watchOS) or `Apple TV 4K` (tvOS). A target OS version is optional and can be specified in the format 'OS=<i>versionNumber</i>', such as `iPhone X,OS=11.1`. A list of simulators installed on the <strong>Hosted macOS</strong> agent can be [found here](https://docs.microsoft.com/en-us/mobile-center/build/software).",
             "visibleRule": "destinationPlatformOption != default && destinationPlatformOption != macOS && destinationTypeOption == simulators"
         },
         {

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -11,10 +11,9 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 135,
+    "Minor": 136,
     "Patch": 0
   },
-  "preview": true,
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [
     "xcode"


### PR DESCRIPTION
This PR removes several tasks from 'preview' in advance of the S136 deployment.  Will you please review yours below?

Chris Patterson and I discussed that there isn't much value in marking things preview anymore (especially for longer than ~1 sprint).  We still support preview tasks and treat them as if they were not in preview.  Then the preview flag makes the task appear incomplete, and often is forgotten to be changed.