### PR TITLE
Import-Module AzureRM fails with The TypeConverter was ignored because it already occurs

### DIFF
--- a/Tasks/Common/VstsAzureHelpers_/ImportFunctions.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/ImportFunctions.ps1
@@ -99,7 +99,7 @@ function Import-FromModulePath {
 
         # Import the module.
         Write-Host "##[command]Import-Module -Name $($module.Path) -Global"
-        $module = Import-Module -Name $module.Path -Global -PassThru
+        $module = Import-Module -Name $module.Path -Global -PassThru -Force
         Write-Verbose "Imported module version: $($module.Version)"
 
         if ($Classic) {
@@ -120,9 +120,9 @@ function Import-FromModulePath {
                 if (!$profileModule) {
                     throw (Get-VstsLocString -Key AZ_AzureRMProfileModuleNotFound)
                 }
-                # Import and then store the AzureRM.profile module. 
-                Write-Host "##[command]Import-Module -Name $($profileModule.Path) -Global" 
-                $script:azureRMProfileModule = Import-Module -Name $profileModule.Path -Global -PassThru 
+                # Import and then store the AzureRM.profile module.
+                Write-Host "##[command]Import-Module -Name $($profileModule.Path) -Global"
+                $script:azureRMProfileModule = Import-Module -Name $profileModule.Path -Global -PassThru -Force
             } else {
                 $script:azureRMProfileModule = $profileModule
             }
@@ -161,7 +161,7 @@ function Import-FromSdkPath {
                 }
                 # Import the module.
                 Write-Host "##[command]Import-Module -Name $path -Global"
-                $module = Import-Module -Name $path -Global -PassThru
+                $module = Import-Module -Name $path -Global -PassThru -Force
                 Write-Verbose "Imported module version: $($module.Version)"
                 # Store the imported module.
                 if ($Classic) {
@@ -202,7 +202,7 @@ function Import-AzureRmSubmodulesFromSdkPath {
         # Azure.Storage submodule needs to be imported first
         $azureStorageModulePath = [System.IO.Path]::Combine($programFiles, "Microsoft SDKs\Azure\PowerShell\Storage\Azure.Storage\Azure.Storage.psd1")
         Write-Host "##[command]Import-Module -Name $azureStorageModulePath -Global"
-        $azureStorageModule = Import-Module -Name $azureStorageModulePath -Global -PassThru
+        $azureStorageModule = Import-Module -Name $azureStorageModulePath -Global -PassThru -Force
         Write-Verbose "Imported module version: $($azureStorageModule.Version)"
     }
     catch {
@@ -220,7 +220,7 @@ function Import-AzureRmSubmodulesFromSdkPath {
         $azureRmNestedModulePath = [System.IO.Path]::Combine($azureRmNestedModule.FullName, $azureRmNestedModule.Name + ".psd1") 
         try {
             Write-Verbose "##[command]Import-Module -Name $azureRmNestedModulePath -Global"
-            $azureRmSubmodule = Import-Module -Name $azureRmNestedModulePath -Global -PassThru
+            $azureRmSubmodule = Import-Module -Name $azureRmNestedModulePath -Global -PassThru -Force
             Write-Verbose "Imported module version: $($azureRmSubmodule.Version)"
         }
         catch {

--- a/Tasks/Common/VstsAzureHelpers_/Tests/Import-FromSdkPath.ImportsModule.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/Tests/Import-FromSdkPath.ImportsModule.ps1
@@ -80,14 +80,14 @@ foreach ($variableSet in $variableSets) {
     # Setup Import-Module.
     if ($variableSet.FoundInProgramFilesX86) {
         $expectedModule = @{ Version = [version]'1.2.3.4' }
-        Register-Mock Import-Module { $expectedModule } -Name $wowPsd1 -Global -PassThru
+        Register-Mock Import-Module { $expectedModule } -Name $wowPsd1 -Global -PassThru -Force
     }
 
     if ($variableSet.FoundInProgramFiles) {
         $expectedModule = @{ Version = [version]'2.3.4.5' }
-        Register-Mock Import-Module { $expectedModule } -Name $psd1 -Global -PassThru
+        Register-Mock Import-Module { $expectedModule } -Name $psd1 -Global -PassThru -Force
     }
-    
+
     if($variableSet.Classic -eq $false) {
         Register-Mock Import-AzureRmSubmodulesFromSdkPath
     }
@@ -100,9 +100,9 @@ foreach ($variableSet in $variableSets) {
     # Assert.
     Assert-AreEqual $true $result
     if ($variableSet.FoundInProgramFilesX86) {
-        Assert-WasCalled Import-Module -- -Name $wowPsd1 -Global -PassThru
+        Assert-WasCalled Import-Module -- -Name $wowPsd1 -Global -PassThru -Force
     } else {
-        Assert-WasCalled Import-Module -- -Name $psd1 -Global -PassThru
+        Assert-WasCalled Import-Module -- -Name $psd1 -Global -PassThru -Force
     }
 
     if ($variableSet.Classic) {


### PR DESCRIPTION
## Issue: [https://github.com/Microsoft/vsts-tasks/issues/7443](url)

## Environment
VSTS

- Agent: Private

- Windows 10 Enterprise N

## Issue Description
**Import-Module -Name C:\Program Files\WindowsPowerShell\Modules\AzureRM\5.6.0\AzureRM.psd1 -Global fails with**:

`Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.Abstractions.IAzureContextContainer": The TypeConverter was ignored because it already occurs.`

Details:

This occurs when the module is already imported and you try to import new version.

```
Task         : Azure PowerShell
Description  : Run a PowerShell script within an Azure environment
Version      : 1.113.5
Author       : Microsoft Corporation
Help         : [More Information](https://go.microsoft.com/fwlink/?LinkID=613749)
```

**Installed AzureRM version**: 5.2.0
**Trying to upgrade to**: 5.6.0

**Failed command**: 
`Import-Module -Name C:\Program Files\WindowsPowerShell\Modules\AzureRM\5.6.0\AzureRM.psd1 -Global`

### Error logs

```
2018-06-12T20:58:33.0134658Z 'C:\Users\<user>\Documents\WindowsPowerShell\Modules\AzureRM.Profile\5.2.0\Microsoft.Azure.Commands.Profile.fo
2018-06-12T20:58:33.0135572Z rmat.ps1xml'.
2018-06-12T20:58:33.1440057Z ##[debug]Leaving Import-FromModulePath.
2018-06-12T20:58:33.1472811Z ##[debug]Leaving Import-AzureModule.
2018-06-12T20:58:33.1502244Z ##[debug]Leaving Initialize-Azure.
2018-06-12T20:58:33.1556380Z ##[debug]Caught exception from task script.
2018-06-12T20:58:33.1585446Z ##[debug]Error record:
2018-06-12T20:58:33.2573751Z ##[debug]The following error occurred while loading the extended type data file: Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.Abstractions.IAzureContextContainer": The TypeConverter was ignored because it already occurs.
2018-06-12T20:58:33.2586179Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.Abstractions.IAzureContextContainer": The member SerializationDepth is already present.
2018-06-12T20:58:33.2599107Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.ProtectedFileTokenCache": The member PropertySerializationSet is already present.
2018-06-12T20:58:33.2611729Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.ProtectedFileTokenCache": The member SerializationMethod is already present.
2018-06-12T20:58:33.2624896Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.AuthenticationStoreTokenCache": The member PropertySerializationSet is already present.
2018-06-12T20:58:33.2637584Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.AuthenticationStoreTokenCache": The member SerializationMethod is already present.
2018-06-12T20:58:33.2649929Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Profile.Models.PSAzureContext": The member SerializationDepth is already present.
2018-06-12T20:58:33.2663009Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Profile.Models.PSAzureProfile": The member SerializationDepth is already present.
2018-06-12T20:58:33.2675417Z ##[debug]
2018-06-12T20:58:33.2704356Z ##[debug]    + CategoryInfo          : NotSpecified: (:) [], RuntimeException
2018-06-12T20:58:33.2705600Z ##[debug]    + FullyQualifiedErrorId : ErrorsUpdatingTypes
2018-06-12T20:58:33.2714140Z ##[debug] 
2018-06-12T20:58:33.2734637Z ##[debug]Script stack trace:
2018-06-12T20:58:33.2780322Z ##[debug]
2018-06-12T20:58:33.2799488Z ##[debug]Exception:
2018-06-12T20:58:33.2845002Z ##[debug]System.Management.Automation.RuntimeException: The following error occurred while loading the extended type data file: Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.Abstractions.IAzureContextContainer": The TypeConverter was ignored because it already occurs.
2018-06-12T20:58:33.2857347Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.Abstractions.IAzureContextContainer": The member SerializationDepth is already present.
2018-06-12T20:58:33.2869995Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.ProtectedFileTokenCache": The member PropertySerializationSet is already present.
2018-06-12T20:58:33.2883336Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.ProtectedFileTokenCache": The member SerializationMethod is already present.
2018-06-12T20:58:33.2895795Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.AuthenticationStoreTokenCache": The member PropertySerializationSet is already present.
2018-06-12T20:58:33.2908513Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.AuthenticationStoreTokenCache": The member SerializationMethod is already present.
2018-06-12T20:58:33.2921035Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Profile.Models.PSAzureContext": The member SerializationDepth is already present.
2018-06-12T20:58:33.2934009Z ##[debug]Error in TypeData "Microsoft.Azure.Commands.Profile.Models.PSAzureProfile": The member SerializationDepth is already present.
2018-06-12T20:58:33.2946183Z ##[debug]
2018-06-12T20:58:33.2959209Z ##[debug]   at System.Management.Automation.Runspaces.InitialSessionState.ThrowTypeOrFormatErrors(String resourceString, String errorMsg, String errorId)
2018-06-12T20:58:33.2971212Z ##[debug]   at System.Management.Automation.Runspaces.InitialSessionState.UpdateTypes(ExecutionContext context, Boolean updateOnly)
2018-06-12T20:58:33.2983861Z ##[debug]   at System.Management.Automation.Runspaces.InitialSessionState.Bind_UpdateTypes(ExecutionContext context, Boolean updateOnly)
2018-06-12T20:58:33.2996133Z ##[debug]   at System.Management.Automation.Runspaces.InitialSessionState.Bind(ExecutionContext context, Boolean updateOnly, PSModuleInfo module, Boolean noClobber, Boolean local)
2018-06-12T20:58:33.3008684Z ##[debug]   at System.Management.Automation.Runspaces.InitialSessionState.Bind(ExecutionContext context, Boolean updateOnly)
2018-06-12T20:58:33.3021731Z ##[debug]   at Microsoft.PowerShell.Commands.ModuleCmdletBase.LoadModuleManifest(String moduleManifestPath, ExternalScriptInfo manifestScriptInfo, Hashtable data, Hashtable localizedData, ManifestProcessingFlags manifestProcessingFlags, Version minimumVersion, Version maximumVersion, Version requiredVersion, Nullable`1 requiredModuleGuid, ImportModuleOptions& options, Boolean& containedErrors)
2018-06-12T20:58:33.3326444Z ##[error]The following error occurred while loading the extended type data file: Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.Abstractions.IAzureContextContainer": The TypeConverter was ignored because it already occurs.
Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.Abstractions.IAzureContextContainer": The member SerializationDepth is already present.
Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.ProtectedFileTokenCache": The member PropertySerializationSet is already present.
Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.ProtectedFileTokenCache": The member SerializationMethod is already present.
Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.AuthenticationStoreTokenCache": The member PropertySerializationSet is already present.
Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.AuthenticationStoreTokenCache": The member SerializationMethod is already present.
Error in TypeData "Microsoft.Azure.Commands.Profile.Models.PSAzureContext": The member SerializationDepth is already present.
Error in TypeData "Microsoft.Azure.Commands.Profile.Models.PSAzureProfile": The member SerializationDepth is already present.
```


Related to [https://github.com/Azure/azure-powershell/issues/4835](url)

## Fix
Running the Import-Module with -Force will fix this
i.e.
`Import-Module -Name C:\Program Files\WindowsPowerShell\Modules\AzureRM\5.6.0\AzureRM.psd1 -Global -Force`