### PR TITLE
Using allowBrokenSymLinks findOptions while calling findMatch API.

### DIFF
--- a/Tasks/PublishTestResultsV2/cieventlogger.ts
+++ b/Tasks/PublishTestResultsV2/cieventlogger.ts
@@ -15,10 +15,27 @@ function getDefaultProps() {
 
 export function publishEvent(properties: { [key: string]: any }): void {
     try {
-        tl.assertAgent('2.125.0');
-        tl.publishTelemetry(area, feature, Object.assign(getDefaultProps(), properties));
-
+        _writeTelemetry(area, feature, Object.assign(getDefaultProps(), properties));
     } catch (err) {
         tl.debug('Unable to publish telemetry due to lower agent version.');
+    }
+}
+
+
+function _writeTelemetry(area, feature, properties) {
+    // The telemetry command was added in agent version 2.120.0.
+    try {
+        var splitVersion = (process.env.AGENT_VERSION || '').split('.');
+        var major = parseInt(splitVersion[0] || '0');
+        var minor = parseInt(splitVersion[1] || '0');
+        if (major > 2 || (major == 2 && minor >= 120)) {
+            console.log(`##vso[telemetry.publish area=${area};feature=${feature}]${JSON.stringify(properties)}`);
+        }
+        else {
+            tl.debug(`cannot write telemetry in agent ${process.env.AGENT_VERSION}`);
+        }
+    }
+    catch (err) {
+        tl.debug(`Error in writing telemetry : ${err}`);
     }
 }

--- a/Tasks/PublishTestResultsV2/package.json
+++ b/Tasks/PublishTestResultsV2/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/microsoft/vsts-tasks#readme",
   "dependencies": {
-    "vsts-task-lib": "2.0.6",
+    "vsts-task-lib": "2.5.0",
     "uuid": "^3.0.1"
   }
 }

--- a/Tasks/PublishTestResultsV2/publishtestresults.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresults.ts
@@ -41,20 +41,13 @@ async function run() {
             searchFolder = tl.getVariable('System.DefaultWorkingDirectory');
         }
 
-        let matchingTestResultsFiles: string [];
-        try {
-            matchingTestResultsFiles = tl.findMatch(searchFolder, testResultsFiles);
-        }
-        catch(error) {
-            tl.debug('Error in find matching files : ' + error);
-            tl.debug('Trying without following symlinks.');
-            // Will remove this once we have right api in vsts-task-lib.
-            const findOptions = <tl.FindOptions>{
-                followSpecifiedSymbolicLink: false,
-                followSymbolicLinks: false
-            };
-            matchingTestResultsFiles = tl.findMatch(searchFolder, testResultsFiles, findOptions);
-        }
+        // Sending allowBrokenSymbolicLinks as true, so we don't want to throw error when symlinks are broken.
+        // And can continue with other files if there are any.
+        const findOptions = <tl.FindOptions>{
+            allowBrokenSymbolicLinks: true
+        };
+
+        let matchingTestResultsFiles = tl.findMatch(searchFolder, testResultsFiles, findOptions);
 
         const testResultsFilesCount = matchingTestResultsFiles ? matchingTestResultsFiles.length : 0;
 

--- a/Tasks/PublishTestResultsV2/publishtestresults.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresults.ts
@@ -44,7 +44,9 @@ async function run() {
         // Sending allowBrokenSymbolicLinks as true, so we don't want to throw error when symlinks are broken.
         // And can continue with other files if there are any.
         const findOptions = <tl.FindOptions>{
-            allowBrokenSymbolicLinks: true
+            allowBrokenSymbolicLinks: true,
+            followSpecifiedSymbolicLink: true,
+            followSymbolicLinks: true
         };
 
         let matchingTestResultsFiles = tl.findMatch(searchFolder, testResultsFiles, findOptions);


### PR DESCRIPTION
- Removing the patchwork that was done earlier to unblock the customers.
- using vsts-task-lib 2.5.0
- 2.5.0 doesn't support sending telemetry, using the alternative agent code to publish telemetry. 