### PR TITLE
Add support for docker image names with tags.

### DIFF
--- a/Tasks/ServiceFabricUpdateManifestsV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ServiceFabricUpdateManifestsV2/Strings/resources.resjson/en-US/resources.resjson
@@ -23,6 +23,8 @@
   "loc.input.help.buildNumber": "The build number for comparison.",
   "loc.input.label.overwriteExistingPkgArtifact": "Overwrite Existing Package Artifact",
   "loc.input.help.overwriteExistingPkgArtifact": "Always download a new copy of the artifact. Otherwise use an existing copy, if present.",
+  "loc.input.label.imageNamesPath": "Image Names Path",
+  "loc.input.help.imageNamesPath": "Path to a text file that contains the names of the Docker images associated with the Service Fabric application that should be updated with digests. Each image name must be on its own line and must be in the same order as he digests in Image Digests file",
   "loc.input.label.imageDigestsPath": "Image Digests Path",
   "loc.input.help.imageDigestsPath": "Path to a text file that contains the digest values of the Docker images associated with the Service Fabric application. This file can be output by the [Docker task](https://go.microsoft.com/fwlink/?linkid=848006) when using the push action. The file should contain lines of text in the format of 'registry/image_name@digest_value'.",
   "loc.messages.ItemSearchMoreThanOneFound": "Found more than one item with search pattern {0}. There can be only one.",
@@ -60,5 +62,6 @@
   "loc.messages.NoChanges": "Found no changes.",
   "loc.messages.PdbWarning": "This package contains '*.pdb' files, which will change in every build even if the 'deterministic' compiler flag is used.  Exclude these files from your package in order to accurately detect if the package has changed.",
   "loc.messages.InvalidImageDigestValue": "The image digest value '{0}' found in file '{1}' is invalid. Expected a value in the format of 'endpoint/image_name@digest_value'.",
-  "loc.messages.CouldNotFindSubPath": "Could not find a subpath of '{0}' under artifact path '{1}'."
+  "loc.messages.CouldNotFindSubPath": "Could not find a subpath of '{0}' under artifact path '{1}'.",
+  "loc.messages.ImageDigestMissmatch": "The list of image names and the list of digests must be the same length. Number of image names: '{0}', number of image digests: '{1}'."
 }

--- a/Tasks/ServiceFabricUpdateManifestsV2/Tests/L0.ts
+++ b/Tasks/ServiceFabricUpdateManifestsV2/Tests/L0.ts
@@ -108,5 +108,8 @@ describe('ServiceFabricUpdateManifests Suite', function () {
         it('test Docker image settings', done => {
             psr.run(path.join(__dirname, 'Test-DockerImageSettings.ps1'), done);
         })
+        it('test Tagged Docker image settings', done => {
+            psr.run(path.join(__dirname, 'Test-TaggedDockerImageSettings.ps1'), done);
+        })
     }
 });

--- a/Tasks/ServiceFabricUpdateManifestsV2/Tests/Test-TaggedDockerImageSettings.ps1
+++ b/Tasks/ServiceFabricUpdateManifestsV2/Tests/Test-TaggedDockerImageSettings.ps1
@@ -1,0 +1,39 @@
+[CmdletBinding()]
+param(
+)
+
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+
+$pkgPath = "$PSScriptRoot\pkg"
+$imageDigestsPath = "$PSScriptRoot\data\TaggedDockerImageAssets\ImageDigestOutput.txt"
+$imageNamesPath = "$PSScriptRoot\data\TaggedDockerImageAssets\BuiltDockerImages.txt"
+
+try
+{
+    # Arrange.
+
+    # Setup working package folder
+    Copy-Item -LiteralPath "$PSScriptRoot\data\TaggedDockerImageAssets\AppPkg\" -Destination $pkgPath -Container -Recurse
+
+    Register-Mock Get-VstsInput { $pkgPath } -- -Name applicationPackagePath -Require
+    Register-Mock Get-VstsInput { $imageDigestsPath } -- -Name imageDigestsPath -Require
+    Register-Mock Get-VstsInput { $imageNamesPath } -- -Name imageNamesPath
+    Register-Mock Find-VstsFiles { $pkgPath } -- -LegacyPattern $pkgPath -IncludeDirectories
+    Register-Mock Find-VstsFiles { $imageDigestsPath } -- -LegacyPattern $imageDigestsPath
+    Register-Mock Find-VstsFiles { $imageNamesPath } -- -LegacyPattern $imageNamesPath
+
+    Microsoft.PowerShell.Core\Import-Module "$PSScriptRoot\..\Update-DockerImageSettings.psm1"
+
+    # Act
+    Update-DockerImageSettings
+
+    # Assert
+    $serviceManifestXml = [xml](Get-Content -LiteralPath "$pkgPath\Service1Pkg\ServiceManifest.xml")
+    Assert-AreEqual "myacr.azurecr.io/image1@sha256:fe15a6d249761e301a577f908aa2e03849869f5731f818e20fef14af499f5fe7" $serviceManifestXml.ServiceManifest.CodePackage.EntryPoint.ContainerHost.ImageName "Service1 image name did not match."
+    $serviceManifestXml = [xml](Get-Content -LiteralPath "$pkgPath\Service2Pkg\ServiceManifest.xml")
+    Assert-AreEqual "myacr.azurecr.io/image2@sha256:51e69f0fb28edfe11b50ed0bfe3a6621445dfef040de53b309bf47750648fb68" $serviceManifestXml.ServiceManifest.CodePackage.EntryPoint.ContainerHost.ImageName "Service1 image name did not match."
+}
+finally
+{
+    Remove-Item -Recurse -Force -LiteralPath $pkgPath
+}

