### PR TITLE
Sending merge option as true while publishing test results.

### DIFF
--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 137,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTestV2/vstest.ts
+++ b/Tasks/VsTestV2/vstest.ts
@@ -643,7 +643,7 @@ function publishTestResults(testResultsDirectory: string): tl.TaskResult {
 
             if (resultFiles && resultFiles.length !== 0) {
                 const tp = new tl.TestPublisher('VSTest');
-                tp.publish(resultFiles, 'false', vstestConfig.buildPlatform, vstestConfig.buildConfig, vstestConfig.testRunTitle, vstestConfig.publishRunAttachments);
+                tp.publish(resultFiles, 'true', vstestConfig.buildPlatform, vstestConfig.buildConfig, vstestConfig.testRunTitle, vstestConfig.publishRunAttachments);
             } else {
                 console.log('##vso[task.logissue type=warning;code=002003;]');
                 tl.warning(tl.loc('NoResultsToPublish'));


### PR DESCRIPTION
- Since VsTest task always creates a single TestRun sending merge option as true.
- This actually fixes one confusion when the users specified the custom test run title in the task,
  Once the test runs are published in the UI they use to see `title` as `title_1`. Which is confusing in the
   single test run scenario.