### PR TITLE
Added functionality to create a kubeconfig for Service account auth scheme

### DIFF
--- a/Tasks/Common/utility-common/kubectlutility.ts
+++ b/Tasks/Common/utility-common/kubectlutility.ts
@@ -58,7 +58,7 @@ export function createKubeconfig(kubernetesServiceEndpoint: string): string
     //populate server url, ca cert and token fields
     kubeconfigTemplate.clusters[0].cluster.server = tl.getEndpointUrl(kubernetesServiceEndpoint, false);
     kubeconfigTemplate.clusters[0].cluster["certificate-authority-data"] = tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'serviceAccountCertificate', false);
-    kubeconfigTemplate.users[0].user.token = Base64.decode(tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'serviceAccountToken', false));
+    kubeconfigTemplate.users[0].user.token = Base64.decode(tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'apiToken', false));
 
     return JSON.stringify(kubeconfigTemplate);
 }

--- a/Tasks/Common/utility-common/kubectlutility.ts
+++ b/Tasks/Common/utility-common/kubectlutility.ts
@@ -7,6 +7,7 @@ import * as util from "util";
 const uuidV4 = require('uuid/v4');
 const kubectlToolName = "kubectl"
 export const stableKubectlVersion = "v1.8.9"
+var Base64 = require('js-base64').Base64;
 
 
 var fs = require('fs');
@@ -49,6 +50,19 @@ export async function downloadKubectl(version: string) : Promise<string> {
     return kubectlPath;
 }
 
+export function createKubeconfig(kubernetesServiceEndpoint: string): string
+{
+    var kubeconfigTemplateString = '{"apiVersion":"v1","kind":"Config","clusters":[{"cluster":{"certificate-authority-data": null,"server": null}}], "users":[{"user":{"token": null}}]}';
+    var kubeconfigTemplate = JSON.parse(kubeconfigTemplateString);
+
+    //populate server url, ca cert and token fields
+    kubeconfigTemplate.clusters[0].cluster.server = tl.getEndpointUrl(kubernetesServiceEndpoint, false);
+    kubeconfigTemplate.clusters[0].cluster["certificate-authority-data"] = tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'serviceAccountCertificate', false);
+    kubeconfigTemplate.users[0].user.token = Base64.decode(tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'serviceAccountToken', false));
+
+    return JSON.stringify(kubeconfigTemplate);
+}
+
 function getTempDirectory(): string {
     return tl.getVariable('agent.tempDirectory') || os.tmpdir();
 }
@@ -76,4 +90,3 @@ function getExecutableExtention(): string {
 
     return "";
 }
-

--- a/Tasks/Common/utility-common/package.json
+++ b/Tasks/Common/utility-common/package.json
@@ -16,6 +16,7 @@
     "semver": "^5.4.1",
     "vso-node-api": "6.0.1-preview",
     "vsts-task-lib": "2.0.6",
-    "vsts-task-tool-lib": "0.4.0"
+    "vsts-task-tool-lib": "0.4.0",
+    "js-base64": "2.4.3"
   }
 }

--- a/Tasks/HelmDeployV0/make.json
+++ b/Tasks/HelmDeployV0/make.json
@@ -10,10 +10,18 @@
         "type": "node",
         "dest": "./",
         "compile": true
-    }],
+    },
+    {
+		"module": "../Common/utility-common",
+		"type": "node",
+		"dest" : "./",
+		"compile" : true
+	}
+],
 	"rm": [
         {
             "items": [
+                "node_modules/utility-common/node_modules/vsts-task-lib",
                 "node_modules/azure-arm-rest/node_modules/vsts-task-lib",
                 "node_modules/securefiles-common/node_modules/vsts-task-lib"
             ],

--- a/Tasks/HelmDeployV0/package.json
+++ b/Tasks/HelmDeployV0/package.json
@@ -4,6 +4,7 @@
     "del": "2.2.0",
     "js-base64": "2.4.3",
     "securefiles-common": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
+    "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
     "vsts-task-tool-lib": "0.4.0"
   }
 }

