### PR TITLE
Added proxy support to DownloadSecureFile task

### DIFF
--- a/Tasks/Common/securefiles-common/securefiles-common.ts
+++ b/Tasks/Common/securefiles-common/securefiles-common.ts
@@ -13,19 +13,10 @@ export class SecureFileHelpers {
         let serverCreds: string = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'ACCESSTOKEN', false);
         let authHandler = vsts.getPersonalAccessTokenHandler(serverCreds);
 
-        let proxy = tl.getHttpProxyConfiguration();
-
-        let option: IRequestOptions = {
-            proxy: {
-                    proxyUrl: proxy.proxyUrl,
-                    proxyUsername: proxy.proxyUsername,
-                    proxyPassword: proxy.proxyPassword,
-                    proxyBypassHosts: proxy.proxyBypassHosts
-                },
-                ignoreSslError: true
-            };
-
-        this.serverConnection = new vsts.WebApi(serverUrl, authHandler, option);
+        const proxy = tl.getHttpProxyConfiguration();
+        const options = proxy ? { proxy, ignoreSslError: true } : undefined;
+        
+        this.serverConnection = new vsts.WebApi(serverUrl, authHandler, options);
     }
 
     /**

--- a/Tasks/Common/securefiles-common/securefiles-common.ts
+++ b/Tasks/Common/securefiles-common/securefiles-common.ts
@@ -3,6 +3,7 @@ import path = require('path');
 import Q = require('q');
 import tl = require('vsts-task-lib/task');
 import vsts = require('vso-node-api');
+import { IRequestOptions } from 'vso-node-api/interfaces/common/VsoBaseInterfaces';
 
 export class SecureFileHelpers {
     serverConnection: vsts.WebApi;
@@ -12,7 +13,19 @@ export class SecureFileHelpers {
         let serverCreds: string = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'ACCESSTOKEN', false);
         let authHandler = vsts.getPersonalAccessTokenHandler(serverCreds);
 
-        this.serverConnection = new vsts.WebApi(serverUrl, authHandler);
+        let proxy = tl.getHttpProxyConfiguration();
+
+        let option: IRequestOptions = {
+            proxy: {
+                    proxyUrl: proxy.proxyUrl,
+                    proxyUsername: proxy.proxyUsername,
+                    proxyPassword: proxy.proxyPassword,
+                    proxyBypassHosts: proxy.proxyBypassHosts
+                },
+                ignoreSslError: true
+            };
+
+        this.serverConnection = new vsts.WebApi(serverUrl, authHandler, option);
     }
 
     /**

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 126,
+        "Minor": 127,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 127,
+        "Minor": 137,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/DownloadSecureFileV1/task.loc.json
+++ b/Tasks/DownloadSecureFileV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 126,
+    "Minor": 137,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
As the DownloadSecureFile meanwhile initializing vso-node-api have not took into account the agent proxy settings, with this change it should solve the issue #7295 