### PR TITLE
Updating VSTS Task Lib in PowerShellV2 task to eliminate environment block size error

### DIFF
--- a/Tasks/PowerShellV2/make.json
+++ b/Tasks/PowerShellV2/make.json
@@ -3,7 +3,7 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.9.0",
+                "version": "0.11.0",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {

--- a/Tasks/PowerShellV2/package-lock.json
+++ b/Tasks/PowerShellV2/package-lock.json
@@ -57,9 +57,9 @@
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "vsts-task-lib": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.5.tgz",
-      "integrity": "sha1-y9WrIy6rtxDJaXkFMYcmlZHA1RA=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
+      "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "1.7.0",

--- a/Tasks/PowerShellV2/package.json
+++ b/Tasks/PowerShellV2/package.json
@@ -11,6 +11,6 @@
   "license": "MIT",
   "dependencies": {
     "uuid": "^3.0.1",
-    "vsts-task-lib": "2.0.5"
+    "vsts-task-lib": "2.6.0"
   }
 }

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 136,
+        "Minor": 137,
         "Patch": 0
     },
     "releaseNotes": "Script task consistency. Added support for macOS and Linux.",

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 137,
+        "Minor": 140,
         "Patch": 0
     },
     "releaseNotes": "Script task consistency. Added support for macOS and Linux.",

--- a/Tasks/PowerShellV2/task.loc.json
+++ b/Tasks/PowerShellV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 136,
+    "Minor": 137,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/PowerShellV2/task.loc.json
+++ b/Tasks/PowerShellV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 137,
+    "Minor": 140,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
Updated the version of VstsTaskSdk (powershell) from 0.9.0 to 0.11.0.
Updated the version of vsts-task-lib from 2.0.5 to 2.6.0.

The reason: environment variable block size issue was fixed in July 2017 in vsts-task-lib. See here: Microsoft/vsts-task-lib#228

VstsTaskSdk 0.9.0 was released in June 2017.
vsts-task-lib 2.0.5 was released in April 2017.

Updating the dependencies should fix the issue: Microsoft/vsts-tasks#7824.
