### PR TITLE
Updating TE package version for data driven results bug

### DIFF
--- a/Tasks/VsTestV2/make.json
+++ b/Tasks/VsTestV2/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/6352212/TestAgent.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/6391069/TestAgent.zip",
                 "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 136,
-        "Patch": 6
+        "Patch": 7
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTestV2/task.loc.json
+++ b/Tasks/VsTestV2/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 136,
-    "Patch": 6
+    "Patch": 7
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Issue: For hierarchical data driven tests, after the fixes were made to add attachments to sub results and parent results, previous code which was handling the attachments was not cleaned up, introducing a bug.
Impact: O365 reported that they are not seeing attachments in Data Driven tests based on Mstest v2 adapter.
Fix: This PR updates the TE package which has the fixes for this issue.