### PR TITLE
Fix Cased .Config Files Being Ignored

### DIFF
--- a/Tasks/Common/webdeployment-common/xdttransformationutility.ts
+++ b/Tasks/Common/webdeployment-common/xdttransformationutility.ts
@@ -56,7 +56,7 @@ export function basicXdtTransformation(rootFolder, transformConfigs): boolean {
     var isTransformationApplied = false;
     Object.keys(sourceXmlFiles).forEach( function(sourceXmlFile) {
         sourceXmlFile = sourceXmlFiles[sourceXmlFile];
-        var sourceBasename = path.win32.basename(sourceXmlFile, ".config");    
+        var sourceBasename = path.win32.basename(sourceXmlFile.replace(/\.config/ig,'\.config'), ".config");    
         transformConfigs.forEach( function(transformConfig) {
             var transformXmlFile = path.join(path.dirname(sourceXmlFile), sourceBasename + "." + transformConfig);
             if(sourceXmlFiles[transformXmlFile.toLowerCase()]) {


### PR DESCRIPTION
Minor fix to correctly strip away the .config suffix for files during
the search for the appropriate environment config file. Without the fix,
for an XML file labelled Web.Config (note the uppercase C), the script would
try and search for a transform file of Web.Config.Dev.config for an
environment named 'Dev' - instead of Web.Dev.config.  This minor 
patch addresses the problem.

The reason I feel it's needed is the time other developers like
myself could waste trying to figure out why the config transform file 
is being ignored.  I inherited a large solution where the original team
had named the config files as .Config.  On first glance, that's not an 
immediately obvious cause of the problem - it was only going through
the task code I realised why after numerous attempts at trying to work
out why they were being ignored.