### PR TITLE
Updated issues template to explicitly request for debug logs

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -19,6 +19,10 @@ Checkout how to troubleshoot failures and collect debug logs: https://docs.micro
 
 [Include task name(s), screenshots and any other relevant details]
 
+### Task logs
+
+[Enable debug logging and please provide the zip file containing all the logs for a speedy resolution]
+
 ### Error logs
 
-[Insert error from the logs here]
+[Insert error from the logs here for a quick overview]


### PR DESCRIPTION
Most issues are created with only one or two lines of logs pertaining to the error that occurred. More oft than not these are not enough to arrive at the root cause of the issue.

Explicitly stating this in the template can help reduce the ETA for issues by quite a bit as the general trend is to request for debug logs and wait around till the customer takes a look and then finds to time to go back and do this thus having delayed the whole process by a few days at the least. Given that these steps are present in the linked msdn docs page however the practical scenario being not many customers come up with the entire set of logs when they initially file an issue.