### PR TITLE
resolve nuget exe

### DIFF
--- a/Tasks/Common/nuget-task-common/NuGetToolRunner.ts
+++ b/Tasks/Common/nuget-task-common/NuGetToolRunner.ts
@@ -100,6 +100,7 @@ export class NuGetToolRunner extends ToolRunner {
 }
 
 export function createNuGetToolRunner(nuGetExePath: string, settings: NuGetEnvironmentSettings): NuGetToolRunner {
+    nuGetExePath = ngutil.resolveToolPath(nuGetExePath);
     let runner = new NuGetToolRunner(nuGetExePath, settings);
     runner.on("debug", message => tl.debug(message));
     return runner;

--- a/Tasks/Common/nuget-task-common/NuGetToolRunner2.ts
+++ b/Tasks/Common/nuget-task-common/NuGetToolRunner2.ts
@@ -151,6 +151,7 @@ export class NuGetToolRunner2 extends ToolRunner {
 }
 
 export function createNuGetToolRunner(nuGetExePath: string, settings: NuGetEnvironmentSettings, authInfo: auth.NuGetExtendedAuthInfo): NuGetToolRunner2 {
+    nuGetExePath = ngutil.resolveToolPath(nuGetExePath);
     let runner = new NuGetToolRunner2(nuGetExePath, settings, authInfo);
     runner.on("debug", message => tl.debug(message));
     return runner;

--- a/Tasks/Common/nuget-task-common/Utility.ts
+++ b/Tasks/Common/nuget-task-common/Utility.ts
@@ -190,6 +190,10 @@ export function getBundledNuGetLocation(uxOption: string): string {
     return toolPath;
 }
 
+export function resolveToolPath(path: string ): string {
+    return tl.resolve(path);
+}
+
 export function locateCredentialProvider(useV2CredProvider?: boolean): string {
     if (useV2CredProvider === true) {
         // tslint:disable-next-line:max-line-length

--- a/Tasks/Common/nuget-task-common/package-lock.json
+++ b/Tasks/Common/nuget-task-common/package-lock.json
@@ -14,7 +14,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -33,7 +33,7 @@
       "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
       "integrity": "sha1-Dly9y1vxeM+ngx6kHcMj2XQiMVo=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "minimatch": {
@@ -41,7 +41,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "mockery": {
@@ -103,9 +103,9 @@
       "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-5.1.2.tgz",
       "integrity": "sha1-gXtm/+1uEcvXH5O5FvSxicljQls=",
       "requires": {
-        "q": "1.5.1",
+        "q": "^1.0.1",
         "tunnel": "0.0.4",
-        "underscore": "1.8.3"
+        "underscore": "^1.8.3"
       }
     },
     "vsts-task-lib": {
@@ -113,12 +113,12 @@
       "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.6.tgz",
       "integrity": "sha1-9sqGS3sDsS23N8nV/2kThGNpEFY=",
       "requires": {
-        "minimatch": "3.0.4",
-        "mockery": "1.7.0",
-        "q": "1.5.1",
-        "semver": "5.5.0",
-        "shelljs": "0.3.0",
-        "uuid": "3.2.1"
+        "minimatch": "^3.0.0",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
       }
     },
     "vsts-task-tool-lib": {
@@ -126,11 +126,11 @@
       "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.1.tgz",
       "integrity": "sha1-mYLTv14YS95SqpdCGJROEGJzRWU=",
       "requires": {
-        "semver": "5.5.0",
-        "semver-compare": "1.0.0",
-        "typed-rest-client": "0.11.0",
-        "uuid": "3.2.1",
-        "vsts-task-lib": "2.2.1"
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
+        "typed-rest-client": "^0.11.0",
+        "uuid": "^3.0.1",
+        "vsts-task-lib": "^2.0.7"
       },
       "dependencies": {
         "vsts-task-lib": {
@@ -138,12 +138,12 @@
           "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.2.1.tgz",
           "integrity": "sha512-FYllK73r1K7+sPUtWKZ4tihskJgpGB3YdNX4qr1YO0cmhFAWHm9FfEVxmKdlNeIyDtu3NyRb4wVUz0Gwi5LyGA==",
           "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.5.1",
-            "semver": "5.5.0",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
+            "minimatch": "^3.0.0",
+            "mockery": "^1.7.0",
+            "q": "^1.1.2",
+            "semver": "^5.1.0",
+            "shelljs": "^0.3.0",
+            "uuid": "^3.0.1"
           }
         }
       }
@@ -153,7 +153,7 @@
       "resolved": "https://registry.npmjs.org/xmlreader/-/xmlreader-0.2.3.tgz",
       "integrity": "sha1-hldutdV5Wabe5+0os8vRw1Wdy5A=",
       "requires": {
-        "sax": "0.5.8"
+        "sax": "~0.5.2"
       }
     }
   }

--- a/Tasks/Common/utility-common/package-lock.json
+++ b/Tasks/Common/utility-common/package-lock.json
@@ -14,7 +14,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -33,7 +33,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "mockery": {
@@ -91,7 +91,7 @@
       "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
       "requires": {
         "tunnel": "0.0.4",
-        "typed-rest-client": "0.12.0",
+        "typed-rest-client": "^0.12.0",
         "underscore": "1.8.3"
       },
       "dependencies": {
@@ -112,11 +112,11 @@
       "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "1.7.0",
-        "q": "1.5.1",
-        "semver": "5.5.0",
-        "shelljs": "0.3.0",
-        "uuid": "3.2.1"
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
       }
     },
     "vsts-task-tool-lib": {
@@ -124,10 +124,10 @@
       "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
       "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
       "requires": {
-        "semver": "5.5.0",
-        "semver-compare": "1.0.0",
-        "typed-rest-client": "0.9.0",
-        "uuid": "3.2.1",
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
+        "typed-rest-client": "^0.9.0",
+        "uuid": "^3.0.1",
         "vsts-task-lib": "2.0.4-preview"
       },
       "dependencies": {
@@ -136,12 +136,12 @@
           "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
           "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
           "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.5.1",
-            "semver": "5.5.0",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
+            "minimatch": "^3.0.0",
+            "mockery": "^1.7.0",
+            "q": "^1.1.2",
+            "semver": "^5.1.0",
+            "shelljs": "^0.3.0",
+            "uuid": "^3.0.1"
           }
         }
       }

--- a/Tasks/DotNetCoreCLIV2/Tests/DotnetMockHelper.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/DotnetMockHelper.ts
@@ -83,6 +83,12 @@ export class DotnetMockHelper {
                 return 'https://vsts/packagesource';
             }
         });
