### PR TITLE
Fixing the default Test result files value.

### DIFF
--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 6
+        "Patch": 7
     },
     "demands": [],
     "releaseNotes": "<ul><li>NUnit3 support</li><li>Support for Minimatch files pattern</li></ul>",
@@ -44,7 +44,7 @@
             "name": "testResultsFiles",
             "type": "multiLine",
             "label": "Test results files",
-            "defaultValue": "**\\TEST-*.xml",
+            "defaultValue": "**/TEST-*.xml",
             "required": true,
             "helpMarkDown": "Test results files path. Supports multiple lines of minimatch patterns. [More Information](https://go.microsoft.com/fwlink/?LinkId=835764)",
             "properties": {

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 6
+    "Patch": 7
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -44,7 +44,7 @@
       "name": "testResultsFiles",
       "type": "multiLine",
       "label": "ms-resource:loc.input.label.testResultsFiles",
-      "defaultValue": "**\\TEST-*.xml",
+      "defaultValue": "**/TEST-*.xml",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.testResultsFiles",
       "properties": {


### PR DESCRIPTION
- Changed the path to contain / separator only. As earlier default \ was not valid in Linux agents.
- #7260 