### PR TITLE
Fail az login only if az CLI exits with code != 0

### DIFF
--- a/Tasks/AzureCLIV1/azureclitask.ts
+++ b/Tasks/AzureCLIV1/azureclitask.ts
@@ -140,7 +140,7 @@ export class azureclitask {
     }
 
     private static throwIfError(resultOfToolExecution): void {
-        if (resultOfToolExecution.stderr) {
+        if (resultOfToolExecution.code != 0) {
             throw resultOfToolExecution;
         }
     }

--- a/Tasks/AzureCLIV1/azureclitask.ts
+++ b/Tasks/AzureCLIV1/azureclitask.ts
@@ -123,10 +123,10 @@ export class azureclitask {
         var tenantId: string = tl.getEndpointAuthorizationParameter(connectedService, "tenantid", false);
         var subscriptionID: string = tl.getEndpointDataParameter(connectedService, "SubscriptionID", true);
         //login using svn
-        this.throwIfError(tl.execSync("az", "login --service-principal -u \"" + servicePrincipalId + "\" -p \"" + cliPassword + "\" --tenant \"" + tenantId + "\""));
+        this.throwIfFailed(tl.execSync("az", "login --service-principal -u \"" + servicePrincipalId + "\" -p \"" + cliPassword + "\" --tenant \"" + tenantId + "\""));
         this.isLoggedIn = true;
         //set the subscription imported to the current subscription
-        this.throwIfError(tl.execSync("az", "account set --subscription \"" + subscriptionID + "\""));
+        this.throwIfFailed(tl.execSync("az", "account set --subscription \"" + subscriptionID + "\""));
     }
 
     private static logoutAzure() {
@@ -139,7 +139,7 @@ export class azureclitask {
         }
     }
 
-    private static throwIfError(resultOfToolExecution): void {
+    private static throwIfFailed(resultOfToolExecution): void {
         if (resultOfToolExecution.code != 0) {
             throw resultOfToolExecution;
         }

--- a/Tasks/AzureCLIV1/task.json
+++ b/Tasks/AzureCLIV1/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 1,
         "Minor": 137,
-        "Patch": 3
+        "Patch": 4
     },
     "minimumAgentVersion": "2.0.0",
     "instanceNameFormat": "Azure CLI $(scriptPath)",

--- a/Tasks/AzureCLIV1/task.loc.json
+++ b/Tasks/AzureCLIV1/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 137,
-    "Patch": 3
+    "Patch": 4
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
We should not fail the task on az login / account set even if there is output to stderr (this isn't a reliable indicator of failure). Fail only if the actual command run exits with a non-zero status code which will appropriately indicate failure.