### PR TITLE
Changing the help text for the option to publish run attachments

### DIFF
--- a/Tasks/PublishTestResultsV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishTestResultsV2/Strings/resources.resjson/en-US/resources.resjson
@@ -20,7 +20,7 @@
   "loc.input.label.configuration": "Configuration",
   "loc.input.help.configuration": "Configuration for which the tests were run.",
   "loc.input.label.publishRunAttachments": "Upload test results files",
-  "loc.input.help.publishRunAttachments": "A test run is created for each results file. Check this option to merge results into a single test run. To optimize for better performance, results will be merged into a single run if there are more than 100 result files, irrespective of this option.",
+  "loc.input.help.publishRunAttachments": "Upload logs and other files containing diagnostic information collected when the tests were run.",
   "loc.messages.NoMatchingFilesFound": "No test result files matching '%s' were found.",
   "loc.messages.ErrorTestResultsPublisher": "Error while executing TestResultsPublisher: %s."
 }

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 7
+        "Patch": 8
     },
     "demands": [],
     "releaseNotes": "<ul><li>NUnit3 support</li><li>Support for Minimatch files pattern</li></ul>",
@@ -100,7 +100,7 @@
             "label": "Upload test results files",
             "defaultValue": "true",
             "required": false,
-            "helpMarkDown": "Upload logs and other files containing diagnostic information from when the tests were run.",
+            "helpMarkDown": "Upload logs and other files containing diagnostic information collected when the tests were run.",
             "groupName": "advanced"
         }
     ],

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -100,7 +100,7 @@
             "label": "Upload test results files",
             "defaultValue": "true",
             "required": false,
-            "helpMarkDown": "A test run is created for each results file. Check this option to merge results into a single test run. To optimize for better performance, results will be merged into a single run if there are more than 100 result files, irrespective of this option.",
+            "helpMarkDown": "Upload logs and other files containing diagnostic information from when the tests were run.",
             "groupName": "advanced"
         }
     ],

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 7
+    "Patch": 8
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
We were using the same string as for a different option leading to confusion
https://developercommunity.visualstudio.com/content/problem/279688/the-publish-test-result-task-has-2-identical-toolt.html