### PR TITLE
Generate TPN: Recurse into node_module directories for packages

### DIFF
--- a/generate-third-party-notice.js
+++ b/generate-third-party-notice.js
@@ -117,6 +117,12 @@ function* collectLicenseInfo(modulesRoot) {
             url: url || 'NO URL FOUND',
             licenseText: licenseText || 'NO LICENSE FOUND'
         };
+
+        // See if this package has its own `node_modules` directory
+        const child_packages = path.join(absolutePath, 'node_modules');
+        if (fs.existsSync(child_packages)) {
+            yield* collectLicenseInfo(child_packages);
+        }
     }
 }
 
@@ -161,7 +167,7 @@ function writeLines(writeStream, lines) {
         writeStream.write(os.EOL);
     };
 
-    for (let line of lines) {
+    for (const line of lines) {
         writeLine(line);
     }
 }


### PR DESCRIPTION
By default, dependencies of dependencies all get flattened out into the node_modules folder.

If multiple dependencies require different versions of a package, one of the dependencies will wind up with its own copy, nested in its own node_modules folder.

![image](https://user-images.githubusercontent.com/33549821/43599958-3e72866e-9657-11e8-8b4d-057e5fed8f22.png)

CELA has advised us to include these in the TPN as well (even though they are always duplicates).

**Testing**
Ran on tasks that have and do not have this kind of node_modules folder.