### PR TITLE
Fixing the download build artifact issue where if forward slash is me…

### DIFF
--- a/Tasks/DownloadBuildArtifactsV0/main.ts
+++ b/Tasks/DownloadBuildArtifactsV0/main.ts
@@ -242,6 +242,12 @@ async function main(): Promise<void> {
                     var containerId = parseInt(containerParts[1]);
                     var containerPath = containerParts.slice(2,containerParts.length).join('/');
 
+                    if (containerPath == "/") {
+                        //container REST api oddity. Passing '/' as itemPath downloads the first file instead of returning the meta data about the all the files in the root level. 
+                        //This happens only if the first item is a file.
+                        containerPath = ""
+                    }
+
                     var itemsUrl = endpointUrl + "/_apis/resources/Containers/" + containerId + "?itemPath=" + encodeURIComponent(containerPath) + "&isShallow=true&api-version=4.1-preview.4";
                     console.log(tl.loc("DownloadArtifacts", artifact.name, itemsUrl));
 

--- a/Tasks/DownloadBuildArtifactsV0/package-lock.json
+++ b/Tasks/DownloadBuildArtifactsV0/package-lock.json
@@ -9,9 +9,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "amdefine": {
@@ -22,7 +22,7 @@
     "artifact-engine": {
       "version": "0.1.23",
       "resolved": "https://registry.npmjs.org/artifact-engine/-/artifact-engine-0.1.23.tgz",
-      "integrity": "sha1-jr3vBt1+DnHuay76BX+W98gTDi0=",
+      "integrity": "sha512-JYtJsBVBqK2pl2b7CLrdyGCsPbTVSVYStnr4g65z3xXiwk2P9nVxq2vHYBTFeEm86oCm//W2syi6cGWnx8NrvQ==",
       "requires": {
         "handlebars": "4.0.10",
         "minimatch": "3.0.2",
@@ -33,14 +33,14 @@
         "vsts-task-lib": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.2.1.tgz",
-          "integrity": "sha1-R4tmbscIpWDdOoRC6NqA/gO3IcQ=",
+          "integrity": "sha512-FYllK73r1K7+sPUtWKZ4tihskJgpGB3YdNX4qr1YO0cmhFAWHm9FfEVxmKdlNeIyDtu3NyRb4wVUz0Gwi5LyGA==",
           "requires": {
-            "minimatch": "^3.0.0",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
+            "minimatch": "3.0.2",
+            "mockery": "1.7.0",
+            "q": "1.5.1",
+            "semver": "5.4.1",
+            "shelljs": "0.3.0",
+            "uuid": "3.1.0"
           }
         }
       }
@@ -60,7 +60,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -76,8 +76,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "optional": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "cliui": {
@@ -86,8 +86,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "optional": true,
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -115,23 +115,23 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       }
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "lazy-cache": {
@@ -150,7 +150,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
       "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
       "requires": {
-        "brace-expansion": "^1.0.0"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -168,8 +168,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
       }
     },
     "q": {
@@ -188,7 +188,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "optional": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "semver": {
@@ -206,7 +206,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "requires": {
-        "amdefine": ">=0.0.4"
+        "amdefine": "1.0.1"
       }
     },
     "tunnel": {
@@ -220,9 +220,9 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "optional": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -255,8 +255,8 @@
       "integrity": "sha1-mZAuYmxAhxarkLBCcFRSyI7BwvA=",
       "requires": {
         "tunnel": "0.0.4",
-        "typed-rest-client": "^0.12.0",
-        "underscore": "^1.8.3"
+        "typed-rest-client": "0.12.0",
+        "underscore": "1.8.3"
       },
       "dependencies": {
         "typed-rest-client": {
@@ -275,12 +275,12 @@
       "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.1.0.tgz",
       "integrity": "sha1-w3Gu/yqNmEOIZSNdyfyUcBxATIQ=",
       "requires": {
-        "minimatch": "^3.0.0",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "minimatch": "3.0.2",
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.4.1",
+        "shelljs": "0.3.0",
+        "uuid": "3.1.0"
       }
     },
     "window-size": {
@@ -300,9 +300,9 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "optional": true,
       "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
         "window-size": "0.1.0"
       }
     }

--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 140,
+    "Minor": 141,
     "Patch": 0
   },
   "groups": [

--- a/Tasks/DownloadBuildArtifactsV0/task.loc.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.loc.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 140,
+    "Minor": 141,
     "Patch": 0
   },
   "groups": [


### PR DESCRIPTION
…ntion for an artifact drop name.

If we pass the slash as itemPath the api downloads the first file if the first entry is file instead of returning the metadata about the all the file/folder at root level.
However if its folder it works fine. We are reverting back to our old behavior in the task where if just a slash is mentioned for itemPath we pass an empty string.