### PR TITLE
Fixing the download build artifact issue where if forward slash is me…

### DIFF
--- a/Tasks/DownloadBuildArtifactsV0/main.ts
+++ b/Tasks/DownloadBuildArtifactsV0/main.ts
@@ -239,6 +239,12 @@ async function main(): Promise<void> {
                     var containerId = parseInt(containerParts[1]);
                     var containerPath = containerParts.slice(2,containerParts.length).join('/');
 
+                    if (containerPath == "/") {
+                        //container REST api oddity. Passing '/' as itemPath downloads the first file instead of returning the meta data about the all the files in the root level. 
+                        //This happens only if the first item is a file.
+                        containerPath = ""
+                    }
+
                     var itemsUrl = endpointUrl + "/_apis/resources/Containers/" + containerId + "?itemPath=" + encodeURIComponent(containerPath) + "&isShallow=true&api-version=4.1-preview.4";
                     console.log(tl.loc("DownloadArtifacts", artifact.name, itemsUrl));
 

--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 139,
+    "Minor": 140,
     "Patch": 0
   },
   "groups": [

--- a/Tasks/DownloadBuildArtifactsV0/task.loc.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.loc.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 139,
+    "Minor": 140,
     "Patch": 0
   },
   "groups": [


### PR DESCRIPTION
…ntioned for an artifact drop name.

If we pass the slash as itemPath the api downloads the first file if the first entry is file instead of returning the metadata about the all the file/folder at root level.
However if its folder it works fine. We are reverting back to our old behavior in the task where if just a slash is mentioned for itemPath we pass an empty string.