### PR TITLE
Updating TE package for TP/TS fix

### DIFF
--- a/Tasks/VsTestV2/make.json
+++ b/Tasks/VsTestV2/make.json
@@ -2,7 +2,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://testselectorv2.blob.core.windows.net/testselector/6175539/TestSelector.zip",
+                "url": "https://testselectorv2.blob.core.windows.net/testselector/6408551/TestSelector.zip",
                 "dest": "./"
             },
             {

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 136,
-        "Patch": 7
+        "Patch": 8
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTestV2/task.loc.json
+++ b/Tasks/VsTestV2/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 136,
-    "Patch": 7
+    "Patch": 8
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Issue: Currently it is allowed to associate same test method to multiple test cases in a TP/TS scenario. With the support for hierarchical results, we introduced data driven result processor which works on the FQDN to determine children results. In the the above special case of TP/TS, the two executions of the same test method will lead to same FQDN in results but are not data driven. We were not handling this special case.
Impact: Bestbuy has reported this issue. A workaround for them is to disable the hierarchical results feature flag.
Fix: We have handled this special case now by using both FQDN and test case id as the key in the result processor.