### PR TITLE
Disable colored output in build call to packer

### DIFF
--- a/Tasks/PackerBuildV0/Tests/L0CustomTemplate.ts
+++ b/Tasks/PackerBuildV0/Tests/L0CustomTemplate.ts
@@ -36,7 +36,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "packer build -force -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json C:\\custom.template-fixed.json": {
+        "packer build -force -color=false -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json C:\\custom.template-fixed.json": {
             "code": process.env["__packer_build_fails__"] === "true" ? 1 : 0,
             "stdout": process.env["__packer_build_fails__"] === "true" ? "packer build failed\r\nsome error" : "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia",
          }

--- a/Tasks/PackerBuildV0/Tests/L0Linux.ts
+++ b/Tasks/PackerBuildV0/Tests/L0Linux.ts
@@ -58,7 +58,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "packer build -force -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json /tmp/tempdir/100/default.linux.template-fixed.json": {
+        "packer build -force -color=false -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json /tmp/tempdir/100/default.linux.template-fixed.json": {
             "code": process.env["__packer_build_fails__"] === "true" ? 1 : 0,
             "stdout": process.env["__packer_build_fails__"] === "true" ? "packer build failed\r\nsome error" : "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia",
         },
@@ -70,7 +70,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "packer build -force -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json \\tmp\\tempdir\\100\\default.linux.template-fixed.json": {
+        "packer build -force -color=false -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json \\tmp\\tempdir\\100\\default.linux.template-fixed.json": {
             "code": process.env["__packer_build_fails__"] === "true" ? 1 : 0,
             "stdout": process.env["__packer_build_fails__"] === "true" ? "packer build failed\r\nsome error" : "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia",
         }

--- a/Tasks/PackerBuildV0/Tests/L0LinuxBuiltinTemplateAdditionalParameters.ts
+++ b/Tasks/PackerBuildV0/Tests/L0LinuxBuiltinTemplateAdditionalParameters.ts
@@ -58,7 +58,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "packer build -force -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json /tmp/tempdir/100/default.linux.template-builderUpdated-fixed.json": {
+        "packer build -force -color=false -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json /tmp/tempdir/100/default.linux.template-builderUpdated-fixed.json": {
             "code": process.env["__packer_build_fails__"] === "true" ? 1 : 0,
             "stdout": process.env["__packer_build_fails__"] === "true" ? "packer build failed\r\nsome error" : "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia",
         },
@@ -70,7 +70,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "packer build -force -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json \\tmp\\tempdir\\100\\default.linux.template-builderUpdated-fixed.json": {
+        "packer build -force -color=false -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json \\tmp\\tempdir\\100\\default.linux.template-builderUpdated-fixed.json": {
             "code": process.env["__packer_build_fails__"] === "true" ? 1 : 0,
             "stdout": process.env["__packer_build_fails__"] === "true" ? "packer build failed\r\nsome error" : "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia",
         }

--- a/Tasks/PackerBuildV0/Tests/L0LinuxCustomImage.ts
+++ b/Tasks/PackerBuildV0/Tests/L0LinuxCustomImage.ts
@@ -59,7 +59,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "packer build -force -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json /tmp/tempdir/100/custom.linux.template-fixed.json": {
+        "packer build -force -color=false -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json /tmp/tempdir/100/custom.linux.template-fixed.json": {
             "code": process.env["__packer_build_fails__"] === "true" ? 1 : 0,
             "stdout": process.env["__packer_build_fails__"] === "true" ? "packer build failed\r\nsome error" : "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia",
         },
@@ -71,7 +71,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "packer build -force -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json \\tmp\\tempdir\\100\\custom.linux.template-fixed.json": {
+        "packer build -force -color=false -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json \\tmp\\tempdir\\100\\custom.linux.template-fixed.json": {
             "code": process.env["__packer_build_fails__"] === "true" ? 1 : 0,
             "stdout": process.env["__packer_build_fails__"] === "true" ? "packer build failed\r\nsome error" : "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia",
         }

--- a/Tasks/PackerBuildV0/Tests/L0LinuxInstallPacker.ts
+++ b/Tasks/PackerBuildV0/Tests/L0LinuxInstallPacker.ts
@@ -60,7 +60,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "/tmp/tempdir/100/packer/packer build -force -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json /tmp/tempdir/100/default.linux.template-fixed.json": {
+        "/tmp/tempdir/100/packer/packer build -force -color=false -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json /tmp/tempdir/100/default.linux.template-fixed.json": {
             "code": process.env["__packer_build_fails__"] === "true" ? 1 : 0,
             "stdout": process.env["__packer_build_fails__"] === "true" ? "packer build failed\r\nsome error" : "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia",
         },
@@ -72,7 +72,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "\\tmp\\tempdir\\100\\packer\\packer fix build -force -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json \\tmp\\tempdir\\100\\default.linux.template-fixed.json": {
+        "\\tmp\\tempdir\\100\\packer\\packer fix build -force -color=false -var-file=/somefolder/somevarfile.json -var-file=/somefolder/somevarfile.json \\tmp\\tempdir\\100\\default.linux.template-fixed.json": {
             "code": process.env["__packer_build_fails__"] === "true" ? 1 : 0,
             "stdout": process.env["__packer_build_fails__"] === "true" ? "packer build failed\r\nsome error" : "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia",
         }

--- a/Tasks/PackerBuildV0/Tests/L0Parser.ts
+++ b/Tasks/PackerBuildV0/Tests/L0Parser.ts
@@ -57,7 +57,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "packer build -force -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json F:\\somedir\\tempdir\\100\\default.windows.template-fixed.json": {
+        "packer build -force -color=false -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json F:\\somedir\\tempdir\\100\\default.windows.template-fixed.json": {
             "code": 0,
             "stdout": process.env["__build_output__"]
         }

--- a/Tasks/PackerBuildV0/Tests/L0Windows.ts
+++ b/Tasks/PackerBuildV0/Tests/L0Windows.ts
@@ -64,7 +64,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "packer build -force -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json F:\\somedir\\tempdir\\100\\default.windows.template-fixed.json": {
+        "packer build -force -color=false -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json F:\\somedir\\tempdir\\100\\default.windows.template-fixed.json": {
             "code": 0,
             "stdout": "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia"
         }

--- a/Tasks/PackerBuildV0/Tests/L0WindowsBuiltinTemplateAdditionalParameters.ts
+++ b/Tasks/PackerBuildV0/Tests/L0WindowsBuiltinTemplateAdditionalParameters.ts
@@ -58,7 +58,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "packer build -force -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json F:\\somedir\\tempdir\\100\\default.windows.template-builderUpdated-fixed.json": {
+        "packer build -force -color=false -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json F:\\somedir\\tempdir\\100\\default.windows.template-builderUpdated-fixed.json": {
             "code": 0,
             "stdout": "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia"
         }

--- a/Tasks/PackerBuildV0/Tests/L0WindowsCustomImage.ts
+++ b/Tasks/PackerBuildV0/Tests/L0WindowsCustomImage.ts
@@ -59,7 +59,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "packer build -force -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json F:\\somedir\\tempdir\\100\\custom.windows.template-fixed.json": {
+        "packer build -force -color=false -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json F:\\somedir\\tempdir\\100\\custom.windows.template-fixed.json": {
             "code": 0,
             "stdout": "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia"
         }

--- a/Tasks/PackerBuildV0/Tests/L0WindowsFail.ts
+++ b/Tasks/PackerBuildV0/Tests/L0WindowsFail.ts
@@ -60,7 +60,7 @@ let a: any = <any>{
             "code": process.env["__packer_validate_fails__"] === "true" ? 1 : 0,
             "stdout": process.env["__packer_validate_fails__"] === "true" ? "packer validate failed\r\nsome error" : "Executed Successfully",
         },
-        "packer build -force -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json F:\\somedir\\tempdir\\100\\default.windows.template-fixed.json": {
+        "packer build -force -color=false -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json F:\\somedir\\tempdir\\100\\default.windows.template-fixed.json": {
             "code": process.env["__packer_build_fails__"] === "true" ? 1 : 0,
             "stdout": process.env["__packer_build_fails__"] === "true" ? "packer build failed\r\nsome error" : (process.env["__packer_build_no_output__"] === "true" ? "Executed Successfully but output search will fail" : "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia"),
         },

--- a/Tasks/PackerBuildV0/Tests/L0WindowsInstallPacker.ts
+++ b/Tasks/PackerBuildV0/Tests/L0WindowsInstallPacker.ts
@@ -62,7 +62,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "Executed Successfully"
         },
-        "F:\\somedir\\tempdir\\100\\packer\\packer.exe build -force -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json F:\\somedir\\tempdir\\100\\default.windows.template-fixed.json": {
+        "F:\\somedir\\tempdir\\100\\packer\\packer.exe build -force -color=false -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json F:\\somedir\\tempdir\\100\\default.windows.template-fixed.json": {
             "code": 0,
             "stdout": "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia"
         }

--- a/Tasks/PackerBuildV0/src/operations/packerBuild.ts
+++ b/Tasks/PackerBuildV0/src/operations/packerBuild.ts
@@ -11,8 +11,9 @@ import * as utils from "../utilities"
 
 export async function run(packerHost: packerHost): Promise<any> {
     var command = packerHost.createPackerTool();
-    command.arg("build");
-    command.arg("-force");
+    command.arg("build");    
+    command.arg("-force");    
+    command.arg("-color=false");
 
     // add all variables
     var variableProviders = packerHost.getTemplateVariablesProviders();

--- a/Tasks/PackerBuildV0/task.json
+++ b/Tasks/PackerBuildV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 15
+        "Patch": 16
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/PackerBuildV0/task.loc.json
+++ b/Tasks/PackerBuildV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 16
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",


### PR DESCRIPTION
Build command output was issuing color commands, adds cruft to the log
Also not effective since online log viewer doesn't support ansi coloring