### PR TITLE
Fix and re-enable broken Conda test

### DIFF
--- a/Tasks/CondaEnvironmentV0/Tests/L0.ts
+++ b/Tasks/CondaEnvironmentV0/Tests/L0.ts
@@ -5,24 +5,24 @@ import * as path from 'path';
 import { MockTestRunner } from 'vsts-task-lib/mock-test';
 
 describe('CondaEnvironment L0 Suite', function () {
-    describe('conda.ts', function () {
-        require('./L0_conda');
-    });
+    // describe('conda.ts', function () {
+    //     require('./L0_conda');
+    // });
 
-    describe('conda_internal.ts', function () {
-        require('./L0_conda_internal');
-    });
+    // describe('conda_internal.ts', function () {
+    //     require('./L0_conda_internal');
+    // });
 
-    it('succeeds when creating and activating an environment', function () {
-        const testFile = path.join(__dirname, 'L0CreateEnvironment.js');
-        const testRunner = new MockTestRunner(testFile);
+    // it('succeeds when creating and activating an environment', function () {
+    //     const testFile = path.join(__dirname, 'L0CreateEnvironment.js');
+    //     const testRunner = new MockTestRunner(testFile);
 
-        testRunner.run();
+    //     testRunner.run();
 
-        assert(testRunner.ran(`conda create --quiet --prefix ${path.join('/', 'miniconda', 'envs', 'test')} --mkdir --yes`));
-        assert.strictEqual(testRunner.stderr.length, 0, 'should not have written to stderr');
-        assert(testRunner.succeeded, 'task should have succeeded');
-    });
+    //     assert(testRunner.ran(`conda create --quiet --prefix ${path.join('/', 'miniconda', 'envs', 'test')} --mkdir --yes`));
+    //     assert.strictEqual(testRunner.stderr.length, 0, 'should not have written to stderr');
+    //     assert(testRunner.succeeded, 'task should have succeeded');
+    // });
 
     it('fails when a Conda installation is not found', function () {
         const testFile = path.join(__dirname, 'L0CondaNotFound.js');
@@ -30,6 +30,10 @@ describe('CondaEnvironment L0 Suite', function () {
 
         testRunner.run();
 
+        console.log('testRunner.stdout:')
+        console.log(testRunner.stdout);
+        console.log('testRunner.cmdlines');
+        console.log(testRunner.cmdlines);
         assert(testRunner.createdErrorIssue('loc_mock_CondaNotFound'));
         assert(testRunner.failed, 'task should have failed');
     });

--- a/Tasks/CondaEnvironmentV0/Tests/L0.ts
+++ b/Tasks/CondaEnvironmentV0/Tests/L0.ts
@@ -24,10 +24,7 @@ describe('CondaEnvironment L0 Suite', function () {
         assert(testRunner.succeeded, 'task should have succeeded');
     });
 
-    // TODO 1263674 There seems to be an issue on the official build
-    // where the test really finds Conda on the build machine
-    // Fix and re-enable
-    xit('fails when a Conda installation is not found', function () {
+    it('fails when a Conda installation is not found', function () {
         const testFile = path.join(__dirname, 'L0CondaNotFound.js');
         const testRunner = new MockTestRunner(testFile);
 

--- a/Tasks/CondaEnvironmentV0/Tests/L0.ts
+++ b/Tasks/CondaEnvironmentV0/Tests/L0.ts
@@ -5,24 +5,24 @@ import * as path from 'path';
 import { MockTestRunner } from 'vsts-task-lib/mock-test';
 
 describe('CondaEnvironment L0 Suite', function () {
-    // describe('conda.ts', function () {
-    //     require('./L0_conda');
-    // });
+    describe('conda.ts', function () {
+        require('./L0_conda');
+    });
 
-    // describe('conda_internal.ts', function () {
-    //     require('./L0_conda_internal');
-    // });
+    describe('conda_internal.ts', function () {
+        require('./L0_conda_internal');
+    });
 
-    // it('succeeds when creating and activating an environment', function () {
-    //     const testFile = path.join(__dirname, 'L0CreateEnvironment.js');
-    //     const testRunner = new MockTestRunner(testFile);
+    it('succeeds when creating and activating an environment', function () {
+        const testFile = path.join(__dirname, 'L0CreateEnvironment.js');
+        const testRunner = new MockTestRunner(testFile);
 
-    //     testRunner.run();
+        testRunner.run();
 
-    //     assert(testRunner.ran(`conda create --quiet --prefix ${path.join('/', 'miniconda', 'envs', 'test')} --mkdir --yes`));
-    //     assert.strictEqual(testRunner.stderr.length, 0, 'should not have written to stderr');
-    //     assert(testRunner.succeeded, 'task should have succeeded');
-    // });
+        assert(testRunner.ran(`conda create --quiet --prefix ${path.join('/', 'miniconda', 'envs', 'test')} --mkdir --yes`));
+        assert.strictEqual(testRunner.stderr.length, 0, 'should not have written to stderr');
+        assert(testRunner.succeeded, 'task should have succeeded');
+    });
 
     it('fails when a Conda installation is not found', function () {
         const testFile = path.join(__dirname, 'L0CondaNotFound.js');
@@ -30,10 +30,6 @@ describe('CondaEnvironment L0 Suite', function () {
 
         testRunner.run();
 
-        console.log('testRunner.stdout:')
-        console.log(testRunner.stdout);
-        console.log('testRunner.cmdlines');
-        console.log(testRunner.cmdlines);
         assert(testRunner.createdErrorIssue('loc_mock_CondaNotFound'));
         assert(testRunner.failed, 'task should have failed');
     });

--- a/Tasks/CondaEnvironmentV0/Tests/L0CondaNotFound.ts
+++ b/Tasks/CondaEnvironmentV0/Tests/L0CondaNotFound.ts
@@ -15,13 +15,8 @@ taskRunner.setAnswers({
     }
 });
 
-const getVariable = sinon.stub();
-getVariable.withArgs('CONDA').returns(undefined);
-
-taskRunner.registerMock('vsts-task-lib/task', {
-    // `getVariable` is not supported by `TaskLibAnswers`
-    getVariable: getVariable
-});
+// `getVariable` is not supported by `TaskLibAnswers`
+process.env['CONDA'] = undefined;
 
 // Mock vsts-task-tool-lib
 taskRunner.registerMock('vsts-task-tool-lib/tool', {

--- a/Tasks/CondaEnvironmentV0/conda_internal.ts
+++ b/Tasks/CondaEnvironmentV0/conda_internal.ts
@@ -7,6 +7,25 @@ import { ToolRunner } from 'vsts-task-lib/toolrunner';
 
 import { Platform } from './taskutil';
 
+const log = {
+    info(message: string) {
+        console.log(`[INFO] ${message}`);
+    },
+    warning(message: string) {
+        console.log(`[WARNING] ${message}`);
+    },
+    error(message: string) {
+        console.error(`[ERROR] ${message}`)
+    }
+};
+
+/** Log `label: ${value}` and pass the value through. */
+function trace(label: string, value: any) {
+    log.info(`${label}: ${value}`);
+    return value;
+}
+
+
 /**
  * Whether `searchDir` has a `conda` executable for `platform`.
  * @param searchDir Absolute path to a directory to look for a `conda` executable in.
@@ -29,17 +48,19 @@ function hasConda(searchDir: string, platform: Platform): boolean {
  *   - The directory where the agent will install Conda if missing
  */
 export function findConda(platform: Platform): string | null {
-    const condaFromPath: string | undefined = task.which('conda');
+    log.info('Entering `findConda`');
+    const condaFromPath: string | undefined = trace('condaFromPath', task.which('conda'));
     if (condaFromPath) {
         // On all platforms, the `conda` executable lives in a directory off the root of the installation
-        return path.dirname(path.dirname(condaFromPath));
+        return trace('`findConda` returning', path.dirname(path.dirname(condaFromPath)));
     }
 
-    const condaFromEnvironment: string | undefined = task.getVariable('CONDA');
+    const condaFromEnvironment: string | undefined = trace('condaFromEnvironment', task.getVariable('CONDA'));
     if (condaFromEnvironment && hasConda(condaFromEnvironment, platform)) {
         return condaFromEnvironment;
     }
 
+    log.info('`findConda` returning `null`');
     return null;
 }
 

--- a/Tasks/CondaEnvironmentV0/conda_internal.ts
+++ b/Tasks/CondaEnvironmentV0/conda_internal.ts
@@ -7,25 +7,6 @@ import { ToolRunner } from 'vsts-task-lib/toolrunner';
 
 import { Platform } from './taskutil';
 
-const log = {
-    info(message: string) {
-        console.log(`[INFO] ${message}`);
-    },
-    warning(message: string) {
-        console.log(`[WARNING] ${message}`);
-    },
-    error(message: string) {
-        console.error(`[ERROR] ${message}`)
-    }
-};
-
-/** Log `label: ${value}` and pass the value through. */
-function trace(label: string, value: any) {
-    log.info(`${label}: ${value}`);
-    return value;
-}
-
-
 /**
  * Whether `searchDir` has a `conda` executable for `platform`.
  * @param searchDir Absolute path to a directory to look for a `conda` executable in.
@@ -48,19 +29,17 @@ function hasConda(searchDir: string, platform: Platform): boolean {
  *   - The directory where the agent will install Conda if missing
  */
 export function findConda(platform: Platform): string | null {
-    log.info('Entering `findConda`');
-    const condaFromPath: string | undefined = trace('condaFromPath', task.which('conda'));
+    const condaFromPath: string | undefined = task.which('conda');
     if (condaFromPath) {
         // On all platforms, the `conda` executable lives in a directory off the root of the installation
-        return trace('`findConda` returning', path.dirname(path.dirname(condaFromPath)));
+        return path.dirname(path.dirname(condaFromPath));
     }
 
-    const condaFromEnvironment: string | undefined = trace('condaFromEnvironment', task.getVariable('CONDA'));
+    const condaFromEnvironment: string | undefined = task.getVariable('CONDA');
     if (condaFromEnvironment && hasConda(condaFromEnvironment, platform)) {
         return condaFromEnvironment;
     }
 
-    log.info('`findConda` returning `null`');
     return null;
 }
 


### PR DESCRIPTION
This was failing because the `CONDA` environment variable is set on build agents.  Apparently attempting to use `setAnswers` and `registerMock` on the task lib at the same time doesn't work, and mocking out `getVariable` in this way wasn't getting picked up.