### PR TITLE
allow user to upgrade service manifest without upgrading code or config

### DIFF
--- a/Tasks/ServiceFabricDeployV1/Create-DiffPackage.psm1
+++ b/Tasks/ServiceFabricDeployV1/Create-DiffPackage.psm1
@@ -83,6 +83,7 @@ function New-DiffPackage
             $localServiceManifest = ([XML](Get-Content -LiteralPath $localServiceManifestPath)).ServiceManifest
             $diffServicePkgPath = [System.IO.Path]::Combine($diffPackagePath, $localServiceManifestName)
             $clusterServiceManifest = $clusterServiceManifestByName[$localServiceManifestName].ServiceManifest
+            $diffPkgServiceManifestPath = Join-Path $diffServicePkgPath $serviceManifestName
 
             # If there's no matching manifest from the cluster it means this is a newly added service that doesn't exist yet on the cluster.
             if (!$clusterServiceManifest)
@@ -105,8 +106,12 @@ function New-DiffPackage
             Copy-DiffPackage -clusterPackages $clusterServiceManifest.ConfigPackage -localPackages $localServiceManifest.ConfigPackage -localParentPkgPath $localServicePkgPath -diffParentPkgPath $diffServicePkgPath
             Copy-DiffPackage -clusterPackages $clusterServiceManifest.DataPackage -localPackages $localServiceManifest.DataPackage -localParentPkgPath $localServicePkgPath -diffParentPkgPath $diffServicePkgPath
 
-            Write-Host (Get-VstsLocString -Key DIFFPKG_CopyingToDiffPackge -ArgumentList @($localServiceManifestPath, (Join-Path $diffServicePkgPath $serviceManifestName)))
-            Copy-Item -LiteralPath $localServiceManifestPath (Join-Path $diffServicePkgPath $serviceManifestName) -Force
+            Write-Host (Get-VstsLocString -Key DIFFPKG_CopyingToDiffPackge -ArgumentList @($localServiceManifestPath, $diffPkgServiceManifestPath))
+            if (!(Test-Path -PathType Container -LiteralPath $diffServicePkgPath))
+            {
+                $diffServicePkgPath = New-Item -ItemType Directory -Path $diffServicePkgPath -Force
+            }
+            Copy-Item -LiteralPath $localServiceManifestPath $diffPkgServiceManifestPath -Force
         }
 
         Return $diffPackagePath

--- a/Tasks/ServiceFabricDeployV1/Create-DiffPackage.psm1
+++ b/Tasks/ServiceFabricDeployV1/Create-DiffPackage.psm1
@@ -102,15 +102,13 @@ function New-DiffPackage
             }
             Write-Host (Get-VstsLocString -Key DIFFPKG_CreatingDiffPackageForService -ArgumentList @($localServiceManifestName, $clusterServiceManifest.Version, $localServiceManifestVersion))
 
+            $diffServicePkgPath = New-Item -ItemType Directory -Path $diffServicePkgPath -Force
+
             Copy-DiffPackage -clusterPackages $clusterServiceManifest.CodePackage -localPackages $localServiceManifest.CodePackage -localParentPkgPath $localServicePkgPath -diffParentPkgPath $diffServicePkgPath
             Copy-DiffPackage -clusterPackages $clusterServiceManifest.ConfigPackage -localPackages $localServiceManifest.ConfigPackage -localParentPkgPath $localServicePkgPath -diffParentPkgPath $diffServicePkgPath
             Copy-DiffPackage -clusterPackages $clusterServiceManifest.DataPackage -localPackages $localServiceManifest.DataPackage -localParentPkgPath $localServicePkgPath -diffParentPkgPath $diffServicePkgPath
 
             Write-Host (Get-VstsLocString -Key DIFFPKG_CopyingToDiffPackge -ArgumentList @($localServiceManifestPath, $diffPkgServiceManifestPath))
-            if (!(Test-Path -PathType Container -LiteralPath $diffServicePkgPath))
-            {
-                $diffServicePkgPath = New-Item -ItemType Directory -Path $diffServicePkgPath -Force
-            }
             Copy-Item -LiteralPath $localServiceManifestPath $diffPkgServiceManifestPath -Force
         }
 

--- a/Tasks/ServiceFabricDeployV1/task.json
+++ b/Tasks/ServiceFabricDeployV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 7,
-        "Patch": 11
+        "Patch": 12
     },
     "demands": [
         "Cmd"

--- a/Tasks/ServiceFabricDeployV1/task.loc.json
+++ b/Tasks/ServiceFabricDeployV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 7,
-    "Patch": 11
+    "Patch": 12
   },
   "demands": [
     "Cmd"


### PR DESCRIPTION
this PR is to fix the issue "if the user only upgrade ServiceManifest.xml without upgrading code or config, ServiceManifest.xml won't be able to be copied to diff package"