### PR TITLE
Remove a leftover from string.js

### DIFF
--- a/Tasks/Common/codecoverage-tools/cobertura/cobertura.ant.ccenabler.ts
+++ b/Tasks/Common/codecoverage-tools/cobertura/cobertura.ant.ccenabler.ts
@@ -49,7 +49,7 @@ export class CoberturaAntCodeCoverageEnabler extends cc.CoberturaCodeCoverageEna
         let ccfilter = [];
 
         if (!util.isNullOrWhitespace(filter)) {
-            util.trimToEmptyString(filter).replace(/\./g, "/").s.split(":").forEach(exFilter => {
+            util.trimToEmptyString(filter).replace(/\./g, "/").split(":").forEach(exFilter => {
                 if (exFilter) {
                     ccfilter.push(exFilter.endsWith("*") ? ("**/" + exFilter + "/**") : ("**/" + exFilter + ".class"));
                 }

--- a/Tasks/Common/codecoverage-tools/cobertura/cobertura.maven.ccenabler.ts
+++ b/Tasks/Common/codecoverage-tools/cobertura/cobertura.maven.ccenabler.ts
@@ -37,7 +37,7 @@ export class CoberturaMavenCodeCoverageEnabler extends cc.CoberturaCodeCoverageE
         let ccfilter = [];
 
         if (!util.isNullOrWhitespace(filter)) {
-            util.trimToEmptyString(filter).replace(/\./g, "/").s.split(":").forEach(exFilter => {
+            util.trimToEmptyString(filter).replace(/\./g, "/").split(":").forEach(exFilter => {
                 if (exFilter) {
                     ccfilter.push(exFilter.endsWith("*") ? (exFilter + "/**") : (exFilter + ".class"));
                 }

--- a/Tasks/Common/codecoverage-tools/jacoco/jacoco.ant.ccenabler.ts
+++ b/Tasks/Common/codecoverage-tools/jacoco/jacoco.ant.ccenabler.ts
@@ -51,7 +51,7 @@ export class JacocoAntCodeCoverageEnabler extends cc.JacocoCodeCoverageEnabler {
         let ccfilter = [];
 
         if (!util.isNullOrWhitespace(filter)) {
-            util.trimToEmptyString(filter).replace(/\./g, "/").s.split(":").forEach(exFilter => {
+            util.trimToEmptyString(filter).replace(/\./g, "/").split(":").forEach(exFilter => {
                 if (exFilter) {
                     ccfilter.push(exFilter.endsWith("*") ? ("**/" + exFilter + "/**") : ("**/" + exFilter + ".class"));
                 }

--- a/Tasks/Common/codecoverage-tools/jacoco/jacoco.gradle.ccenabler.ts
+++ b/Tasks/Common/codecoverage-tools/jacoco/jacoco.gradle.ccenabler.ts
@@ -47,7 +47,7 @@ export class JacocoGradleCodeCoverageEnabler extends cc.JacocoCodeCoverageEnable
         let ccfilter = [];
 
         if (!util.isNullOrWhitespace(filter)) {
-            util.trimToEmptyString(filter).replace(/\./g, "/").s.split(":").forEach(exFilter => {
+            util.trimToEmptyString(filter).replace(/\./g, "/").split(":").forEach(exFilter => {
                 if (exFilter) {
                     ccfilter.push(exFilter.endsWith("*") ? ("'" + exFilter + "/**'") : ("'" + exFilter + ".class'"));
                 }

--- a/Tasks/Common/codecoverage-tools/jacoco/jacoco.maven.ccenabler.ts
+++ b/Tasks/Common/codecoverage-tools/jacoco/jacoco.maven.ccenabler.ts
@@ -45,7 +45,7 @@ export class JacocoMavenCodeCoverageEnabler extends cc.JacocoCodeCoverageEnabler
         let ccfilter = [];
 
         if (!util.isNullOrWhitespace(filter)) {
-            util.trimToEmptyString(filter).replace(/\./g, "/").s.split(":").forEach(exFilter => {
+            util.trimToEmptyString(filter).replace(/\./g, "/").split(":").forEach(exFilter => {
                 if (exFilter) {
                     ccfilter.push(exFilter.endsWith("*") ? ("**/" + exFilter + "/**") : ("**/" + exFilter + ".class"));
                 }


### PR DESCRIPTION
I missed part of string.js in the same spot in a few files.  These were caught by the legacy tests which I forgot to run, and the builds weren't running due to NPM (non-legacy) test failures.  The versions for the affected tasks have already been bumped.