### PR TITLE
Extract Tar bug fix

### DIFF
--- a/Tasks/Common/azure-arm-rest/package-lock.json
+++ b/Tasks/Common/azure-arm-rest/package-lock.json
@@ -26,7 +26,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }

--- a/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
+++ b/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
@@ -65,9 +65,13 @@ export class JavaFilesExtractor {
 
     private async tarExtract(file, destinationFolder) {
         console.log(taskLib.loc('TarExtractFile', file));
-        const tr: tr.ToolRunner = taskLib.tool('tar');
-        tr.arg(['xzC', destinationFolder, '-f', file]);
-        tr.exec();
+        var xpTarLocation = taskLib.which('tar', true);
+        var tar = taskLib.tool(xpTarLocation);
+        tar.arg('-xvf');
+        tar.arg(file);
+        tar.arg('-C');
+        tar.arg(destinationFolder);
+        return tar.execSync();
     }
 
     private extractFiles(file: string, fileEnding: string) {

--- a/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
+++ b/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
@@ -71,7 +71,7 @@ export class JavaFilesExtractor {
         tar.arg(file);
         tar.arg('-C');
         tar.arg(destinationFolder);
-        return tar.execSync();
+        tar.execSync();
     }
 
     private extractFiles(file: string, fileEnding: string) {

--- a/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
+++ b/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
@@ -65,8 +65,8 @@ export class JavaFilesExtractor {
 
     private async tarExtract(file, destinationFolder) {
         console.log(taskLib.loc('TarExtractFile', file));
-        var xpTarLocation = taskLib.which('tar', true);
-        var tar = taskLib.tool(xpTarLocation);
+        const tarLocation = taskLib.which('tar', true);
+        const tar = taskLib.tool(tarLocation);
         tar.arg('-xvf');
         tar.arg(file);
         tar.arg('-C');

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 137,
+        "Minor": 139,
         "Patch": 0
     },
     "satisfies": ["Java"],

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 137,
+    "Minor": 139,
     "Patch": 0
   },
   "satisfies": [


### PR DESCRIPTION
Fix for [issue #833](https://github.com/MicrosoftDocs/vsts-docs/issues/830#event-1639300140) on the vsts-docs repo.

The JavaToolInstaller was failing for tar files on Linux machines.  This was due to a bug in how the files were being extracted.  Updated the logic to correctly extract the jdk from the tar file and set JAVA_HOME to the extract location.