--- a/Tasks/ServiceFabricUpdateManifestsV2/Tests/data/TaggedDockerImageAssets/AppPkg/ApplicationManifest.xml
+++ b/Tasks/ServiceFabricUpdateManifestsV2/Tests/data/TaggedDockerImageAssets/AppPkg/ApplicationManifest.xml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ApplicationManifest ApplicationTypeName="AppType"
+                     ApplicationTypeVersion="1.0.0"
+                     xmlns="http://schemas.microsoft.com/2011/01/fabric"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <ServiceManifestImport>
+    <ServiceManifestRef ServiceManifestName="Service1Pkg" ServiceManifestVersion="1.0.0" />
+  </ServiceManifestImport>
+  <ServiceManifestImport>
+    <ServiceManifestRef ServiceManifestName="Service2Pkg" ServiceManifestVersion="1.0.0" />
+  </ServiceManifestImport>
+</ApplicationManifest>

--- a/Tasks/ServiceFabricUpdateManifestsV2/Tests/data/TaggedDockerImageAssets/AppPkg/Service1Pkg/ServiceManifest.xml
+++ b/Tasks/ServiceFabricUpdateManifestsV2/Tests/data/TaggedDockerImageAssets/AppPkg/Service1Pkg/ServiceManifest.xml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ServiceManifest Name="Service1Pkg"
+                 Version="1.0.0"
+                 xmlns="http://schemas.microsoft.com/2011/01/fabric"
+                 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <ServiceTypes>
+    <!-- This is the name of your ServiceType.
+         This name must match the string used in RegisterServiceType call in Program.cs. -->
+    <StatelessServiceType ServiceTypeName="ServiceType" />
+  </ServiceTypes>
+
+  <!-- Code package is your service executable. -->
+  <CodePackage Name="Code" Version="1.0.0">
+    <EntryPoint>
+      <ContainerHost>
+        <ImageName>image1:dev</ImageName>
+      </ContainerHost>
+    </EntryPoint>
+  </CodePackage>
+
+  <!-- Config package is the contents of the Config directoy under PackageRoot that contains an
+       independently-updateable and versioned set of custom configuration settings for your service. -->
+  <ConfigPackage Name="Config" Version="1.0.0" />
+
+  <DataPackage Name="Data" Version="1.0.0" />
+
+  <Resources>
+    <Endpoints>
+      <!-- This endpoint is used by the communication listener to obtain the port on which to
+           listen. Please note that if your service is partitioned, this port is shared with
+           replicas of different partitions that are placed in your code. -->
+      <Endpoint Protocol="http" Name="ServiceEndpoint" Type="Input" Port="1" />
+    </Endpoints>
+  </Resources>
+</ServiceManifest>

