### PR TITLE
Updating the test execution package to fix rerun issue

### DIFF
--- a/Tasks/VsTest/make.json
+++ b/Tasks/VsTest/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/6255884/TestAgent.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/6268036/TestAgent.zip",
                 "dest": "./Modules"
             },
             {

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 136,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 136,
-    "Patch": 1
+    "Patch": 3
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Issue: Due to a code defect in the distributed mode of VSTest task, we end up adding duplicate "Custom Slicing" nodes in the run settings file when rerun is enabled. The second node should be a rerun node but instead gets created as Custom Slicing node.

UserExperience: Those users who are using the distributed mode of VsTest task and have rerun enabled will not see any reruns for their failed test cases even if the run meets the rerun criteria. The user will not see any visible errors or warnings.

Fix: This PR updates the package of test agent which has settings processor fixes. Manually tested the fix.