### PR TITLE
[AppCenterDistributeV1] Updating request source to Appcenter specific triggered builds

### DIFF
--- a/Tasks/AppCenterDistributeV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AppCenterDistributeV1/Strings/resources.resjson/en-US/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "For help with this task, visit the Visual Studio App Center [support site](https://aka.ms/appcentersupport/).",
   "loc.description": "Distribute app builds to testers and users via App Center",
   "loc.instanceNameFormat": "Deploy $(app) to Visual Studio App Center",
-  "loc.releaseNotes": "Provide build id to distribution API for additional context.",
+  "loc.releaseNotes": "Updating request source for AppCenter triggered builds.",
   "loc.group.displayName.symbols": "Symbols",
   "loc.input.label.serverEndpoint": "App Center service connection",
   "loc.input.help.serverEndpoint": "Select the service connection for Visual Studio App Center. To create one, click the Manage link and create a new service connection.",

--- a/Tasks/AppCenterDistributeV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AppCenterDistributeV1/Strings/resources.resjson/en-US/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "For help with this task, visit the Visual Studio App Center [support site](https://aka.ms/appcentersupport/).",
   "loc.description": "Distribute app builds to testers and users via App Center",
   "loc.instanceNameFormat": "Deploy $(app) to Visual Studio App Center",
-  "loc.releaseNotes": "Updating request source for AppCenter triggered builds.",
+  "loc.releaseNotes": "Add support for distribution to stores.",
   "loc.group.displayName.symbols": "Symbols",
   "loc.input.label.serverEndpoint": "App Center service connection",
   "loc.input.help.serverEndpoint": "Select the service connection for Visual Studio App Center. To create one, click the Manage link and create a new service connection.",

--- a/Tasks/AppCenterDistributeV1/appcenterdistribute.ts
+++ b/Tasks/AppCenterDistributeV1/appcenterdistribute.ts
@@ -175,7 +175,7 @@ function publishRelease(apiServer: string, releaseUrl: string, releaseNotes: str
     const commitMessage = process.env['LASTCOMMITMESSAGE'];
     // Updating the internal_request_source to distinguish the AppCenter triggered build and custom build
     if(!!commitMessage) {
-        headers["internal-request-source"] = "VSTS_APPCENTER";
+        headers["internal-request-source"] = "VSTS-APPCENTER";
     } 
 
     // Including these information for distribution notification to have additional context

--- a/Tasks/AppCenterDistributeV1/appcenterdistribute.ts
+++ b/Tasks/AppCenterDistributeV1/appcenterdistribute.ts
@@ -173,7 +173,14 @@ function publishRelease(apiServer: string, releaseUrl: string, releaseNotes: str
 
     // Builds started by App Center has the commit message set when distribution is enabled
     const commitMessage = process.env['LASTCOMMITMESSAGE'];
+    // Updating the internal_request_source to distinguish the AppCenter triggered build and custom build
+    if(!!commitMessage) {
+        headers["internal-request-source"] = "VSTS_APPCENTER";
+    } 
 
+    console.log("Headers:"+JSON.stringify(headers));
+
+    console.log("Build details: buildId"+buildId + " branchName"+branchName +" sourceVersion "+sourceVersion+" commitMessage"+commitMessage);
     // Including these information for distribution notification to have additional context
     // Commit message is optional
     if (branchName && sourceVersion) {

--- a/Tasks/AppCenterDistributeV1/appcenterdistribute.ts
+++ b/Tasks/AppCenterDistributeV1/appcenterdistribute.ts
@@ -178,9 +178,6 @@ function publishRelease(apiServer: string, releaseUrl: string, releaseNotes: str
         headers["internal-request-source"] = "VSTS_APPCENTER";
     } 
 
-    console.log("Headers:"+JSON.stringify(headers));
-
-    console.log("Build details: buildId"+buildId + " branchName"+branchName +" sourceVersion "+sourceVersion+" commitMessage"+commitMessage);
     // Including these information for distribution notification to have additional context
     // Commit message is optional
     if (branchName && sourceVersion) {

--- a/Tasks/AppCenterDistributeV1/task.json
+++ b/Tasks/AppCenterDistributeV1/task.json
@@ -15,7 +15,7 @@
         "Minor": 139,
         "Patch": 0
     },
-    "releaseNotes": "Provide build id to distribution API for additional context.",
+    "releaseNotes": "Updating request source for AppCenter triggered builds.",
     "groups": [
         {
             "name": "symbols",

--- a/Tasks/AppCenterDistributeV1/task.json
+++ b/Tasks/AppCenterDistributeV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 138,
+        "Minor": 139,
         "Patch": 0
     },
     "releaseNotes": "Provide build id to distribution API for additional context.",

--- a/Tasks/AppCenterDistributeV1/task.json
+++ b/Tasks/AppCenterDistributeV1/task.json
@@ -15,7 +15,7 @@
         "Minor": 139,
         "Patch": 0
     },
-    "releaseNotes": "Updating request source for AppCenter triggered builds.",
+    "releaseNotes": "Add support for distribution to stores.",
     "groups": [
         {
             "name": "symbols",

--- a/Tasks/AppCenterDistributeV1/task.loc.json
+++ b/Tasks/AppCenterDistributeV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 138,
+    "Minor": 139,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
This AppCenterDistributeV1 task is being used in AppCenter triggered builds and custom builds.
Updating the `internal_request_source` in headers to distinguish both.