--- a/Tasks/ServiceFabricUpdateManifestsV2/Tests/data/TaggedDockerImageAssets/AppPkg/Service2Pkg/ServiceManifest.xml
+++ b/Tasks/ServiceFabricUpdateManifestsV2/Tests/data/TaggedDockerImageAssets/AppPkg/Service2Pkg/ServiceManifest.xml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ServiceManifest Name="Service2Pkg"
+                 Version="1.0.0"
+                 xmlns="http://schemas.microsoft.com/2011/01/fabric"
+                 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <ServiceTypes>
+    <!-- This is the name of your ServiceType.
+         This name must match the string used in RegisterServiceType call in Program.cs. -->
+    <StatelessServiceType ServiceTypeName="ServiceType" />
+  </ServiceTypes>
+
+  <!-- Code package is your service executable. -->
+  <CodePackage Name="Code" Version="1.0.0">
+    <EntryPoint>
+      <ContainerHost>
+        <ImageName>image2:dev</ImageName>
+      </ContainerHost>
+    </EntryPoint>
+  </CodePackage>
+
+  <!-- Config package is the contents of the Config directoy under PackageRoot that contains an
+       independently-updateable and versioned set of custom configuration settings for your service. -->
+  <ConfigPackage Name="Config" Version="1.0.0" />
+
+  <DataPackage Name="Data" Version="1.0.0" />
+
+  <Resources>
+    <Endpoints>
+      <!-- This endpoint is used by the communication listener to obtain the port on which to
+           listen. Please note that if your service is partitioned, this port is shared with
+           replicas of different partitions that are placed in your code. -->
+      <Endpoint Protocol="http" Name="ServiceEndpoint" Type="Input" Port="1" />
+    </Endpoints>
+  </Resources>
+</ServiceManifest>

--- a/Tasks/ServiceFabricUpdateManifestsV2/Tests/data/TaggedDockerImageAssets/BuiltDockerImages.txt
+++ b/Tasks/ServiceFabricUpdateManifestsV2/Tests/data/TaggedDockerImageAssets/BuiltDockerImages.txt
@@ -1,0 +1,2 @@
+image1:dev
+image2:dev

--- a/Tasks/ServiceFabricUpdateManifestsV2/Tests/data/TaggedDockerImageAssets/ImageDigestOutput.txt
+++ b/Tasks/ServiceFabricUpdateManifestsV2/Tests/data/TaggedDockerImageAssets/ImageDigestOutput.txt
@@ -1,0 +1,2 @@
+myacr.azurecr.io/image1@sha256:fe15a6d249761e301a577f908aa2e03849869f5731f818e20fef14af499f5fe7
+myacr.azurecr.io/image2@sha256:51e69f0fb28edfe11b50ed0bfe3a6621445dfef040de53b309bf47750648fb68

--- a/Tasks/ServiceFabricUpdateManifestsV2/Update-DockerImageSettings.psm1
+++ b/Tasks/ServiceFabricUpdateManifestsV2/Update-DockerImageSettings.psm1
@@ -12,18 +12,44 @@ function Update-DockerImageSettings
         $appPackagePathSearchPattern = (Get-VstsInput -Name applicationPackagePath -Require)
         $appPackagePath = Find-VstsFiles -LegacyPattern $appPackagePathSearchPattern -IncludeDirectories
 
-        # Collect the image digest values for the images
-        $imageDigestValues = (Get-Content -LiteralPath $imageDigestsPath).Replace("`r`n", "`n").Split("`n")
-        $imageNameToDigestMapping = @{}
-        foreach ($imageDigestValue in $imageDigestValues)
+        $imageNamesFilePathSearchPattern = Get-VstsInput -Name imageNamesPath
+        $imageNamesPath = $null
+        if (-not [string]::IsNullOrEmpty($imageNamesFilePathSearchPattern))
         {
-            $slashIndex = $imageDigestValue.IndexOf("/")
-            $hashSeparatorIndex = $imageDigestValue.IndexOf("@")
-            if ($slashIndex -lt 0 -or $hashSeparatorIndex -lt 0)
+            $imageNamesPath = Find-VstsFiles -LegacyPattern $imageNamesFilePathSearchPattern
+        }
+
+        $imageDigestValues = (Get-Content -LiteralPath $imageDigestsPath).Replace("`r`n", "`n").Split("`n")
+        $imageNames = $null
+        if (($imageNamesPath -ne $null))
+        {
+            $imageNames = (Get-Content -LiteralPath $imageNamesPath).Replace("`r`n", "`n").Split("`n")
+            if ($imageNames.Count -ne $imageDigestValues.Count)
             {
-                throw (Get-VstsLocString -Key InvalidImageDigestValue -ArgumentList @($imageDigestValue, $imageDigestsPath))
+                throw (Get-VstsLocString -Key ImageDigestMissmatch -ArgumentList @($imageNames.Count, $imageDigestValues.Count))
             }
-            $imageName = $imageDigestValue.Substring($slashIndex + 1, $hashSeparatorIndex - $slashIndex - 1)
+        }
+
+        # Collect the image digest values for the images
+        $imageNameToDigestMapping = @{}
+        for ($ind = 0; $ind -lt $imageDigestValues.Count; $ind++)
+        {
+            $imageDigestValue = $imageDigestValues[$ind]
+            $imageName = $null
+            if ($imageNames -ne $null)
+            {
+                $imageName = $imageNames[$ind]
+            }
+            else
+            {
+                $slashIndex = $imageDigestValue.IndexOf("/")
+                $hashSeparatorIndex = $imageDigestValue.IndexOf("@")
+                if ($slashIndex -lt 0 -or $hashSeparatorIndex -lt 0)
+                {
+                    throw (Get-VstsLocString -Key InvalidImageDigestValue -ArgumentList @($imageDigestValue, $imageDigestsPath))
+                }
+                $imageName = $imageDigestValue.Substring($slashIndex + 1, $hashSeparatorIndex - $slashIndex - 1)
+            }
             $imageNameToDigestMapping[$imageName] = $imageDigestValue
         }
 