+        
+        this.tmr.registerMock('./Utility', {
+            resolveToolPath: function(path) {
+                return path;
+            }
+        });
     }
 
     public registerVstsNuGetPushRunnerMock() {

--- a/Tasks/NuGetCommandV2/Tests/NugetMockHelper.ts
+++ b/Tasks/NuGetCommandV2/Tests/NugetMockHelper.ts
@@ -77,6 +77,9 @@ export class NugetMockHelper {
             getBundledNuGetLocation: function(version) {
                 return 'c:\\agent\\home\\directory\\externals\\nuget\\nuget.exe';
             },
+            resolveToolPath: function(path) {
+                return path;
+            },
             stripLeadingAndTrailingQuotes: function(path) {
                 return path;
             },
@@ -103,6 +106,9 @@ export class NugetMockHelper {
             },
             getBundledNuGetLocation: function(version) {
                 return '~/myagent/_work/_tasks/NuGet/nuget.exe';
+            },
+            resolveToolPath: function(path) {
+                return path;
             },
             locateCredentialProvider: function(path) {
                 return '~/myagent/_work/_tasks/NuGet/CredentialProvider';

--- a/Tasks/NuGetCommandV2/Tests/NugetMockHelper.ts
+++ b/Tasks/NuGetCommandV2/Tests/NugetMockHelper.ts
@@ -77,9 +77,6 @@ export class NugetMockHelper {
             getBundledNuGetLocation: function(version) {
                 return 'c:\\agent\\home\\directory\\externals\\nuget\\nuget.exe';
             },
-            resolveToolPath: function(path) {
-                return path;
-            },
             stripLeadingAndTrailingQuotes: function(path) {
                 return path;
             },
@@ -92,6 +89,11 @@ export class NugetMockHelper {
             },
             getNuGetFeedRegistryUrl(accessToken, feedId, nuGetVersion) {
                 return 'https://vsts/packagesource';
+            }
+        });
+        this.tmr.registerMock('./Utility', {
+            resolveToolPath: function(path) {
+                return path;
             }
         });
     }
@@ -116,6 +118,11 @@ export class NugetMockHelper {
             setConsoleCodePage: function() {
                 var tlm = require('vsts-task-lib/mock-task');
                 tlm.debug(`setting console code page`);
+            }
+        });
+        this.tmr.registerMock('./Utility', {
+            resolveToolPath: function(path) {
+                return path;
             }
         });
     }

