### PR TITLE
update blob path and increase version 🎉

### DIFF
--- a/Tasks/PublishTestResultsV2/make.json
+++ b/Tasks/PublishTestResultsV2/make.json
@@ -2,7 +2,7 @@
   "externals": {
     "archivePackages": [
       {
-        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/4637974/PublishTestResults.zip",
+        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/6277666/PublishTestResults.zip",
         "dest": "./"
       }
     ]

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 5
+        "Patch": 6
     },
     "demands": [],
     "releaseNotes": "<ul><li>NUnit3 support</li><li>Support for Minimatch files pattern</li></ul>",

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 5
+    "Patch": 6
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
- Released signed `publistestresults.zip` from releases/M135.
- Updated the blob version in `make.json`.
- Increase version of task in `task.json`
- Manual validation done.

Changes that are going in publisher
- Updated version of newtonsoft.json
- publisher will directly make a call to `tcm` endpoint instead of `tfs`