### PR TITLE
Added check to remove json and yaml output format for kubectl commands that don't support it

### DIFF
--- a/Tasks/KubernetesV0/Tests/L0.ts
+++ b/Tasks/KubernetesV0/Tests/L0.ts
@@ -524,4 +524,19 @@ describe('Kubernetes Suite', function() {
         console.log(tr.stderr);	
         done();	
     });
+
+    it('Json and yaml output format should not added for commands that dont support it', (done:MochaDone) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        process.env[shared.TestEnvVars.command] = shared.Commands.logs;
+        process.env[shared.TestEnvVars.arguments] = "nginx";    
+        tr.run();
+
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
+        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+        assert(tr.stdout.indexOf(`[command]kubectl --kubeconfig ${shared.formatPath("newUserDir/config")} logs nginx`) != -1, "kubectl logs should run");
+        console.log(tr.stderr);
+        done();
+    });
 });

--- a/Tasks/KubernetesV0/Tests/TestSetup.ts
+++ b/Tasks/KubernetesV0/Tests/TestSetup.ts
@@ -150,6 +150,9 @@ a.exec[`kubectl --kubeconfig ${KubconfigFile} get secrets my-secret -o yaml`] = 
     "code": 0,
     "stdout": "successfully got secret my-secret and printed it in the specified format"
 };
+a.exec[`kubectl --kubeconfig ${KubconfigFile} logs nginx`] = {
+    "code": 0
+};
 
 tr.setAnswers(<any>a);
 

--- a/Tasks/KubernetesV0/src/kubernetescommand.ts
+++ b/Tasks/KubernetesV0/src/kubernetescommand.ts
@@ -18,16 +18,24 @@ export function run(connection: ClusterConnection, kubecommand: string, outputUp
     command.arg(getNameSpace());
     command.arg(getCommandConfigurationFile());
     command.line(getCommandArguments());
-    command.arg(getCommandOutputFormat());
+    command.arg(getCommandOutputFormat(kubecommand));
     return connection.execCommand(command);
 }
 
-function getCommandOutputFormat() : string[] {
+function getCommandOutputFormat(kubecommand: string) : string[] {
     var args: string[] =[];
     var ouputVariableName =  tl.getInput("kubectlOutput", false);  
     var outputFormat = tl.getInput("outputFormat", false);
     if(ouputVariableName)
     {
+        if (outputFormat === "json" || outputFormat === "yaml")
+        {
+            if (!isJsonOrYamlOutputFormatSupported(kubecommand))
+            {
+                return args;
+            }
+        }
+
        args[0] = "-o";
        args[1] = outputFormat;
     }
@@ -56,6 +64,20 @@ function getCommandConfigurationFile() : string[] {
 
 function getCommandArguments(): string {
     return tl.getInput("arguments", false);
+}
+
+function isJsonOrYamlOutputFormatSupported(kubecommand) : boolean
+{
+   switch (kubecommand) {
+       case "delete":
+          return false;
+       case "exec":
+          return false;
+       case "logs":
+          return false;
+       default: 
+          return true;
+   }
 }
 
 export function getNameSpace(): string[] {

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 26
+        "Patch": 27
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 26
+    "Patch": 27
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/Tests/L0.ts
+++ b/Tasks/KubernetesV1/Tests/L0.ts
@@ -536,4 +536,19 @@ describe('Kubernetes Suite', function() {
         console.log(tr.stderr);
         done();
     });
+
+    it('Json and yaml output format should not added for commands that dont support it', (done:MochaDone) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        process.env[shared.TestEnvVars.command] = shared.Commands.logs;
+        process.env[shared.TestEnvVars.arguments] = "nginx";    
+        tr.run();
+
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
+        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+        assert(tr.stdout.indexOf(`[command]kubectl logs nginx`) != -1, "kubectl logs should run");
+        console.log(tr.stderr);
+        done();
+    });
 });

--- a/Tasks/KubernetesV1/Tests/TestSetup.ts
+++ b/Tasks/KubernetesV1/Tests/TestSetup.ts
@@ -198,6 +198,9 @@ a.exec[`kubectl get secrets my-secret -o yaml`] = {
     "code": 0,
     "stdout": "successfully got secret my-secret and printed it in the specified format"
 };
+a.exec[`kubectl logs nginx`] = {
+    "code": 0
+};
 
 tr.setAnswers(<any>a);
 

--- a/Tasks/KubernetesV1/src/kubernetescommand.ts
+++ b/Tasks/KubernetesV1/src/kubernetescommand.ts
@@ -18,17 +18,25 @@ export function run(connection: ClusterConnection, kubecommand: string, outputUp
     command.arg(getNameSpace());
     command.arg(getCommandConfigurationFile());
     command.line(getCommandArguments());
-    command.arg(getCommandOutputFormat());
+    command.arg(getCommandOutputFormat(kubecommand));
     return connection.execCommand(command);
 }
 
-function getCommandOutputFormat() : string[] {
+function getCommandOutputFormat(kubecommand: string) : string[] {
     var args: string[] =[];
     var outputFormat = tl.getInput("outputFormat", false);
     if(outputFormat)
     {
-        args[0] = "-o";
-        args[1] = outputFormat;
+       if (outputFormat === "json" || outputFormat === "yaml")
+       {
+           if (!isJsonOrYamlOutputFormatSupported(kubecommand))
+           {
+               return args;
+           }
+       }
+      
+       args[0] = "-o";
+       args[1] = outputFormat;
     }
    
     return args;
@@ -55,6 +63,20 @@ function getCommandConfigurationFile() : string[] {
 
 function getCommandArguments(): string {
     return tl.getInput("arguments", false);
+}
+
+function isJsonOrYamlOutputFormatSupported(kubecommand) : boolean
+{
+   switch (kubecommand) {
+       case "delete":
+          return false;
+       case "exec":
+          return false;
+       case "logs":
+          return false;
+       default: 
+          return true;
+   }
 }
 
 export function getNameSpace(): string[] {

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "preview": "true",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "preview": "true",


### PR DESCRIPTION
Existing commands in the dropdown that don't support json and yaml output format
1. delete
2. exec
3. logs