--- a/Tasks/NuGetCommandV2/package-lock.json
+++ b/Tasks/NuGetCommandV2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nugetcommand",
-  "version": "2.0.35",
+  "version": "2.0.36",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Tasks/NuGetInstallerV0/Tests/NugetMockHelper.ts
+++ b/Tasks/NuGetInstallerV0/Tests/NugetMockHelper.ts
@@ -55,7 +55,13 @@ export class NugetMockHelper {
                 var tlm = require('vsts-task-lib/mock-task');
                 tlm.debug(`setting console code page`);
             }
-        } )
+        } );
+        
+        this.tmr.registerMock('./Utility', {
+            resolveToolPath: function(path) {
+                return path;
+            }
+        });
     }
     
     public registerNugetConfigMock() {

--- a/Tasks/NuGetInstallerV0/task.json
+++ b/Tasks/NuGetInstallerV0/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 33
+        "Patch": 34
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetInstallerV0/task.loc.json
+++ b/Tasks/NuGetInstallerV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 33
+    "Patch": 34
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetPublisherV0/Tests/NugetMockHelper.ts
+++ b/Tasks/NuGetPublisherV0/Tests/NugetMockHelper.ts
@@ -55,7 +55,13 @@ export class NugetMockHelper {
                 var tlm = require('vsts-task-lib/mock-task');
                 tlm.debug(`setting console code page`);
             }
-        } )
+        } );
+        
+        this.tmr.registerMock('./Utility', {
+            resolveToolPath: function(path) {
+                return path;
+            }
+        });
     }
     
     public registerNugetConfigMock() {

--- a/Tasks/NuGetPublisherV0/package-lock.json
+++ b/Tasks/NuGetPublisherV0/package-lock.json
@@ -165,19 +165,6 @@
             "underscore": "1.8.3"
           }
         },
-        "vsts-task-lib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
-          "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
-          "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
-          }
-        },
         "vsts-task-tool-lib": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
@@ -254,21 +241,6 @@
         "typed-rest-client": "^0.11.0",
         "uuid": "^3.0.1",
         "vsts-task-lib": "^2.0.7"
