### PR TITLE
Fix for issue #830: Updated the logic to extract a tar file on Linux OS

### DIFF
--- a/Tasks/Common/azure-arm-rest/package-lock.json
+++ b/Tasks/Common/azure-arm-rest/package-lock.json
@@ -26,7 +26,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }

--- a/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
+++ b/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
@@ -65,12 +65,12 @@ export class JavaFilesExtractor {
 
     private async tarExtract(file, destinationFolder) {
         console.log(taskLib.loc('TarExtractFile', file));
-        const tarLocation = taskLib.which('tar', true);
-        const tar = taskLib.tool(tarLocation);
-        tar.arg('-xvf');
-        tar.arg(file);
-        tar.arg('-C');
-        tar.arg(destinationFolder);
+        const tarLocation: string = taskLib.which('tar', true);
+        const tar: tr.ToolRunner = taskLib.tool(tarLocation);
+        tar.arg('-xvf'); // extract, verbose, show file name type of the archive file
+        tar.arg(file); // file to be extracted
+        tar.arg('-C'); // untar in specified directory
+        tar.arg(destinationFolder); // directory into which files are to be extracted
         tar.execSync();
     }
 

--- a/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
+++ b/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
@@ -65,9 +65,13 @@ export class JavaFilesExtractor {
 
     private async tarExtract(file, destinationFolder) {
         console.log(taskLib.loc('TarExtractFile', file));
-        const tr: tr.ToolRunner = taskLib.tool('tar');
-        tr.arg(['xzC', destinationFolder, '-f', file]);
-        tr.exec();
+        const tarLocation = taskLib.which('tar', true);
+        const tar = taskLib.tool(tarLocation);
+        tar.arg('-xvf');
+        tar.arg(file);
+        tar.arg('-C');
+        tar.arg(destinationFolder);
+        tar.execSync();
     }
 
     private extractFiles(file: string, fileEnding: string) {

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 137,
+        "Minor": 138,
         "Patch": 0
     },
     "satisfies": ["Java"],

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 137,
+    "Minor": 138,
     "Patch": 0
   },
   "satisfies": [


### PR DESCRIPTION
Fix for issue #833 on the vsts-docs repo.

The JavaToolInstaller was failing for tar files on Linux machines. This was due to a bug in how the files were being extracted. Updated the logic to correctly extract the jdk from the tar file and set JAVA_HOME to the extract location.

Porting this change into the m138 branch to get the fix out.  A more extensive fix will be done in the current sprint.