### PR TITLE
Add run system information for test run creation

### DIFF
--- a/Tasks/DotNetCoreCLIV2/Tests/DotnetMockHelper.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/DotnetMockHelper.ts
@@ -10,7 +10,7 @@ export class DotnetMockHelper {
     constructor(
         private tmr: tmrm.TaskMockRunner) {
         process.env['AGENT_HOMEDIRECTORY'] = "c:\\agent\\home\\directory";
-        process.env['AGENT_TEMPDIRECTORY'] = "c:\\agent\\home\\temp";
+        process.env['AGENT.TEMPDIRECTORY'] = "c:\\agent\\home\\temp";
         process.env['BUILD_SOURCESDIRECTORY'] = "c:\\agent\\home\\directory\\sources",
         process.env['ENDPOINT_AUTH_SYSTEMVSSCONNECTION'] = "{\"parameters\":{\"AccessToken\":\"token\"},\"scheme\":\"OAuth\"}";
         process.env['ENDPOINT_URL_SYSTEMVSSCONNECTION'] = "https://example.visualstudio.com/defaultcollection";

--- a/Tasks/DotNetCoreCLIV2/Tests/L0.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/L0.ts
@@ -449,7 +449,7 @@ describe('DotNetCoreExe Suite', function () {
 
         let tp = path.join(__dirname, './TestCommandTests/publishtests.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
+        
         tr.run();
         assert(tr.invokedToolCount == 1, 'should have run dotnet once');
         assert(tr.ran('c:\\path\\dotnet.exe test c:\\agent\\home\\directory\\temp.csproj --logger trx --results-directory c:\\agent\\home\\temp'), 'it should have run dotnet test');

--- a/Tasks/DotNetCoreCLIV2/Tests/L0.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/L0.ts
@@ -449,7 +449,7 @@ describe('DotNetCoreExe Suite', function () {
 
         let tp = path.join(__dirname, './TestCommandTests/publishtests.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-        
+
         tr.run();
         assert(tr.invokedToolCount == 1, 'should have run dotnet once');
         assert(tr.ran('c:\\path\\dotnet.exe test c:\\agent\\home\\directory\\temp.csproj --logger trx --results-directory c:\\agent\\home\\temp'), 'it should have run dotnet test');

--- a/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtests.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtests.ts
@@ -53,9 +53,9 @@ const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 const tl = require('vsts-task-lib/mock-task');
 const tlClone = Object.assign({}, tl);
 tlClone.getVariable = function(variable: string) {
-    if (variable == "Agent.TempDirectory")
+    if (variable.toUpperCase() === "Agent.TempDirectory".toUpperCase())
     {
-        return process.env[variable];
+        return process.env[variable.toUpperCase()];
     }
     else
     {

--- a/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtests.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtests.ts
@@ -48,6 +48,22 @@ const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         }
     }
 };
+
+// Create mock for getVariable
+const tl = require('vsts-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+tlClone.getVariable = function(variable: string) {
+    if (variable == "Agent.TempDirectory")
+    {
+        return process.env[variable];
+    }
+    else
+    {
+        return tl.getVariable(variable);
+    }    
+};
+tmr.registerMock('vsts-task-lib/mock-task', tlClone);
+
 nmh.setAnswers(a);
 nmh.registerNugetUtilityMock(['c:\\agent\\home\\directory\\temp.csproj']);
 nmh.registerDefaultNugetVersionMock();

--- a/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithFailedTestCommand.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithFailedTestCommand.ts
@@ -53,10 +53,9 @@ const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 const tl = require('vsts-task-lib/mock-task');
 const tlClone = Object.assign({}, tl);
 tlClone.getVariable = function(variable: string) {
-    console.log(`Called for ${variable}`);
-    if (variable == "Agent.TempDirectory")
+    if (variable.toUpperCase() === "Agent.TempDirectory".toUpperCase())
     {
-        return process.env[variable];
+        return process.env[variable.toUpperCase()];
     }
     else
     {

--- a/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithFailedTestCommand.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithFailedTestCommand.ts
@@ -48,6 +48,23 @@ const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         }
     }
 };
+
+// Create mock for getVariable
+const tl = require('vsts-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+tlClone.getVariable = function(variable: string) {
+    console.log(`Called for ${variable}`);
+    if (variable == "Agent.TempDirectory")
+    {
+        return process.env[variable];
+    }
+    else
+    {
+        return tl.getVariable(variable);
+    }    
+};
+tmr.registerMock('vsts-task-lib/mock-task', tlClone);
+
 nmh.setAnswers(a);
 nmh.registerNugetUtilityMock(['c:\\agent\\home\\directory\\temp.csproj']);
 nmh.registerDefaultNugetVersionMock();

--- a/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithSpaceDir.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithSpaceDir.ts
@@ -16,7 +16,7 @@ tmr.setInput('publishTestResults', 'true');
 
 process.env['AGENT_HOMEDIRECTORY'] = "c:\\agent new\\home\\directory";
 process.env['BUILD_SOURCESDIRECTORY'] = "c:\\agent new\\home\\directory\\sources",
-process.env['AGENT_TEMPDIRECTORY'] = "c:\\agent new\\home\\temp";
+process.env['AGENT.TEMPDIRECTORY'] = "c:\\agent new\\home\\temp";
 process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'] = "c:\\agent new\\home\\directory";
 process.env['TASK_TEST_TRACE'] = "1";
 
@@ -54,6 +54,22 @@ const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         }
     }
 };
+
+// Create mock for getVariable
+const tl = require('vsts-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+tlClone.getVariable = function(variable: string) {
+    if (variable == "Agent.TempDirectory")
+    {
+        return process.env[variable];
+    }
+    else
+    {
+        return tl.getVariable(variable);
+    }    
+};
+tmr.registerMock('vsts-task-lib/mock-task', tlClone);
+
 nmh.setAnswers(a);
 nmh.registerNugetUtilityMock(['c:\\agent new\\home\\directory\\temp.csproj']);
 nmh.registerDefaultNugetVersionMock();

--- a/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithSpaceDir.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithSpaceDir.ts
@@ -59,9 +59,9 @@ const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 const tl = require('vsts-task-lib/mock-task');
 const tlClone = Object.assign({}, tl);
 tlClone.getVariable = function(variable: string) {
-    if (variable == "Agent.TempDirectory")
+    if (variable.toUpperCase() === "Agent.TempDirectory".toUpperCase())
     {
-        return process.env[variable];
+        return process.env[variable.toUpperCase()];
     }
     else
     {

--- a/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithoutBuildConfig.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithoutBuildConfig.ts
@@ -46,6 +46,23 @@ const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         }
     }
 };
+
+// Create mock for getVariable
+const tl = require('vsts-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+tlClone.getVariable = function(variable: string) {
+    console.log(`Called for ${variable}`);
+    if (variable == "Agent.TempDirectory")
+    {
+        return process.env[variable];
+    }
+    else
+    {
+        return tl.getVariable(variable);
+    }    
+};
+tmr.registerMock('vsts-task-lib/mock-task', tlClone);
+
 nmh.setAnswers(a);
 nmh.registerNugetUtilityMock(['c:\\agent\\home\\directory\\temp.csproj']);
 nmh.registerDefaultNugetVersionMock();

--- a/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithoutBuildConfig.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithoutBuildConfig.ts
@@ -51,10 +51,9 @@ const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 const tl = require('vsts-task-lib/mock-task');
 const tlClone = Object.assign({}, tl);
 tlClone.getVariable = function(variable: string) {
-    console.log(`Called for ${variable}`);
-    if (variable == "Agent.TempDirectory")
+    if (variable.toUpperCase() === "Agent.TempDirectory".toUpperCase())
     {
-        return process.env[variable];
+        return process.env[variable.toUpperCase()];
     }
     else
     {

--- a/Tasks/DotNetCoreCLIV2/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLIV2/dotnetcore.ts
@@ -18,6 +18,7 @@ export class dotNetExe {
     private outputArgument: string = "";
     private outputArgumentIndex: number = 0;
     private workingDirectory: string;
+    private testRunSystem: string = "VSTS - dotnet";
 
     constructor() {
         this.command = tl.getInput("command");
@@ -159,7 +160,7 @@ export class dotNetExe {
             tl.warning('No test result files were found.');
         } else {
             const tp: tl.TestPublisher = new tl.TestPublisher('VSTest');
-            tp.publish(matchingTestResultsFiles, 'false', buildPlaform, buildConfig, '', 'true');
+            tp.publish(matchingTestResultsFiles, 'false', buildPlaform, buildConfig, '', 'true', this.testRunSystem);
             //refer https://github.com/Microsoft/vsts-task-lib/blob/master/node/task.ts#L1620
         }
     }

--- a/Tasks/DotNetCoreCLIV2/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLIV2/dotnetcore.ts
@@ -113,7 +113,6 @@ export class dotNetExe {
         const dotnetPath = tl.which('dotnet', true);
         const enablePublishTestResults: boolean = tl.getBoolInput('publishTestResults', false) || false;
         const resultsDirectory = tl.getVariable('Agent.TempDirectory');
-
         if (enablePublishTestResults && enablePublishTestResults === true) {
             this.arguments = this.arguments.concat(` --logger trx --results-directory "${resultsDirectory}"`);
         }

--- a/Tasks/DotNetCoreCLIV2/package.json
+++ b/Tasks/DotNetCoreCLIV2/package.json
@@ -21,6 +21,6 @@
         "nuget-task-common": "file:../../_build/Tasks/Common/nuget-task-common-1.0.1.tgz",
         "q": "^1.4.1",
         "vso-node-api": "6.0.1-preview",
-        "vsts-task-lib": "2.0.6"
+        "vsts-task-lib": "2.6.0"
     }
 }

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -16,8 +16,8 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 137,
-        "Patch": 1
+        "Minor": 139,
+        "Patch": 0
     },
     "minimumAgentVersion": "2.0.0",
     "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -16,8 +16,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 137,
-    "Patch": 1
+    "Minor": 139,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
The ability to distinguish in the telemetry the source from which a test run originated is recently added. This is a reactionary work to determine the source as dotnet task and to differentiate it from vstest and publishtest results tasks.

Please refer [https://mseng.visualstudio.com/VSOnline/_workitems/edit/1288284](url) for the string value as suggested by Prachi for RunSystem generated from dotnet task