### PR TITLE
fixing npm tests

### DIFF
--- a/Tasks/NpmV1/Tests/L0.ts
+++ b/Tasks/NpmV1/Tests/L0.ts
@@ -179,7 +179,7 @@ describe('Npm Task', function () {
         tr.run();
 
         assert.equal(tr.invokedToolCount, 3, 'task should have run npm');
-        assert(tr.stdOutContained('npm publish successful'), 'npm should have installed the package');
+        assert(tr.stdOutContained('npm publish successful'), 'npm should have published the package');
         assert(tr.stdOutContained('OverridingProjectNpmrc'), 'publish should always ooverrideverride project .npmrc');
         assert(tr.stdOutContained('RestoringProjectNpmrc'), 'publish should always restore project .npmrc');
         assert(tr.succeeded, 'task should have succeeded');
@@ -195,7 +195,7 @@ describe('Npm Task', function () {
         tr.run();
 
         assert.equal(tr.invokedToolCount, 3, 'task should have run npm');
-        assert(tr.stdOutContained('npm publish successful'), 'npm should have installed the package');
+        assert(tr.stdOutContained('npm publish successful'), 'npm should have published the package');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();
@@ -346,8 +346,8 @@ describe('Npm Task', function () {
             getEndpointUrl: (id, optional) => {
                 return 'http://serviceendpoint.visualstudio.com';
             },
-            loc: (n, ...param) => {
-                console.log(n);
+            loc: (key: string) => {
+                // no-op
             },
             getHttpProxyConfiguration: (endpoint) => {
                 return null;

--- a/Tasks/NpmV1/Tests/NpmMockHelper.ts
+++ b/Tasks/NpmV1/Tests/NpmMockHelper.ts
@@ -54,6 +54,25 @@ export class NpmMockHelper extends TaskMockRunner {
         this.answers.rmRF[tempNpmPath] = { success: true };
         const tempNpmrcPath = path.join(tempNpmPath, `${NpmMockHelper.BuildBuildId}.npmrc`);
         this.answers.rmRF[tempNpmrcPath] = { success: true };
+
+        this.registerMock('typed-rest-client/HttpClient', {
+            HttpClient: function() {
+                return {
+                    get: function(url, headers) {
+                        return {
+                        then: function(handler) {
+                            handler({
+                                message: {
+                                    statusCode: 401,
+                                    rawHeaders: ['x-tfs-foo: abc', 'x-content-type-options: nosniff', 'X-Powered-By: ASP.NET']
+                                }
+                            });
+                        }
+                        };
+                    }
+                };
+            }
+        });
     }
 
     public run(noMockTask?: boolean): void {


### PR DESCRIPTION
The npm tests, which worked completely fine for me, failed in the builds. Adding the extra mock seems to make it happy for node 6, and removing the splat for node 5.