### PR TITLE
Updating TE package for fixing data driven results bug

### DIFF
--- a/Tasks/VsTest/make.json
+++ b/Tasks/VsTest/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/6332486/TestAgent.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/6391071/TestAgent.zip",
                 "dest": "./Modules"
             },
             {

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 136,
-        "Patch": 5
+        "Patch": 6
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 136,
-    "Patch": 5
+    "Patch": 6
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Issue: For hierarchical data driven tests, after the fixes were made to add attachments to sub results and parent results, previous code which was handling the attachments was not cleaned up, introducing a bug.
Impact: O365 reported that they are not seeing attachments in Data Driven tests based on Mstest v2 adapter.
Fix: This PR updates the TE package which has the fixes for this issue.