-      },
-      "dependencies": {
-        "vsts-task-lib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
-          "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
-          "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
-          }
-        }
       }
     },
     "xmlreader": {

--- a/Tasks/NuGetPublisherV0/task.json
+++ b/Tasks/NuGetPublisherV0/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 39
+        "Patch": 40
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetPublisherV0/task.loc.json
+++ b/Tasks/NuGetPublisherV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 39
+    "Patch": 40
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetRestoreV1/Tests/NugetMockHelper.ts
+++ b/Tasks/NuGetRestoreV1/Tests/NugetMockHelper.ts
@@ -77,7 +77,13 @@ export class NugetMockHelper {
                 var tlm = require('vsts-task-lib/mock-task');
                 tlm.debug(`setting console code page`);
             }
-        } )
+        } );
+        
+        this.tmr.registerMock('./Utility', {
+            resolveToolPath: function(path) {
+                return path;
+            }
+        });
     }
     
     public registerNugetConfigMock() {

--- a/Tasks/NuGetRestoreV1/task.json
+++ b/Tasks/NuGetRestoreV1/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetRestoreV1/task.loc.json
+++ b/Tasks/NuGetRestoreV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 3
+    "Patch": 4
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetToolInstallerV0/package-lock.json
+++ b/Tasks/NuGetToolInstallerV0/package-lock.json
@@ -10,11 +10,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -33,7 +33,7 @@
       "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
       "integrity": "sha1-Dly9y1vxeM+ngx6kHcMj2XQiMVo=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "minimatch": {
@@ -41,7 +41,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "mockery": {
@@ -52,12 +52,12 @@
     "nuget-task-common": {
       "version": "file:../../_build/Tasks/Common/nuget-task-common-1.0.1.tgz",
       "requires": {
-        "ltx": "2.7.1",
-        "mockery": "1.7.0",
-        "vso-node-api": "5.1.2",
+        "ltx": "^2.6.2",
+        "mockery": "^1.7.0",
+        "vso-node-api": "^5.0.5",
         "vsts-task-lib": "2.0.6",
         "vsts-task-tool-lib": "0.4.1",
-        "xmlreader": "0.2.3"
+        "xmlreader": "^0.2.3"
       }
     },
     "q": {
@@ -71,9 +71,9 @@
       "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -97,26 +97,33 @@
       "requires": {
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        }
       }
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "vso-node-api": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-5.1.2.tgz",
       "integrity": "sha1-gXtm/+1uEcvXH5O5FvSxicljQls=",
       "requires": {
-        "q": "1.5.1",
+        "q": "^1.0.1",
         "tunnel": "0.0.4",
-        "underscore": "1.8.3"
+        "underscore": "^1.8.3"
       }
     },
     "vsts-task-lib": {
@@ -124,12 +131,12 @@
       "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.6.tgz",
       "integrity": "sha1-9sqGS3sDsS23N8nV/2kThGNpEFY=",
       "requires": {
-        "minimatch": "3.0.4",
-        "mockery": "1.7.0",
-        "q": "1.5.1",
-        "semver": "5.5.0",
-        "shelljs": "0.3.0",
-        "uuid": "3.2.1"
+        "minimatch": "^3.0.0",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
       }
     },
     "vsts-task-tool-lib": {
@@ -137,24 +144,24 @@
       "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.1.tgz",
       "integrity": "sha1-mYLTv14YS95SqpdCGJROEGJzRWU=",
       "requires": {
-        "semver": "5.5.0",
-        "semver-compare": "1.0.0",
-        "typed-rest-client": "0.11.0",
-        "uuid": "3.2.1",
-        "vsts-task-lib": "2.2.1"
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
+        "typed-rest-client": "^0.11.0",
+        "uuid": "^3.0.1",
+        "vsts-task-lib": "^2.0.7"
       },
       "dependencies": {
         "vsts-task-lib": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.2.1.tgz",
-          "integrity": "sha512-FYllK73r1K7+sPUtWKZ4tihskJgpGB3YdNX4qr1YO0cmhFAWHm9FfEVxmKdlNeIyDtu3NyRb4wVUz0Gwi5LyGA==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
+          "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
           "requires": {
             "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.5.1",
-            "semver": "5.5.0",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
+            "mockery": "^1.7.0",
+            "q": "^1.1.2",
+            "semver": "^5.1.0",
+            "shelljs": "^0.3.0",
+            "uuid": "^3.0.1"
           }
         }
       }
@@ -164,7 +171,7 @@
       "resolved": "https://registry.npmjs.org/xmlreader/-/xmlreader-0.2.3.tgz",
       "integrity": "sha1-hldutdV5Wabe5+0os8vRw1Wdy5A=",
       "requires": {
-        "sax": "0.5.8"
+        "sax": "~0.5.2"
       }
     }
   }

--- a/Tasks/NuGetV0/Tests/NugetMockHelper.ts
+++ b/Tasks/NuGetV0/Tests/NugetMockHelper.ts
@@ -71,7 +71,13 @@ export class NugetMockHelper {
                 var tlm = require('vsts-task-lib/mock-task');
                 tlm.debug(`setting console code page`);
             }
-        } )
+        } );
+        
+        this.tmr.registerMock('./Utility', {
+            resolveToolPath: function(path) {
+                return path;
+            }
+        });
     }
     
     public registerNugetConfigMock() {

--- a/Tasks/NuGetV0/package-lock.json
+++ b/Tasks/NuGetV0/package-lock.json
@@ -165,19 +165,6 @@
             "underscore": "1.8.3"
           }
         },
-        "vsts-task-lib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
-          "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
-          "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
-          }
-        },
         "vsts-task-tool-lib": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
@@ -254,21 +241,6 @@
         "typed-rest-client": "^0.11.0",
         "uuid": "^3.0.1",
         "vsts-task-lib": "^2.0.7"
-      },
-      "dependencies": {
-        "vsts-task-lib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
-          "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
-          "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
-          }
-        }
       }
     },
     "xmlreader": {

--- a/Tasks/NuGetV0/task.json
+++ b/Tasks/NuGetV0/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 4
+        "Patch": 5
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetV0/task.loc.json
+++ b/Tasks/NuGetV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 4
+    "Patch": 5
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
Fixes an issue with supplying a relative path to nuget.exe in the old version of the nuget task. The toolrunner added a where() command, which doesn't like relative paths.