### PR TITLE
Users/midenn/symbols compress

### DIFF
--- a/Tasks/PublishSymbolsV2/PublishHelpers/PublishFunctions.ps1
+++ b/Tasks/PublishSymbolsV2/PublishHelpers/PublishFunctions.ps1
@@ -15,7 +15,8 @@ function Invoke-PublishSymbols {
         [timespan]$MaximumWaitTime,
         [Parameter(Mandatory = $true)]
         [string]$SemaphoreMessage,
-        [string]$ArtifactName)
+        [string]$ArtifactName,
+        [switch]$CompressSymbols)
 
     Trace-VstsEnteringInvocation $MyInvocation
     try {
@@ -37,7 +38,7 @@ function Invoke-PublishSymbols {
             $semaphore = Lock-Semaphore -Share $Share -MaximumWaitTime $MaximumWaitTime -SemaphoreMessage $SemaphoreMessage
             try {
                 # Invoke symstore.exe.
-                $symstoreArgs = "add /f ""@$symbolsRspFile"" /s ""$Share"" /t ""$Product"" /v ""$Version"""
+                $symstoreArgs = "add /f ""@$symbolsRspFile"" /s ""$Share"" /t ""$Product"" /v ""$Version"" $(if ($CompressSymbols) { "/compress" })"
                 Invoke-VstsTool -FileName (Get-SymStorePath) -Arguments $symstoreArgs -WorkingDirectory ([System.IO.Path]::GetTempPath()) 2>&1 |
                     ForEach-Object {
                         if ($_ -is [System.Management.Automation.ErrorRecord]) {

--- a/Tasks/PublishSymbolsV2/PublishSymbols.ps1
+++ b/Tasks/PublishSymbolsV2/PublishSymbols.ps1
@@ -99,6 +99,7 @@ try {
         [string]$SymbolsArtifactName = Get-VstsInput -Name 'SymbolsArtifactName'
     }
     [bool]$SkipIndexing = -not (Get-VstsInput -Name 'IndexSources' -AsBool)
+    [bool]$CompressSymbols = (Get-VstsInput -Name 'CompressSymbols' -AsBool)
     [bool]$TreatNotIndexedAsWarning = Get-VstsInput -Name 'TreatNotIndexedAsWarning' -AsBool
     [string]$defaultSymbolFolder = (Get-VstsTaskVariable -Name 'Build.SourcesDirectory' -Default "")
     [string]$SymbolsFolder = Get-VstsInput -Name 'SymbolsFolder' -Default $defaultSymbolFolder
@@ -154,7 +155,7 @@ try {
 
             # Publish the symbols.
             Import-Module -Name $PSScriptRoot\PublishHelpers\PublishHelpers.psm1
-            Invoke-PublishSymbols -PdbFiles $fileList -Share $SymbolsPath -Product $SymbolsProduct -Version $SymbolsVersion -MaximumWaitTime $SymbolsMaximumWaitTime -ArtifactName $SymbolsArtifactName -SemaphoreMessage $semaphoreMessage
+            Invoke-PublishSymbols -PdbFiles $fileList -Share $SymbolsPath -Product $SymbolsProduct -Version $SymbolsVersion -MaximumWaitTime $SymbolsMaximumWaitTime -ArtifactName $SymbolsArtifactName -SemaphoreMessage $semaphoreMessage -CompressSymbols:$CompressSymbols
         } else {
             Write-Verbose "SymbolsPath was not set, publish symbols step was skipped."
         }

--- a/Tasks/PublishSymbolsV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishSymbolsV2/Strings/resources.resjson/en-US/resources.resjson
@@ -16,6 +16,8 @@
   "loc.input.help.SymbolServerType": "Choose where to publish symbols. Symbols published to the VSTS Symbol Server are accessible by any user with access to the account/collection. Team Foundation Server only supports the \"File share\" option. Follow [these instructions](https://go.microsoft.com/fwlink/?linkid=846265) to use Symbol Server in VSTS.",
   "loc.input.label.SymbolsPath": "Path to publish symbols",
   "loc.input.help.SymbolsPath": "The file share that hosts your symbols. This value will be used in the call to `symstore.exe add` as the `/s` parameter.",
+  "loc.input.label.CompressSymbols": "Compress symbols",
+  "loc.input.help.CompressSymbols": "Compress symbols when publishing to file share.",
   "loc.input.label.DetailedLog": "Verbose logging",
   "loc.input.help.DetailedLog": "Use verbose logging.",
   "loc.input.label.TreatNotIndexedAsWarning": "Warn if not indexed",

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 9
+        "Patch": 10
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [
@@ -79,6 +79,15 @@
             "required": false,
             "helpMarkDown": "The file share that hosts your symbols. This value will be used in the call to `symstore.exe add` as the `/s` parameter.",
             "visibleRule": "PublishSymbols = true && SymbolServerType = FileShare"
+        },
+        {
+            "name": "CompressSymbols",
+            "type": "boolean",
+            "label": "Compress symbols",
+            "defaultValue": "false",
+            "required": true,
+            "helpMarkDown": "Compress symbols when publishing to file share.",
+            "visibleRule": "SymbolServerType = FileShare"
         },
         {
             "name": "DetailedLog",

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 9
+    "Patch": 10
   },
   "minimumAgentVersion": "1.95.0",
   "groups": [
@@ -78,6 +78,15 @@
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.SymbolsPath",
       "visibleRule": "PublishSymbols = true && SymbolServerType = FileShare"
+    },
+    {
+      "name": "CompressSymbols",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.CompressSymbols",
+      "defaultValue": "false",
+      "required": true,
+      "helpMarkDown": "ms-resource:loc.input.help.CompressSymbols",
+      "visibleRule": "SymbolServerType = FileShare"
     },
     {
       "name": "DetailedLog",


### PR DESCRIPTION
This pull request adds support for the /compress option on the symstore.exe command that the Index & Publish Symbols task executes when users are publishing symbols to a fileshare. This was in result to a customer request and it was pretty easy to add support for it.