### PR TITLE
Updating Jacoco version to 0.8.1

### DIFF
--- a/Tasks/ANTV1/package-lock.json
+++ b/Tasks/ANTV1/package-lock.json
@@ -336,7 +336,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.11"
       }

--- a/Tasks/ANTV1/task.json
+++ b/Tasks/ANTV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 140,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "ant"

--- a/Tasks/ANTV1/task.loc.json
+++ b/Tasks/ANTV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 140,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "ant"

--- a/Tasks/Common/codeanalysis-common/package-lock.json
+++ b/Tasks/Common/codeanalysis-common/package-lock.json
@@ -138,7 +138,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.2.0"
           }
@@ -321,7 +321,7 @@
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -332,7 +332,7 @@
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+      "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
     },
     "htmlparser2": {
       "version": "3.9.2",
@@ -574,7 +574,7 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
     },
     "readable-stream": {
       "version": "2.3.3",
@@ -593,7 +593,7 @@
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -650,7 +650,7 @@
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
       "requires": {
         "hoek": "4.2.0"
       }

--- a/Tasks/Common/codecoverage-tools/codecoverageconstants.ts
+++ b/Tasks/Common/codecoverage-tools/codecoverageconstants.ts
@@ -294,7 +294,7 @@ export function jacocoMavenMultiModuleReport(reportDir: string, srcData: string,
         <dependencies>
           <dependency>
             <groupId>org.jacoco</groupId>
-            <artifactIdorg.jacoco.ant</artifactId>
+            <artifactId>org.jacoco.ant</artifactId>
             <version>0.8.1</version>
           </dependency>
         </dependencies>

--- a/Tasks/Common/codecoverage-tools/codecoverageconstants.ts
+++ b/Tasks/Common/codecoverage-tools/codecoverageconstants.ts
@@ -189,7 +189,7 @@ export function jacocoMavenPluginEnable(includeFilter: string[], excludeFilter: 
     let plugin = {
         "groupId": "org.jacoco",
         "artifactId": "jacoco-maven-plugin",
-        "version": "0.7.5.201505241946",
+        "version": "0.8.1",
         "configuration": {
             "destFile": path.join(outputDirectory, "jacoco.exec"),
             "outputDirectory": outputDirectory,
@@ -294,8 +294,8 @@ export function jacocoMavenMultiModuleReport(reportDir: string, srcData: string,
         <dependencies>
           <dependency>
             <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.ant</artifactId>
-            <version>0.7.5.201505241946</version>
+            <artifactIdorg.jacoco.ant</artifactId>
+            <version>0.8.1</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/Tasks/Common/java-common/package-lock.json
+++ b/Tasks/Common/java-common/package-lock.json
@@ -52,7 +52,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }

--- a/Tasks/Common/utility-common/package-lock.json
+++ b/Tasks/Common/utility-common/package-lock.json
@@ -14,7 +14,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -33,7 +33,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "mockery": {
@@ -91,7 +91,7 @@
       "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
       "requires": {
         "tunnel": "0.0.4",
-        "typed-rest-client": "^0.12.0",
+        "typed-rest-client": "0.12.0",
         "underscore": "1.8.3"
       },
       "dependencies": {
@@ -112,11 +112,11 @@
       "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.2.1"
       }
     },
     "vsts-task-tool-lib": {
@@ -124,10 +124,10 @@
       "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
       "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
       "requires": {
-        "semver": "^5.3.0",
-        "semver-compare": "^1.0.0",
-        "typed-rest-client": "^0.9.0",
-        "uuid": "^3.0.1",
+        "semver": "5.5.0",
+        "semver-compare": "1.0.0",
+        "typed-rest-client": "0.9.0",
+        "uuid": "3.2.1",
         "vsts-task-lib": "2.0.4-preview"
       },
       "dependencies": {
@@ -136,12 +136,12 @@
           "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
           "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
           "requires": {
-            "minimatch": "^3.0.0",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
+            "minimatch": "3.0.4",
+            "mockery": "1.7.0",
+            "q": "1.5.1",
+            "semver": "5.5.0",
+            "shelljs": "0.3.0",
+            "uuid": "3.2.1"
           }
         }
       }

--- a/Tasks/MavenV3/package-lock.json
+++ b/Tasks/MavenV3/package-lock.json
@@ -967,31 +967,28 @@
       "requires": {
         "js-base64": "2.4.3",
         "semver": "5.5.0",
-        "vso-node-api": "6.0.1-preview",
-        "vsts-task-lib": "2.0.6",
+        "vso-node-api": "6.5.0",
+        "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
       },
       "dependencies": {
         "typed-rest-client": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
-          "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
+          "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
           "requires": {
             "tunnel": "0.0.4",
             "underscore": "1.8.3"
           }
         },
-        "vsts-task-lib": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.6.tgz",
-          "integrity": "sha1-9sqGS3sDsS23N8nV/2kThGNpEFY=",
+        "vso-node-api": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
+          "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
           "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.5.1",
-            "semver": "5.5.0",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
+            "tunnel": "0.0.4",
+            "typed-rest-client": "0.12.0",
+            "underscore": "1.8.3"
           }
         },
         "vsts-task-tool-lib": {
@@ -1006,6 +1003,15 @@
             "vsts-task-lib": "2.0.4-preview"
           },
           "dependencies": {
+            "typed-rest-client": {
+              "version": "0.9.0",
+              "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
+              "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+              "requires": {
+                "tunnel": "0.0.4",
+                "underscore": "1.8.3"
+              }
+            },
             "vsts-task-lib": {
               "version": "2.0.4-preview",
               "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 3,
         "Minor": 140,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV3/task.loc.json
+++ b/Tasks/MavenV3/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 139,
-    "Patch": 2
+    "Minor": 140,
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [


### PR DESCRIPTION
Updating the Jacoco version we use in our codecoverage tools to newest version.

Tested in dev environment and via running unit tests.