--- a/Tasks/ServiceFabricUpdateManifestsV2/task.json
+++ b/Tasks/ServiceFabricUpdateManifestsV2/task.json
@@ -18,8 +18,8 @@
     ],
     "version": {
         "Major": 2,
-        "Minor": 2,
-        "Patch": 3
+        "Minor": 3,
+        "Patch": 0
     },
     "minimumAgentVersion": "1.95.0",
     "instanceNameFormat": "Update Service Fabric Manifests ($(updateType))",
@@ -126,6 +126,14 @@
             "helpMarkDown": "Always download a new copy of the artifact. Otherwise use an existing copy, if present."
         },
         {
+            "name": "imageNamesPath",
+            "type": "filePath",
+            "label": "Image Names Path",
+            "required": false,
+            "visibleRule": "updateType = Docker image settings",
+            "helpMarkDown": "Path to a text file that contains the names of the Docker images associated with the Service Fabric application that should be updated with digests. Each image name must be on its own line and must be in the same order as he digests in Image Digests file"
+        },
+        {
             "name": "imageDigestsPath",
             "type": "filePath",
             "label": "Image Digests Path",
@@ -176,6 +184,7 @@
         "NoChanges": "Found no changes.",
         "PdbWarning": "This package contains '*.pdb' files, which will change in every build even if the 'deterministic' compiler flag is used.  Exclude these files from your package in order to accurately detect if the package has changed.",
         "InvalidImageDigestValue": "The image digest value '{0}' found in file '{1}' is invalid. Expected a value in the format of 'endpoint/image_name@digest_value'.",
-        "CouldNotFindSubPath": "Could not find a subpath of '{0}' under artifact path '{1}'."
+        "CouldNotFindSubPath": "Could not find a subpath of '{0}' under artifact path '{1}'.",
+        "ImageDigestMissmatch": "The list of image names and the list of digests must be the same length. Number of image names: '{0}', number of image digests: '{1}'."
     }
 }

--- a/Tasks/ServiceFabricUpdateManifestsV2/task.loc.json
+++ b/Tasks/ServiceFabricUpdateManifestsV2/task.loc.json
@@ -18,8 +18,8 @@
   ],
   "version": {
     "Major": 2,
-    "Minor": 2,
-    "Patch": 3
+    "Minor": 3,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -126,6 +126,14 @@
       "helpMarkDown": "ms-resource:loc.input.help.overwriteExistingPkgArtifact"
     },
     {
+      "name": "imageNamesPath",
+      "type": "filePath",
+      "label": "ms-resource:loc.input.label.imageNamesPath",
+      "required": false,
+      "visibleRule": "updateType = Docker image settings",
+      "helpMarkDown": "ms-resource:loc.input.help.imageNamesPath"
+    },
+    {
       "name": "imageDigestsPath",
       "type": "filePath",
       "label": "ms-resource:loc.input.label.imageDigestsPath",
@@ -176,6 +184,7 @@
     "NoChanges": "ms-resource:loc.messages.NoChanges",
     "PdbWarning": "ms-resource:loc.messages.PdbWarning",
     "InvalidImageDigestValue": "ms-resource:loc.messages.InvalidImageDigestValue",
-    "CouldNotFindSubPath": "ms-resource:loc.messages.CouldNotFindSubPath"
+    "CouldNotFindSubPath": "ms-resource:loc.messages.CouldNotFindSubPath",
+    "ImageDigestMissmatch": "ms-resource:loc.messages.ImageDigestMissmatch"
   }
 }


### PR DESCRIPTION
Fix for #6856 add support for updating tagged images by using BuiltDockerImages to map from the original name to the digest based name.