### PR TITLE
Add back publish artifacts

### DIFF
--- a/templates/ci/python-package.yml
+++ b/templates/ci/python-package.yml
@@ -51,3 +51,8 @@ phases:
 
   - script: python setup.py sdist
     displayName: 'Build sdist'
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: 'dist'
+      artifactName: 'dist'


### PR DESCRIPTION
For some reason this was commented out and removed along with the PyPI publish task.  I think we still want to publish artifacts here; we just may not want to upload them.