### PR TITLE
Fixing dotnet pack automatic versioning bug

### DIFF
--- a/Tasks/DotNetCoreCLIV2/Tests/L0.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/L0.ts
@@ -380,7 +380,7 @@ describe('DotNetCoreExe Suite', function () {
 
         tr.run();
         assert(tr.invokedToolCount == 1, 'should have run dotnet once');
-        assert(tr.ran('c:\\path\\dotnet.exe pack c:\\agent\\home\\directory\\single.csproj --output C:\\out\\dir /p:PackageVersion=1.2.3'), 'it should have run dotnet');
+        assert(tr.ran('c:\\path\\dotnet.exe pack c:\\agent\\home\\directory\\single.csproj --output C:\\out\\dir /p:PackageVersion=1.2.3-prerelease'), 'it should have run dotnet');
         assert(tr.stdOutContained('dotnet output'), "should have dotnet output");
         assert(tr.succeeded, 'should have succeeded');
         assert.equal(tr.errorIssues.length, 0, "should have no errors");

--- a/Tasks/DotNetCoreCLIV2/Tests/PackTests/packBuildNumber.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/PackTests/packBuildNumber.ts
@@ -23,7 +23,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "dotnet": "c:\\path\\dotnet.exe"
     },
     "exec": {
-        "c:\\path\\dotnet.exe pack c:\\agent\\home\\directory\\single.csproj --output C:\\out\\dir /p:PackageVersion=1.2.3": {
+        "c:\\path\\dotnet.exe pack c:\\agent\\home\\directory\\single.csproj --output C:\\out\\dir /p:PackageVersion=1.2.3-prerelease": {
             "code": 0,
             "stdout": "dotnet output",
             "stderr": ""
@@ -43,7 +43,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 };
 nmh.setAnswers(a);
 
-process.env['BUILD_BUILDNUMBER'] = '1.2.3'
+process.env['BUILD_BUILDNUMBER'] = '1.2.3-prerelease'
 nmh.registerNugetUtilityMock(["c:\\agent\\home\\directory\\single.csproj"]);
 nmh.registerDefaultNugetVersionMock();
 nmh.registerToolRunnerMock();

--- a/Tasks/DotNetCoreCLIV2/packcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/packcommand.ts
@@ -60,7 +60,7 @@ export async function run(): Promise<void> {
                 let buildNumber: string = tl.getVariable("BUILD_BUILDNUMBER");
                 tl.debug(`Build number: ${buildNumber}`);
 
-                let versionRegex = /\d+\.\d+\.\d+(?:\.\d+)?/;
+                let versionRegex = /\bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z-]+(?:\.[\da-z-]+)*)?\b/;
                 let versionMatches = buildNumber.match(versionRegex);
                 if (!versionMatches) {
                     tl.setResult(tl.TaskResult.Failed, tl.loc("Error_NoVersionFoundInBuildNumber"));


### PR DESCRIPTION
Allowing "1.0.0-flag" format in dotnet pack when using build number format in the package version number #5655 