### PR TITLE
Fixed the check for empty runsettings input and fast fail for search folder unc path

### DIFF
--- a/Tasks/VsTestV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VsTestV2/Strings/resources.resjson/en-US/resources.resjson
@@ -177,5 +177,6 @@
   "loc.messages.VsTestVersionEmpty": "VsTestVersion is null or empty",
   "loc.messages.UserProvidedSourceFilter": "Source filter: %s",
   "loc.messages.UnableToGetFeatureFlag": "Unable to get feature flag: %s",
-  "loc.messages.diagnosticsInput": "Diagnostics enabled : %s"
+  "loc.messages.diagnosticsInput": "Diagnostics enabled : %s",
+  "loc.messages.UncPathNotSupported": "Path to test sources search folder cannot be a UNC path. Please provide a rooted path or a path relative to $(System.DefaultWorkingDirectory)."
 }

--- a/Tasks/VsTestV2/inputparser.ts
+++ b/Tasks/VsTestV2/inputparser.ts
@@ -295,18 +295,13 @@ function getDistributionSettings(inputDataContract : idc.InputDataContract) : id
 
 function getExecutionSettings(inputDataContract : idc.InputDataContract) : idc.InputDataContract {
     inputDataContract.ExecutionSettings = <idc.ExecutionSettings>{};
-    inputDataContract.ExecutionSettings.SettingsFile = tl.getPathInput('runSettingsFile');
+
+    if (tl.filePathSupplied('runSettingsFile')) {
+        inputDataContract.ExecutionSettings.SettingsFile = path.resolve(tl.getPathInput('runSettingsFile'));
+        console.log(tl.loc('runSettingsFileInput', inputDataContract.ExecutionSettings.SettingsFile));
+    }
 
     inputDataContract.ExecutionSettings.TempFolder = utils.Helper.GetTempFolder();
-
-    if (!utils.Helper.isNullOrWhitespace(inputDataContract.ExecutionSettings.SettingsFile)) {
-        inputDataContract.ExecutionSettings.SettingsFile = path.resolve(inputDataContract.ExecutionSettings.SettingsFile);
-    }
-
-    if (inputDataContract.ExecutionSettings.SettingsFile === tl.getVariable('System.DefaultWorkingDirectory')) {
-        delete inputDataContract.ExecutionSettings.SettingsFile;
-    }
-    console.log(tl.loc('runSettingsFileInput', inputDataContract.ExecutionSettings.SettingsFile));
 
     inputDataContract.ExecutionSettings.OverridenParameters = tl.getInput('overrideTestrunParameters');
     tl.debug(`OverrideTestrunParameters set to ${inputDataContract.ExecutionSettings.OverridenParameters}`);

--- a/Tasks/VsTestV2/inputparser.ts
+++ b/Tasks/VsTestV2/inputparser.ts
@@ -1,14 +1,12 @@
 import * as path from 'path';
 import * as tl from 'vsts-task-lib/task';
-import * as tr from 'vsts-task-lib/toolrunner';
 import * as utils from './helpers';
 import * as constants from './constants';
-import * as os from 'os';
 import * as ci from './cieventlogger';
-import { AreaCodes, ResultMessages, DistributionTypes } from './constants';
+import { AreaCodes, DistributionTypes } from './constants';
 import * as idc from './inputdatacontract';
 import * as versionfinder from './versionfinder';
-import * as uuid from 'uuid';
+import * as isUncPath from 'is-unc-path';
 const regedit = require('regedit');
 
 let serverBasedRun = false;
@@ -122,6 +120,11 @@ function getTestSelectionInputs(inputDataContract : idc.InputDataContract) : idc
     if (inputDataContract.TestSelectionSettings.SearchFolder && !utils.Helper.pathExistsAsDirectory(inputDataContract.TestSelectionSettings.SearchFolder)) {
         throw new Error(tl.loc('searchLocationNotDirectory', inputDataContract.TestSelectionSettings.SearchFolder));
     }
+
+    if (isUncPath(inputDataContract.TestSelectionSettings.SearchFolder)) {
+        throw new Error(tl.loc('UncPathNotSupported'));
+    }
+
     console.log(tl.loc('searchFolderInput', inputDataContract.TestSelectionSettings.SearchFolder));
 
     return inputDataContract;

--- a/Tasks/VsTestV2/package-lock.json
+++ b/Tasks/VsTestV2/package-lock.json
@@ -205,6 +205,14 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "requires": {
+        "unc-path-regex": "0.1.2"
+      }
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -462,6 +470,11 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
     "underscore": {
       "version": "1.8.3",

--- a/Tasks/VsTestV2/package.json
+++ b/Tasks/VsTestV2/package.json
@@ -13,13 +13,14 @@
   },
   "homepage": "https://github.com/Microsoft/vsts-tasks#readme",
   "dependencies": {
+    "is-unc-path": "^1.0.0",
     "performance-now": "0.2.0",
+    "request": "2.87.0",
     "string": "3.3.1",
     "uuid": "3.1.0",
     "vso-node-api": "6.0.4-preview",
     "vsts-task-lib": "2.0.6",
-    "xml2js": "0.4.16",
-    "request": "2.87.0"
+    "xml2js": "0.4.16"
   },
   "optionalDependencies": {
     "regedit": "2.2.6"

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 140,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -614,6 +614,7 @@
         "VsTestVersionEmpty": "VsTestVersion is null or empty",
         "UserProvidedSourceFilter": "Source filter: %s",
         "UnableToGetFeatureFlag": "Unable to get feature flag: %s",
-        "diagnosticsInput": "Diagnostics enabled : %s"
+        "diagnosticsInput": "Diagnostics enabled : %s",
+        "UncPathNotSupported": "Path to test sources search folder cannot be a UNC path. Please provide a rooted path or a path relative to $(System.DefaultWorkingDirectory)."
     }
 }

--- a/Tasks/VsTestV2/task.loc.json
+++ b/Tasks/VsTestV2/task.loc.json
@@ -614,6 +614,7 @@
     "VsTestVersionEmpty": "ms-resource:loc.messages.VsTestVersionEmpty",
     "UserProvidedSourceFilter": "ms-resource:loc.messages.UserProvidedSourceFilter",
     "UnableToGetFeatureFlag": "ms-resource:loc.messages.UnableToGetFeatureFlag",
-    "diagnosticsInput": "ms-resource:loc.messages.diagnosticsInput"
+    "diagnosticsInput": "ms-resource:loc.messages.diagnosticsInput",
+    "UncPathNotSupported": "ms-resource:loc.messages.UncPathNotSupported"
   }
 }

--- a/Tasks/VsTestV2/task.loc.json
+++ b/Tasks/VsTestV2/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 140,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
related to issue https://github.com/Microsoft/vsts-tasks/issues/7485 

Also The task now fails fast if search folder is unc path instead of much later down the execution chain.