### PR TITLE
Add auxiliary files with a iconTaskName property for each CI template.

### DIFF
--- a/templates/ci/.net-desktop.yml.metadata
+++ b/templates/ci/.net-desktop.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "VSBuild"
+}

--- a/templates/ci/android.yml.metadata
+++ b/templates/ci/android.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "Gradle"
+}

--- a/templates/ci/ant.yml.metadata
+++ b/templates/ci/ant.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "Ant"
+}

--- a/templates/ci/asp.net-core-.net-framework.yml.metadata
+++ b/templates/ci/asp.net-core-.net-framework.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "VSBuild"
+}

--- a/templates/ci/asp.net-core.yml.metadata
+++ b/templates/ci/asp.net-core.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "DotNetCoreCLI"
+}

--- a/templates/ci/asp.net.yml.metadata
+++ b/templates/ci/asp.net.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "VSBuild"
+}

--- a/templates/ci/docker-container.yml.metadata
+++ b/templates/ci/docker-container.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "Docker"
+}

--- a/templates/ci/empty.yml.metadata
+++ b/templates/ci/empty.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "CmdLine"
+}

--- a/templates/ci/gcc.yml.metadata
+++ b/templates/ci/gcc.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": ""
+}

--- a/templates/ci/go.yml.metadata
+++ b/templates/ci/go.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "Go"
+}

--- a/templates/ci/gradle.yml.metadata
+++ b/templates/ci/gradle.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "Gradle"
+}

--- a/templates/ci/html.yml.metadata
+++ b/templates/ci/html.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": ""
+}

--- a/templates/ci/jekyll-container.yml.metadata
+++ b/templates/ci/jekyll-container.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "Docker"
+}

--- a/templates/ci/maven.yml.metadata
+++ b/templates/ci/maven.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "Maven"
+}

--- a/templates/ci/node.js-with-angular.yml.metadata
+++ b/templates/ci/node.js-with-angular.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "NodeTool"
+}

--- a/templates/ci/node.js-with-grunt.yml.metadata
+++ b/templates/ci/node.js-with-grunt.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "Grunt"
+}

--- a/templates/ci/node.js-with-gulp.yml.metadata
+++ b/templates/ci/node.js-with-gulp.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "Gulp"
+}

--- a/templates/ci/node.js-with-vue.yml.metadata
+++ b/templates/ci/node.js-with-vue.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "NodeTool"
+}

--- a/templates/ci/node.js-with-webpack.yml.metadata
+++ b/templates/ci/node.js-with-webpack.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "NodeTool"
+}

--- a/templates/ci/php.yml.metadata
+++ b/templates/ci/php.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": ""
+}

--- a/templates/ci/python-django.yml.metadata
+++ b/templates/ci/python-django.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "PythonScript"
+}

--- a/templates/ci/python-package.yml.metadata
+++ b/templates/ci/python-package.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "PythonScript"
+}

--- a/templates/ci/ruby.yml.metadata
+++ b/templates/ci/ruby.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "UseRubyVersion"
+}

--- a/templates/ci/universal-windows-platform.yml.metadata
+++ b/templates/ci/universal-windows-platform.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "VSBuild"
+}

--- a/templates/ci/xamarin.android.yml.metadata
+++ b/templates/ci/xamarin.android.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "XamarinAndroid"
+}

--- a/templates/ci/xamarin.ios.yml.metadata
+++ b/templates/ci/xamarin.ios.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "XamariniOS"
+}

--- a/templates/ci/xcode.yml.metadata
+++ b/templates/ci/xcode.yml.metadata
@@ -1,0 +1,3 @@
+{
+  "iconTaskName": "Xcode"
+}


### PR DESCRIPTION
The .metadata auxiliary files will be used for template properties we need beyond name and description. By having one auxiliary file per template, it's harder to overlook template properties when adding or updating a template, and makes removing templates easier. I considered the file extension ".props", but that's already a popular extension.

The first property, `iconTaskName`, is used to associate a task's icon with a template. VSTS Build designer templates use `iconTaskId` and the task id guid for association. But those templates also refer to tasks by id. Given that yaml configuration refers to tasks by name, it should be safe and stable to use task names in our properties. Using task names makes authoring and code review easier.