### PR TITLE
Add Xcode task telemetry.

### DIFF
--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 5,
         "Minor": 139,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "This version of the task is compatible with Xcode 8 and Xcode 9. Features that were there solely to maintain compat with Xcode 7 have been removed. The task has better options to work with the Hosted macOS pool.",
     "demands": [

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 5,
     "Minor": 139,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [


### PR DESCRIPTION
We want to see how many builds are using earlier major versions of Xcode.

(cherry picked from commit e675e378a8a38f2756bc9182972a4630bda3a388)