### PR TITLE
Removed deprecated parameter in Service Fabric release definition.

### DIFF
--- a/Tasks/ServiceFabricDeployV1/task.json
+++ b/Tasks/ServiceFabricDeployV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 7,
-        "Patch": 22
+        "Patch": 23
     },
     "demands": [
         "Cmd"

--- a/Tasks/ServiceFabricDeployV1/task.json
+++ b/Tasks/ServiceFabricDeployV1/task.json
@@ -214,15 +214,6 @@
             "visibleRule": "overridePublishProfileSettings = true && isUpgrade = true"
         },
         {
-            "name": "ReplicaQuorumTimeoutSec",
-            "type": "string",
-            "label": "ReplicaQuorumTimeoutSec",
-            "defaultValue": "",
-            "required": false,
-            "groupname": "upgrade",
-            "visibleRule": "overridePublishProfileSettings = true && isUpgrade = true"
-        },
-        {
             "name": "TimeoutSec",
             "type": "string",
             "label": "TimeoutSec",

--- a/Tasks/ServiceFabricDeployV1/task.loc.json
+++ b/Tasks/ServiceFabricDeployV1/task.loc.json
@@ -214,15 +214,6 @@
       "visibleRule": "overridePublishProfileSettings = true && isUpgrade = true"
     },
     {
-      "name": "ReplicaQuorumTimeoutSec",
-      "type": "string",
-      "label": "ms-resource:loc.input.label.ReplicaQuorumTimeoutSec",
-      "defaultValue": "",
-      "required": false,
-      "groupname": "upgrade",
-      "visibleRule": "overridePublishProfileSettings = true && isUpgrade = true"
-    },
-    {
       "name": "TimeoutSec",
       "type": "string",
       "label": "ms-resource:loc.input.label.TimeoutSec",

--- a/Tasks/ServiceFabricDeployV1/utilities.ps1
+++ b/Tasks/ServiceFabricDeployV1/utilities.ps1
@@ -152,7 +152,6 @@ function Get-VstsUpgradeParameters
 
     $parameterNames = @(
         "UpgradeReplicaSetCheckTimeoutSec",
-        "ReplicaQuorumTimeoutSec",
         "TimeoutSec",
         "ForceRestart"
     )


### PR DESCRIPTION
Removed the "ReplicaQuorumTimeoutSec" parameter everywhere except the resource strings since it is deprecated. Should use "UpgradeReplicaSetCheckTimeoutSec" instead, which is already implemented in the task.

Raised an issue about this at [https://github.com/Microsoft/vsts-tasks/issues/8255](https://github.com/Microsoft/vsts-tasks/issues/8255) before realizing this may be an easy change to make myself.