### PR TITLE
Add CondaEnvironmentV0 to make-options.json

### DIFF
--- a/make-options.json
+++ b/make-options.json
@@ -29,6 +29,7 @@
         "CMakeV1",
         "CmdLineV2",
         "CocoaPodsV0",
+        "CondaEnvironmentV0",
         "CondaEnvironmentV1",
         "CopyFilesV2",
         "CopyFilesOverSSHV0",


### PR DESCRIPTION
I added back this old version for servicing in #7851 

It needs to go back in make-options.json to get picked up and uploaded to VSO