### PR TITLE
Update packer version and modified the test to pull the defined version from task constants

### DIFF
--- a/Tasks/PackerBuildV0/Tests/L0.ts
+++ b/Tasks/PackerBuildV0/Tests/L0.ts
@@ -1,5 +1,7 @@
 import * as path from 'path';
 import * as assert from 'assert';
+import * as util from 'util';
+import * as constants from '../src/constants';
 import * as ttm from 'vsts-task-lib/mock-test';
 import tl = require('vsts-task-lib');
 
@@ -365,8 +367,9 @@ describe('PackerBuild Suite', function() {
             assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
             assert(tr.succeeded, 'task should have succeeded');
             assert(tr.stdout.indexOf("loc_mock_DownloadingPackerRequired") != -1, "should show message that packer will be downloaded");
-            assert(tr.stdout.indexOf("Downloading packer from url: https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_windows_amd64.zip") != -1, "should download from correct url");
-            assert(tr.stdout.indexOf("downloading from url https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_windows_amd64.zip to F:\\somedir\\tempdir\\100\\packer.zip") != -1, "should download to correct staging dir");
+            var packerWindowsDownloadUrl = util.format(constants.PackerDownloadUrlFormat, constants.CurrentSupportedPackerVersionString, constants.CurrentSupportedPackerVersionString, 'windows_amd64');
+            assert(tr.stdout.indexOf('Downloading packer from url: ' + packerWindowsDownloadUrl ) != -1, "should download from correct url");
+            assert(tr.stdout.indexOf('downloading from url '+ packerWindowsDownloadUrl+'to F:\\somedir\\tempdir\\100\\packer.zip') != -1, "should download to correct staging dir");
             assert(tr.stdout.indexOf("extracting from zip F:\\somedir\\tempdir\\100\\packer.zip to F:\\somedir\\tempdir\\100\\packer") != -1, "should extract from and to correct path");
             assert(tr.stdout.indexOf("Packer path to be used by task: F:\\somedir\\tempdir\\100\\packer\\packer.exe") != -1, "should show message that packer will be downloaded");
             assert(tr.stdout.indexOf("##vso[task.setvariable variable=imageUri;issecret=false;]https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd") != -1, "image uri output variable not set");
@@ -387,8 +390,9 @@ describe('PackerBuild Suite', function() {
             assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
             assert(tr.succeeded, 'task should have succeeded');
             assert(tr.stdout.indexOf("loc_mock_DownloadingPackerRequired") != -1, "should show message that packer will be downloaded");
-            assert(tr.stdout.indexOf("Downloading packer from url: https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_windows_amd64.zip") != -1, "should download from correct url");
-            assert(tr.stdout.indexOf("downloading from url https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_windows_amd64.zip to F:\\somedir\\tempdir\\100\\packer.zip") != -1, "should download to correct staging dir");
+            var packerWindowsDownloadUrl = util.format(constants.PackerDownloadUrlFormat, constants.CurrentSupportedPackerVersionString, constants.CurrentSupportedPackerVersionString, 'windows_amd64');
+            assert(tr.stdout.indexOf('Downloading packer from url: ' + packerWindowsDownloadUrl ) != -1, "should download from correct url");
+            assert(tr.stdout.indexOf('downloading from url '+ packerWindowsDownloadUrl+'to F:\\somedir\\tempdir\\100\\packer.zip') != -1, "should download to correct staging dir");
             assert(tr.stdout.indexOf("extracting from zip F:\\somedir\\tempdir\\100\\packer.zip to F:\\somedir\\tempdir\\100\\packer") != -1, "should extract from and to correct path");
             assert(tr.stdout.indexOf("Packer path to be used by task: F:\\somedir\\tempdir\\100\\packer\\packer.exe") != -1, "should show message that packer will be downloaded");
             assert(tr.stdout.indexOf("##vso[task.setvariable variable=imageUri;issecret=false;]https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd") != -1, "image uri output variable not set");
@@ -568,8 +572,9 @@ describe('PackerBuild Suite', function() {
             assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
             assert(tr.succeeded, 'task should have succeeded');
             assert(tr.stdout.indexOf("loc_mock_DownloadingPackerRequired") != -1, "should show message that packer will be downloaded");
-            assert(tr.stdout.indexOf("Downloading packer from url: https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_linux_amd64.zip") != -1, "should download from correct url");
-            assert(tr.stdout.indexOf("downloading from url https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_linux_amd64.zip to /tmp/tempdir/100/packer.zip") != -1, "should download to correct staging dir");
+            var packerLinuxDownloadUrl = util.format(constants.PackerDownloadUrlFormat, constants.CurrentSupportedPackerVersionString, constants.CurrentSupportedPackerVersionString, 'linux_amd64');
+            assert(tr.stdout.indexOf('Downloading packer from url: ' + packerLinuxDownloadUrl) != -1, "should download from correct url");
+            assert(tr.stdout.indexOf('downloading from url '+ packerLinuxDownloadUrl +' to /tmp/tempdir/100/packer.zip') != -1, "should download to correct staging dir");
             assert(tr.stdout.indexOf("extracting from zip /tmp/tempdir/100/packer.zip to /tmp/tempdir/100/packer") != -1, "should extract from and to correct path");
             assert(tr.stdout.indexOf("Packer path to be used by task: /tmp/tempdir/100/packer/packer") != -1, "should show message that packer will be downloaded");
             assert(tr.stdout.indexOf("##vso[task.setvariable variable=imageUri;issecret=false;]https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd") != -1, "image uri output variable not set");
@@ -590,8 +595,9 @@ describe('PackerBuild Suite', function() {
             assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
             assert(tr.succeeded, 'task should have succeeded');
             assert(tr.stdout.indexOf("loc_mock_DownloadingPackerRequired") != -1, "should show message that packer will be downloaded");
-            assert(tr.stdout.indexOf("Downloading packer from url: https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_linux_amd64.zip") != -1, "should download from correct url");
-            assert(tr.stdout.indexOf("downloading from url https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_linux_amd64.zip to /tmp/tempdir/100/packer.zip") != -1, "should download to correct staging dir");
+            var packerLinuxDownloadUrl = util.format(constants.PackerDownloadUrlFormat, constants.CurrentSupportedPackerVersionString, constants.CurrentSupportedPackerVersionString, 'linux_amd64');
+            assert(tr.stdout.indexOf('Downloading packer from url: ' + packerLinuxDownloadUrl) != -1, "should download from correct url");
+            assert(tr.stdout.indexOf('downloading from url '+ packerLinuxDownloadUrl +' to /tmp/tempdir/100/packer.zip') != -1, "should download to correct staging dir");
             assert(tr.stdout.indexOf("extracting from zip /tmp/tempdir/100/packer.zip to /tmp/tempdir/100/packer") != -1, "should extract from and to correct path");
             assert(tr.stdout.indexOf("Packer path to be used by task: /tmp/tempdir/100/packer/packer") != -1, "should show message that packer will be downloaded");
             assert(tr.stdout.indexOf("##vso[task.setvariable variable=imageUri;issecret=false;]https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd") != -1, "image uri output variable not set");

--- a/Tasks/PackerBuildV0/Tests/L0CustomTemplate.ts
+++ b/Tasks/PackerBuildV0/Tests/L0CustomTemplate.ts
@@ -1,6 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import * as constants from '../src/constants';
 
 let taskPath = path.join(__dirname, '..\\src\\main.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
@@ -26,7 +27,7 @@ let a: any = <any>{
     "exec": {
         "packer --version": {
             "code": 0,
-            "stdout": "0.12.3"
+            "stdout": constants.CurrentSupportedPackerVersionString
         },
         "packer fix -validate=false C:\\custom.template.json": {
             "code": 0,

--- a/Tasks/PackerBuildV0/Tests/L0Linux.ts
+++ b/Tasks/PackerBuildV0/Tests/L0Linux.ts
@@ -1,7 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
-
+import * as constants from '../src/constants';
 const DefaultWorkingDirectory: string = "/a/w";
 
 let taskPath = path.join(__dirname, '..', 'src', 'main.js');
@@ -48,7 +48,7 @@ let a: any = <any>{
     "exec": {
         "packer --version": {
             "code": 0,
-            "stdout": "0.12.3"
+            "stdout": constants.CurrentSupportedPackerVersionString
         },
         "packer fix -validate=false /tmp/tempdir/100/default.linux.template.json": {
             "code": 0,

--- a/Tasks/PackerBuildV0/Tests/L0LinuxBuiltinTemplateAdditionalParameters.ts
+++ b/Tasks/PackerBuildV0/Tests/L0LinuxBuiltinTemplateAdditionalParameters.ts
@@ -1,6 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import * as constants from '../src/constants';
 
 const DefaultWorkingDirectory: string = "/a/w";
 
@@ -48,7 +49,7 @@ let a: any = <any>{
     "exec": {
         "packer --version": {
             "code": 0,
-            "stdout": "0.12.3"
+            "stdout": constants.CurrentSupportedPackerVersionString
         },
         "packer fix -validate=false /tmp/tempdir/100/default.linux.template-builderUpdated.json": {
             "code": 0,

--- a/Tasks/PackerBuildV0/Tests/L0LinuxCustomImage.ts
+++ b/Tasks/PackerBuildV0/Tests/L0LinuxCustomImage.ts
@@ -1,6 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import * as constants from '../src/constants';
 
 const DefaultWorkingDirectory: string = "/a/w";
 
@@ -49,7 +50,7 @@ let a: any = <any>{
     "exec": {
         "packer --version": {
             "code": 0,
-            "stdout": "0.12.3"
+            "stdout": constants.CurrentSupportedPackerVersionString
         },
         "packer fix -validate=false /tmp/tempdir/100/custom.linux.template.json": {
             "code": 0,

--- a/Tasks/PackerBuildV0/Tests/L0LinuxInstallPacker.ts
+++ b/Tasks/PackerBuildV0/Tests/L0LinuxInstallPacker.ts
@@ -1,6 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import * as constants from '../src/constants';
 
 const DefaultWorkingDirectory: string = "/a/w";
 
@@ -50,7 +51,7 @@ let a: any = <any>{
     "exec": {
         "packer --version": {
             "code": 0,
-            "stdout": process.env["__lower_version__"] === "true" ? "0.11.2" : "0.12.3"
+            "stdout": process.env["__lower_version__"] === "true" ? "0.11.2" : constants.CurrentSupportedPackerVersionString
         },
         "/tmp/tempdir/100/packer/packer fix -validate=false /tmp/tempdir/100/default.linux.template.json": {
             "code": 0,

--- a/Tasks/PackerBuildV0/Tests/L0LinuxsBuiltinTemplateAdditionalParameters.ts
+++ b/Tasks/PackerBuildV0/Tests/L0LinuxsBuiltinTemplateAdditionalParameters.ts
@@ -1,6 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import * as constants from '../src/constants';
 
 const DefaultWorkingDirectory: string = "/a/w";
 
@@ -48,7 +49,7 @@ let a: any = <any>{
     "exec": {
         "packer --version": {
             "code": 0,
-            "stdout": "0.12.3"
+            "stdout": constants.CurrentSupportedPackerVersionString
         },
         "packer fix -validate=false /tmp/tempdir/100/default.linux.template-builderUpdated.json": {
             "code": 0,

--- a/Tasks/PackerBuildV0/Tests/L0Parser.ts
+++ b/Tasks/PackerBuildV0/Tests/L0Parser.ts
@@ -1,6 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import * as constants from '../src/constants';
 
 const DefaultWorkingDirectory: string = "C:\\a\\w\\";
 
@@ -47,7 +48,7 @@ let a: any = <any>{
     "exec": {
         "packer --version": {
             "code": 0,
-            "stdout": "0.12.3"
+            "stdout": constants.CurrentSupportedPackerVersionString
         },
         "packer fix -validate=false F:\\somedir\\tempdir\\100\\default.windows.template.json": {
             "code": 0,

--- a/Tasks/PackerBuildV0/Tests/L0Windows.ts
+++ b/Tasks/PackerBuildV0/Tests/L0Windows.ts
@@ -1,6 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import * as constants from '../src/constants';
 
 const DefaultWorkingDirectory: string = "C:\\a\\w\\";
 
@@ -54,7 +55,7 @@ let a: any = <any>{
     "exec": {
         "packer --version": {
             "code": 0,
-            "stdout": "0.12.3"
+            "stdout": constants.CurrentSupportedPackerVersionString
         },
         "packer fix -validate=false F:\\somedir\\tempdir\\100\\default.windows.template.json": {
             "code": 0,

--- a/Tasks/PackerBuildV0/Tests/L0WindowsBuiltinTemplateAdditionalParameters.ts
+++ b/Tasks/PackerBuildV0/Tests/L0WindowsBuiltinTemplateAdditionalParameters.ts
@@ -1,6 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import * as constants from '../src/constants';
 
 const DefaultWorkingDirectory: string = "C:\\a\\w\\";
 
@@ -48,7 +49,7 @@ let a: any = <any>{
     "exec": {
         "packer --version": {
             "code": 0,
-            "stdout": "0.12.3"
+            "stdout": constants.CurrentSupportedPackerVersionString
         },
         "packer fix -validate=false F:\\somedir\\tempdir\\100\\default.windows.template-builderUpdated.json": {
             "code": 0,

--- a/Tasks/PackerBuildV0/Tests/L0WindowsCustomImage.ts
+++ b/Tasks/PackerBuildV0/Tests/L0WindowsCustomImage.ts
@@ -1,6 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import * as constants from '../src/constants';
 
 const DefaultWorkingDirectory: string = "C:\\a\\w\\";
 
@@ -49,7 +50,7 @@ let a: any = <any>{
     "exec": {
         "packer --version": {
             "code": 0,
-            "stdout": "0.12.3"
+            "stdout": constants.CurrentSupportedPackerVersionString
         },
         "packer fix -validate=false F:\\somedir\\tempdir\\100\\custom.windows.template.json": {
             "code": 0,

--- a/Tasks/PackerBuildV0/Tests/L0WindowsFail.ts
+++ b/Tasks/PackerBuildV0/Tests/L0WindowsFail.ts
@@ -1,6 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import * as constants from '../src/constants';
 
 const DefaultWorkingDirectory: string = "C:\\a\\w\\";
 
@@ -49,7 +50,7 @@ let a: any = <any>{
     "exec": {
         "packer --version": {
             "code": 0,
-            "stdout": "0.12.3"
+            "stdout": constants.CurrentSupportedPackerVersionString
         },
         "packer fix -validate=false F:\\somedir\\tempdir\\100\\default.windows.template.json": {
             "code": process.env["__packer_fix_fails__"] === "true" ? 1 : 0,

--- a/Tasks/PackerBuildV0/Tests/L0WindowsInstallPacker.ts
+++ b/Tasks/PackerBuildV0/Tests/L0WindowsInstallPacker.ts
@@ -1,6 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import * as constants from '../src/constants';
 
 const DefaultWorkingDirectory: string = "C:\\a\\w\\";
 
@@ -48,11 +49,11 @@ let a: any = <any>{
     "exec": {
         "packer --version": {
             "code": 0,
-            "stdout": process.env["__lower_version__"] === "true" ? "0.11.2" : "0.12.3"
+            "stdout": process.env["__lower_version__"] === "true" ? "0.11.2" : constants.CurrentSupportedPackerVersionString
         },
         "F:\\somedir\\tempdir\\100\\packer\\packer.exe --version": {
             "code": 0,
-            "stdout": process.env["__lower_version__"] === "true" ? "0.11.2" : "0.12.3"
+            "stdout": process.env["__lower_version__"] === "true" ? "0.11.2" : constants.CurrentSupportedPackerVersionString
         },
         "F:\\somedir\\tempdir\\100\\packer\\packer.exe fix -validate=false F:\\somedir\\tempdir\\100\\default.windows.template.json": {
             "code": 0,

--- a/Tasks/PackerBuildV0/src/constants.ts
+++ b/Tasks/PackerBuildV0/src/constants.ts
@@ -46,7 +46,7 @@ export var PackerLogTokenStorageLocation = "StorageAccountLocation";
 
 export var OutputVariableImageUri = "imageUri";
 
-export var CurrentSupportedPackerVersionString = "0.12.3";
+export var CurrentSupportedPackerVersionString = "1.2.4";
 export var PackerDownloadUrlFormat =  "https://releases.hashicorp.com/packer/%s/packer_%s_%s.zip"
 
 export var TemplateTypeCustom = "custom";

--- a/Tasks/PackerBuildV0/task.json
+++ b/Tasks/PackerBuildV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 14
+        "Patch": 15
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",


### PR DESCRIPTION
- Update the packer version to latest (1.2.4)

- Modified the test suite (L0) removing the hardcoded packer version and replace it with a reference to the version defined in the constant file.

- The PR should address the following open issues #6876 and #6196

![screen shot 2018-06-18 at 1 52 54 pm](https://user-images.githubusercontent.com/5002831/41530121-3bdec8ec-7300-11e8-8948-f8c466f08d5a.png)