--- a/Tasks/HelmDeployV0/src/clusters/generickubernetescluster.ts
+++ b/Tasks/HelmDeployV0/src/clusters/generickubernetescluster.ts
@@ -1,8 +1,17 @@
 "use strict";
 
 import tl = require('vsts-task-lib/task');
+import kubectlutility = require("utility-common/kubectlutility");
 
 export async function getKubeConfig(): Promise<string> {
     var kubernetesServiceEndpoint = tl.getInput("kubernetesServiceEndpoint", true);
-    return tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'kubeconfig', false);
+    var authorizationType = tl.getEndpointDataParameter(kubernetesServiceEndpoint, 'authorizationType', false);
+    if (authorizationType === "Kubeconfig")
+    {
+        return tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'kubeconfig', false);
+    }
+    else if (authorizationType === "ServiceAccount")
+    {
+        return kubectlutility.createKubeconfig(kubernetesServiceEndpoint);
+    } 
 }

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 8
+        "Patch": 9
     },
     "demands": [],
     "preview": "true",

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 8
+    "Patch": 9
   },
   "demands": [],
   "preview": "true",

--- a/Tasks/KubernetesV0/Tests/TestSetup.ts
+++ b/Tasks/KubernetesV0/Tests/TestSetup.ts
@@ -49,7 +49,7 @@ process.env["ENDPOINT_AUTH_kubernetesEndpoint"] = "{\"parameters\":{\"kubeconfig
 process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_KUBECONFIG"] =  "{\"apiVersion\":\"v1\", \"clusters\": [{\"cluster\": {\"insecure-skip-tls-verify\":\"true\", \"server\":\"https://5.6.7.8\", \"name\" : \"scratch\"}}], \"contexts\": [{\"context\" : {\"cluster\": \"scratch\", \"namespace\" : \"default\", \"user\": \"experimenter\", \"name\" : \"exp-scratch\"}], \"current-context\" : \"exp-scratch\", \"kind\": \"Config\", \"users\" : [{\"user\": {\"password\": \"regpassword\", \"username\" : \"test\"}]}";
 process.env["ENDPOINT_DATA_kubernetesEndpoint_AUTHORIZATIONTYPE"] = process.env[shared.endpointAuthorizationType];
 process.env["ENDPOINT_URL_kubernetesEndpoint"] = "https://mycluster.azure.com";
-process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_SERVICEACCOUNTTOKEN"] =  "saToken";
+process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_APITOKEN"] =  "saToken";
 process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_SERVICEACCOUNTCERTIFICATE"] =  "saCert";
 
 process.env["ENDPOINT_AUTH_SCHEME_AzureRMSpn"] = "ServicePrincipal";

--- a/Tasks/KubernetesV0/Tests/TestSetup.ts
+++ b/Tasks/KubernetesV0/Tests/TestSetup.ts
@@ -47,6 +47,11 @@ process.env["SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"] = "https://abc.visualstudio.co
 process.env["ENDPOINT_AUTH_dockerhubendpoint"] = "{\"parameters\":{\"username\":\"test\", \"password\":\"regpassword\", \"email\":\"test@microsoft.com\",\"registry\":\"https://index.docker.io/v1/\"},\"scheme\":\"UsernamePassword\"}";
 process.env["ENDPOINT_AUTH_kubernetesEndpoint"] = "{\"parameters\":{\"kubeconfig\":\"kubeconfig\", \"username\":\"test\", \"password\":\"regpassword\",},\"scheme\":\"UsernamePassword\"}";
 process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_KUBECONFIG"] =  "{\"apiVersion\":\"v1\", \"clusters\": [{\"cluster\": {\"insecure-skip-tls-verify\":\"true\", \"server\":\"https://5.6.7.8\", \"name\" : \"scratch\"}}], \"contexts\": [{\"context\" : {\"cluster\": \"scratch\", \"namespace\" : \"default\", \"user\": \"experimenter\", \"name\" : \"exp-scratch\"}], \"current-context\" : \"exp-scratch\", \"kind\": \"Config\", \"users\" : [{\"user\": {\"password\": \"regpassword\", \"username\" : \"test\"}]}";
+process.env["ENDPOINT_DATA_kubernetesEndpoint_AUTHORIZATIONTYPE"] = process.env[shared.endpointAuthorizationType];
+process.env["ENDPOINT_URL_kubernetesEndpoint"] = "https://mycluster.azure.com";
+process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_SERVICEACCOUNTTOKEN"] =  "saToken";
+process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_SERVICEACCOUNTCERTIFICATE"] =  "saCert";
+
 process.env["ENDPOINT_AUTH_SCHEME_AzureRMSpn"] = "ServicePrincipal";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALID"] = "spId";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";

--- a/Tasks/KubernetesV0/Tests/TestShared.ts
+++ b/Tasks/KubernetesV0/Tests/TestShared.ts
@@ -44,6 +44,7 @@ export let Commands = {
 };
 
 export let isKubectlPresentOnMachine = "true"; 
+export let endpointAuthorizationType = "Kubeconfig";
 
 export let ContainerTypes = {
     AzureContainerRegistry: "Azure Container Registry",

--- a/Tasks/KubernetesV0/make.json
+++ b/Tasks/KubernetesV0/make.json
@@ -15,7 +15,9 @@
         {
             "items": [
                 "node_modules/utility-common/node_modules/vsts-task-lib",
-                "node_modules/docker-common/node_modules/vsts-task-lib"
+                "node_modules/docker-common/node_modules/vsts-task-lib",
+                "node_modules/vsts-task-tool-lib/node_modules/vsts-task-lib",
+                "node_modules/azure-arm-rest/node_modules/vsts-task-lib"
             ],
             "options": "-Rf"
         }

--- a/Tasks/KubernetesV0/package.json
+++ b/Tasks/KubernetesV0/package.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "del": "2.2.0",
     "docker-common": "file:../../_build/Tasks/Common/docker-common-1.0.0.tgz",
-    "js-base64": "2.4.3",
     "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
     "vsts-task-tool-lib": "0.4.0"
   }

--- a/Tasks/KubernetesV0/package.json
+++ b/Tasks/KubernetesV0/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "del": "2.2.0",
     "docker-common": "file:../../_build/Tasks/Common/docker-common-1.0.0.tgz",
+    "js-base64": "2.4.3",
     "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
     "vsts-task-tool-lib": "0.4.0"
   }

--- a/Tasks/KubernetesV0/src/clusterconnection.ts
+++ b/Tasks/KubernetesV0/src/clusterconnection.ts
@@ -8,6 +8,7 @@ import * as tr from "vsts-task-lib/toolrunner";
 import AuthenticationToken from "docker-common/registryauthenticationprovider/registryauthenticationtoken"
 import * as utils from "./utilities";
 import * as os from "os";
+var Base64 = require('js-base64').Base64;
 
 export default class ClusterConnection {
     private kubectlPath: string;
@@ -41,9 +42,17 @@ export default class ClusterConnection {
     // open kubernetes connection
     public async open(kubernetesEndpoint?: string){
          return this.initialize().then(() => {
-            if (kubernetesEndpoint) {
-                this.downloadKubeconfigFileFromEndpoint(kubernetesEndpoint);
+            var authorizationType = tl.getEndpointDataParameter(kubernetesEndpoint, 'authorizationType', false);
+            if (authorizationType === "Kubeconfig")
+            {
+                if (kubernetesEndpoint) {
+                    this.downloadKubeconfigFileFromEndpoint(kubernetesEndpoint);
+                } 
             }
+            else if (authorizationType === "ServiceAccount")
+            {
+                this.createKubeconfig(kubernetesEndpoint);
+            }            
          });
     }
 
@@ -69,6 +78,20 @@ export default class ClusterConnection {
         this.kubeconfigFile = path.join(this.userDir, "config");
         var kubeconfig = tl.getEndpointAuthorizationParameter(kubernetesEndpoint, 'kubeconfig', false);
         fs.writeFileSync(this.kubeconfigFile, kubeconfig);
+    }
+
+    private createKubeconfig(kubernetesEndpoint: string): void {
+
+        var kubeconfigTemplateString = '{"apiVersion":"v1","kind":"Config","clusters":[{"cluster":{"certificate-authority-data": null,"server": null}}], "users":[{"user":{"token": null}}]}';
+        var kubeconfigTemplate = JSON.parse(kubeconfigTemplateString);
+
+        //populate server url, ca cert and token fields
+        kubeconfigTemplate.clusters[0].cluster.server = tl.getEndpointUrl(kubernetesEndpoint, false);
+        kubeconfigTemplate.clusters[0].cluster["certificate-authority-data"] = tl.getEndpointAuthorizationParameter(kubernetesEndpoint, 'serviceAccountCertificate', false);
+        kubeconfigTemplate.users[0].user.token = Base64.decode(tl.getEndpointAuthorizationParameter(kubernetesEndpoint, 'serviceAccountToken', false));
+
+        this.kubeconfigFile = path.join(this.userDir, "config");
+        fs.writeFileSync(this.kubeconfigFile, JSON.stringify(kubeconfigTemplate));
     }
 
     private getExecutableExtention(): string {

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 21
+        "Patch": 22
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 21
+    "Patch": 22
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/Tests/L0.ts
+++ b/Tasks/KubernetesV1/Tests/L0.ts
@@ -12,6 +12,7 @@ describe('Kubernetes Suite', function() {
     });
     beforeEach(() => {
         process.env[shared.isKubectlPresentOnMachine] = "true";
+        process.env[shared.endpointAuthorizationType] = "Kubeconfig";
         delete process.env[shared.TestEnvVars.command];
         delete process.env[shared.TestEnvVars.containerType];
         delete process.env[shared.TestEnvVars.connectionType];
@@ -42,6 +43,23 @@ describe('Kubernetes Suite', function() {
         process.env[shared.TestEnvVars.command] = shared.Commands.get;
         process.env[shared.TestEnvVars.arguments] = "pods";    
         process.env[shared.TestEnvVars.connectionType] = shared.ConnectionType.KubernetesServiceConnection;        
+        tr.run();
+
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
+        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+        assert(tr.stdout.indexOf(`[command]kubectl --kubeconfig ${shared.formatPath("newUserDir/config")} get pods -o json`) != -1, "kubectl get should run");
+        console.log(tr.stderr);
+        done();
+    });
+
+    it('Run successfully when the authorization type of the endpoint is service account and connectionType is Kubernetes Service Connection', (done:MochaDone) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        process.env[shared.TestEnvVars.command] = shared.Commands.get;
+        process.env[shared.TestEnvVars.arguments] = "pods";    
+        process.env[shared.TestEnvVars.connectionType] = shared.ConnectionType.KubernetesServiceConnection;
+        process.env[shared.endpointAuthorizationType] = "ServiceAccount";
         tr.run();
 
         assert(tr.succeeded, 'task should have succeeded');

--- a/Tasks/KubernetesV1/Tests/TestSetup.ts
+++ b/Tasks/KubernetesV1/Tests/TestSetup.ts
@@ -56,7 +56,7 @@ process.env["ENDPOINT_AUTH_kubernetesEndpoint"] = "{\"parameters\":{\"kubeconfig
 process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_KUBECONFIG"] =  "{\"apiVersion\":\"v1\", \"clusters\": [{\"cluster\": {\"insecure-skip-tls-verify\":\"true\", \"server\":\"https://5.6.7.8\", \"name\" : \"scratch\"}}], \"contexts\": [{\"context\" : {\"cluster\": \"scratch\", \"namespace\" : \"default\", \"user\": \"experimenter\", \"name\" : \"exp-scratch\"}], \"current-context\" : \"exp-scratch\", \"kind\": \"Config\", \"users\" : [{\"user\": {\"password\": \"regpassword\", \"username\" : \"test\"}]}";
 process.env["ENDPOINT_DATA_kubernetesEndpoint_AUTHORIZATIONTYPE"] = process.env[shared.endpointAuthorizationType];
 process.env["ENDPOINT_URL_kubernetesEndpoint"] = "https://mycluster.azure.com";
-process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_SERVICEACCOUNTTOKEN"] =  "saToken";
+process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_APITOKEN"] =  "saToken";
 process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_SERVICEACCOUNTCERTIFICATE"] =  "saCert";
 
 process.env["ENDPOINT_AUTH_SCHEME_AzureRMSpn"] = "ServicePrincipal";

--- a/Tasks/KubernetesV1/Tests/TestSetup.ts
+++ b/Tasks/KubernetesV1/Tests/TestSetup.ts
@@ -54,6 +54,11 @@ process.env["SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"] = "https://abc.visualstudio.co
 process.env["ENDPOINT_AUTH_dockerhubendpoint"] = "{\"parameters\":{\"username\":\"test\", \"password\":\"regpassword\", \"email\":\"test@microsoft.com\",\"registry\":\"https://index.docker.io/v1/\"},\"scheme\":\"UsernamePassword\"}";
 process.env["ENDPOINT_AUTH_kubernetesEndpoint"] = "{\"parameters\":{\"kubeconfig\":\"kubeconfig\", \"username\":\"test\", \"password\":\"regpassword\",},\"scheme\":\"UsernamePassword\"}";
 process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_KUBECONFIG"] =  "{\"apiVersion\":\"v1\", \"clusters\": [{\"cluster\": {\"insecure-skip-tls-verify\":\"true\", \"server\":\"https://5.6.7.8\", \"name\" : \"scratch\"}}], \"contexts\": [{\"context\" : {\"cluster\": \"scratch\", \"namespace\" : \"default\", \"user\": \"experimenter\", \"name\" : \"exp-scratch\"}], \"current-context\" : \"exp-scratch\", \"kind\": \"Config\", \"users\" : [{\"user\": {\"password\": \"regpassword\", \"username\" : \"test\"}]}";
+process.env["ENDPOINT_DATA_kubernetesEndpoint_AUTHORIZATIONTYPE"] = process.env[shared.endpointAuthorizationType];
+process.env["ENDPOINT_URL_kubernetesEndpoint"] = "https://mycluster.azure.com";
+process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_SERVICEACCOUNTTOKEN"] =  "saToken";
+process.env["ENDPOINT_AUTH_PARAMETER_kubernetesEndpoint_SERVICEACCOUNTCERTIFICATE"] =  "saCert";
+
 process.env["ENDPOINT_AUTH_SCHEME_AzureRMSpn"] = "ServicePrincipal";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALID"] = "MOCK_SPN_ID";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "MOCK_SPN_KEY";

--- a/Tasks/KubernetesV1/Tests/TestShared.ts
+++ b/Tasks/KubernetesV1/Tests/TestShared.ts
@@ -45,6 +45,7 @@ export let Commands = {
 };
 
 export let isKubectlPresentOnMachine = "true"; 
+export let endpointAuthorizationType = "Kubeconfig";
 
 export let ContainerTypes = {
     AzureContainerRegistry: "Azure Container Registry",

--- a/Tasks/KubernetesV1/src/clusters/generickubernetescluster.ts
+++ b/Tasks/KubernetesV1/src/clusters/generickubernetescluster.ts
@@ -9,7 +9,6 @@ export async function getKubeConfig(): Promise<string> {
     if (authorizationType === "Kubeconfig")
     {
         return tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'kubeconfig', false);
-
     }
     else if (authorizationType === "ServiceAccount")
     {

--- a/Tasks/KubernetesV1/src/clusters/generickubernetescluster.ts
+++ b/Tasks/KubernetesV1/src/clusters/generickubernetescluster.ts
@@ -1,8 +1,31 @@
 "use strict";
 
 import tl = require('vsts-task-lib/task');
+var Base64 = require('js-base64').Base64;
 
 export async function getKubeConfig(): Promise<string> {
     var kubernetesServiceEndpoint = tl.getInput("kubernetesServiceEndpoint", true);
-    return tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'kubeconfig', false);
+    var authorizationType = tl.getEndpointDataParameter(kubernetesServiceEndpoint, 'authorizationType', false);
+    if (authorizationType === "Kubeconfig")
+    {
+        return tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'kubeconfig', false);
+
+    }
+    else if (authorizationType === "ServiceAccount")
+    {
+        return createKubeconfig(kubernetesServiceEndpoint);
+    } 
+}
+
+function createKubeconfig(kubernetesServiceEndpoint: string): string
+{
+    var kubeconfigTemplateString = '{"apiVersion":"v1","kind":"Config","clusters":[{"cluster":{"certificate-authority-data": null,"server": null}}], "users":[{"user":{"token": null}}]}';
+    var kubeconfigTemplate = JSON.parse(kubeconfigTemplateString);
+
+    //populate server url, ca cert and token fields
+    kubeconfigTemplate.clusters[0].cluster.server = tl.getEndpointUrl(kubernetesServiceEndpoint, false);
+    kubeconfigTemplate.clusters[0].cluster["certificate-authority-data"] = tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'serviceAccountCertificate', false);
+    kubeconfigTemplate.users[0].user.token = Base64.decode(tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'serviceAccountToken', false));
+
+    return JSON.stringify(kubeconfigTemplate);
 }

--- a/Tasks/KubernetesV1/src/clusters/generickubernetescluster.ts
+++ b/Tasks/KubernetesV1/src/clusters/generickubernetescluster.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import tl = require('vsts-task-lib/task');
-var Base64 = require('js-base64').Base64;
+import kubectlutility = require("utility-common/kubectlutility");
 
 export async function getKubeConfig(): Promise<string> {
     var kubernetesServiceEndpoint = tl.getInput("kubernetesServiceEndpoint", true);
@@ -13,19 +13,6 @@ export async function getKubeConfig(): Promise<string> {
     }
     else if (authorizationType === "ServiceAccount")
     {
-        return createKubeconfig(kubernetesServiceEndpoint);
+        return kubectlutility.createKubeconfig(kubernetesServiceEndpoint);
     } 
-}
-
-function createKubeconfig(kubernetesServiceEndpoint: string): string
-{
-    var kubeconfigTemplateString = '{"apiVersion":"v1","kind":"Config","clusters":[{"cluster":{"certificate-authority-data": null,"server": null}}], "users":[{"user":{"token": null}}]}';
-    var kubeconfigTemplate = JSON.parse(kubeconfigTemplateString);
-
-    //populate server url, ca cert and token fields
-    kubeconfigTemplate.clusters[0].cluster.server = tl.getEndpointUrl(kubernetesServiceEndpoint, false);
-    kubeconfigTemplate.clusters[0].cluster["certificate-authority-data"] = tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'serviceAccountCertificate', false);
-    kubeconfigTemplate.users[0].user.token = Base64.decode(tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'serviceAccountToken', false));
-
-    return JSON.stringify(kubeconfigTemplate);
 }

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "preview": "true",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "preview": "true",


### PR DESCRIPTION
For the service account auth scheme, 
we need to generate a kubeconfig to run any commands.
