### PR TITLE
Logging merging test result files message as debug instead of warning

### DIFF
--- a/Tasks/PublishTestResults/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishTestResults/Strings/resources.resjson/en-US/resources.resjson
@@ -21,7 +21,6 @@
   "loc.input.help.configuration": "Configuration for which the tests were run.",
   "loc.input.label.publishRunAttachments": "Upload test results files",
   "loc.input.help.publishRunAttachments": "A test run is created for each results file. Check this option to merge results into a single test run. To optimize for better performance, results will be merged into a single run if there are more than 100 result files, irrespective of this option.",
-  "loc.messages.mergeFiles": "Number of results files is greater than %d. Therefore merging all files to publish results against a single test run.",
   "loc.messages.NoMatchingFilesFound": "No test result files matching '%s' were found.",
   "loc.messages.ErrorTestResultsPublisher": "Error while executing TestResultsPublisher: %s."
 }

--- a/Tasks/PublishTestResults/publishtestresults.ts
+++ b/Tasks/PublishTestResults/publishtestresults.ts
@@ -44,9 +44,10 @@ async function run() {
         let matchingTestResultsFiles: string[] = tl.findMatch(searchFolder, testResultsFiles);
         const testResultsFilesCount = matchingTestResultsFiles ? matchingTestResultsFiles.length : 0;
 
+        tl.debug(`Detected ${testResultsFilesCount} test result files`)
         const forceMerge = testResultsFilesCount > MERGE_THRESHOLD;
         if (forceMerge) {
-            tl.warning(tl.loc('mergeFiles', MERGE_THRESHOLD));
+            tl.debug('Detected large number of test result files. Merged all of them into a single file and published a single test run to optimize for test result publish performance instead of publishing hundreds of test runs');
         }
 
         if (testResultsFilesCount === 0) {

--- a/Tasks/PublishTestResults/task.json
+++ b/Tasks/PublishTestResults/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [],
     "releaseNotes": "<ul><li>NUnit3 support</li><li>Support for Minimatch files pattern</li></ul>",
@@ -112,7 +112,6 @@
         }
     },
     "messages": {
-        "mergeFiles": "Number of results files is greater than %d. Therefore merging all files to publish results against a single test run.",
         "NoMatchingFilesFound": "No test result files matching '%s' were found.",
         "ErrorTestResultsPublisher": "Error while executing TestResultsPublisher: %s."
     }

--- a/Tasks/PublishTestResults/task.loc.json
+++ b/Tasks/PublishTestResults/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -112,7 +112,6 @@
     }
   },
   "messages": {
-    "mergeFiles": "ms-resource:loc.messages.mergeFiles",
     "NoMatchingFilesFound": "ms-resource:loc.messages.NoMatchingFilesFound",
     "ErrorTestResultsPublisher": "ms-resource:loc.messages.ErrorTestResultsPublisher"
   }


### PR DESCRIPTION
- Updating the task version & adding loc files.
- Porting from #6607