### PR TITLE
Change maxlength for inline text field to 5000 in Azure Powershell task

### DIFF
--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -97,7 +97,7 @@
             "properties": {
                 "resizable": "true",
                 "rows": "10",
-                "maxLength": "500"
+                "maxLength": "5000"
             }
         },
         {


### PR DESCRIPTION
Changing maxlength for textbox in inline text mode to 5000 similar [normal PS task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/PowerShellOnTargetMachinesV3/task.json).

![image](https://user-images.githubusercontent.com/2685029/44364042-dbe82b00-a4bd-11e8-879a-763aa26e3205.png)

Should fix #8078 