### PR TITLE
Handle backward compatibility if authorizationType parameter is not present

### DIFF
--- a/Tasks/KubernetesV0/src/clusterconnection.ts
+++ b/Tasks/KubernetesV0/src/clusterconnection.ts
@@ -42,9 +42,9 @@ export default class ClusterConnection {
     // open kubernetes connection
     public async open(kubernetesEndpoint?: string){
          return this.initialize().then(() => {
-            var authorizationType = tl.getEndpointDataParameter(kubernetesEndpoint, 'authorizationType', false);
+            var authorizationType = tl.getEndpointDataParameter(kubernetesEndpoint, 'authorizationType', true);
             var kubeconfig = null;
-            if (authorizationType === "Kubeconfig")
+            if (authorizationType == null || authorizationType === "Kubeconfig")
             {
                 if (kubernetesEndpoint) {
                      kubeconfig = tl.getEndpointAuthorizationParameter(kubernetesEndpoint, 'kubeconfig', false);

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 24
+        "Patch": 25
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 24
+    "Patch": 25
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/src/clusters/generickubernetescluster.ts
+++ b/Tasks/KubernetesV1/src/clusters/generickubernetescluster.ts
@@ -5,8 +5,8 @@ import kubectlutility = require("utility-common/kubectlutility");
 
 export async function getKubeConfig(): Promise<string> {
     var kubernetesServiceEndpoint = tl.getInput("kubernetesServiceEndpoint", true);
-    var authorizationType = tl.getEndpointDataParameter(kubernetesServiceEndpoint, 'authorizationType', false);
-    if (authorizationType === "Kubeconfig")
+    var authorizationType = tl.getEndpointDataParameter(kubernetesServiceEndpoint, 'authorizationType', true);
+    if (authorizationType == null || authorizationType === "Kubeconfig")
     {
         return tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'kubeconfig', false);
     }

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [],
     "preview": "true",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [],
   "preview": "true",


### PR DESCRIPTION
Fix for issue

https://developercommunity.visualstudio.com/content/problem/291499/kubernetes-deploy-from-vsts-no-longer-working.html