### PR TITLE
#6965 Azure ARM Keyvault console error shows for all exceptions from the server, not just invalid names

### DIFF
--- a/Tasks/AzureKeyVaultV1/operations/azure-arm-keyvault.ts
+++ b/Tasks/AzureKeyVaultV1/operations/azure-arm-keyvault.ts
@@ -101,8 +101,10 @@ export class KeyVaultClient extends azureServiceClient.ServiceClient {
                 var result = response.body.value;
                 return new azureServiceClient.ApiResult(null, result);
             }
+            else if (response.statusCode == 400) {
+                return new azureServiceClient.ApiResult(tl.loc('GetSecretFailedBecauseOfInvalidCharacters', secretName));
+            }
             else {
-                console.error('##[error]' + tl.loc('GetSecretFailedBecauseOfInvalidCharacters', secretName));
                 return new azureServiceClient.ApiResult(azureServiceClient.ToError(response));
             }
         }).then((apiResult: azureServiceClient.ApiResult) => callback(apiResult.error, apiResult.result),

--- a/Tasks/AzureKeyVaultV1/task.json
+++ b/Tasks/AzureKeyVaultV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 18
+        "Patch": 19
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",
@@ -91,7 +91,7 @@
         "AccessDeniedError": "%s. Specified Azure endpoint needs to have Get, List secret management permissions on the selected key vault. To set these permissions, download ProvisionKeyVaultPermissions.ps1 script from build/release logs and execute it OR set them from Azure portal.",
         "GetSecretValueFailed": "Get secret value failed for: %s. Error: %s.",
         "ConflictingVariableFound": "Variable with name %s is defined in both environment and key vault",
-        "GetSecretFailedBecauseOfInvalidCharacters": "Cannot find the secret with name: %s. Secret name must be a string 1-127 characters in length containing only 0-9, a-z, A-Z, and -",
+        "GetSecretFailedBecauseOfInvalidCharacters": "Secret not found: %s. Secret name must be a string 1-127 characters in length containing only -, 0-9, a-z and A-Z.",
         "UploadingAttachment": "Uploading %s as attachment",
         "CouldNotWriteToFile": "Could not save content to file. Failed with an error %s",
         "CouldNotMaskSecret": "%s value has regular expressions hence could not mask completely",

--- a/Tasks/AzureKeyVaultV1/task.loc.json
+++ b/Tasks/AzureKeyVaultV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 18
+    "Patch": 19
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",


### PR DESCRIPTION
#6965 Azure ARM Keyvault console error shows for all exceptions from the server, not just invalid names