### PR TITLE
Fixing a dependency issue in universal task

### DIFF
--- a/Tasks/Common/utility-common/package-lock.json
+++ b/Tasks/Common/utility-common/package-lock.json
@@ -14,7 +14,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -31,9 +31,9 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "mockery": {
@@ -91,7 +91,7 @@
       "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
       "requires": {
         "tunnel": "0.0.4",
-        "typed-rest-client": "0.12.0",
+        "typed-rest-client": "^0.12.0",
         "underscore": "1.8.3"
       },
       "dependencies": {
@@ -112,11 +112,11 @@
       "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "1.7.0",
-        "q": "1.5.1",
-        "semver": "5.5.0",
-        "shelljs": "0.3.0",
-        "uuid": "3.2.1"
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
       }
     },
     "vsts-task-tool-lib": {
@@ -124,10 +124,10 @@
       "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
       "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
       "requires": {
-        "semver": "5.5.0",
-        "semver-compare": "1.0.0",
-        "typed-rest-client": "0.9.0",
-        "uuid": "3.2.1",
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
+        "typed-rest-client": "^0.9.0",
+        "uuid": "^3.0.1",
         "vsts-task-lib": "2.0.4-preview"
       },
       "dependencies": {
@@ -136,12 +136,12 @@
           "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
           "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
           "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.5.1",
-            "semver": "5.5.0",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
+            "minimatch": "^3.0.0",
+            "mockery": "^1.7.0",
+            "q": "^1.1.2",
+            "semver": "^5.1.0",
+            "shelljs": "^0.3.0",
+            "uuid": "^3.0.1"
           }
         }
       }

--- a/Tasks/UniversalPackagesV0/make.json
+++ b/Tasks/UniversalPackagesV0/make.json
@@ -5,5 +5,13 @@
             "type": "node",
             "compile": true
         }
+    ],
+    "rm": [
+        {
+            "items": [
+                "node_modules/utility-common/node_modules/vsts-task-lib"
+            ],
+            "options": "-Rf"
+        }
     ]
 }

--- a/Tasks/UniversalPackagesV0/package-lock.json
+++ b/Tasks/UniversalPackagesV0/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "universalpackages",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Tasks/UniversalPackagesV0/package-lock.json
+++ b/Tasks/UniversalPackagesV0/package-lock.json
@@ -71,31 +71,14 @@
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-    },
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
         "js-base64": "2.4.3",
         "semver": "^5.4.1",
-        "vso-node-api": "6.0.1-preview",
-        "vsts-task-lib": "2.0.6",
+        "vso-node-api": "6.5.0",
+        "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
-      },
-      "dependencies": {
-        "vso-node-api": {
-          "version": "6.0.1-preview",
-          "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.0.1-preview.tgz",
-          "integrity": "sha1-RBprv5s8aNpiTbAeo1y6jwpMLKs=",
-          "requires": {
-            "q": "^1.0.1",
-            "tunnel": "0.0.4",
-            "underscore": "^1.8.3"
-          }
-        }
       }
     },
     "uuid": {
@@ -130,11 +113,11 @@
       }
     },
     "vsts-task-lib": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.6.tgz",
-      "integrity": "sha1-9sqGS3sDsS23N8nV/2kThGNpEFY=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
+      "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
       "requires": {
-        "minimatch": "^3.0.0",
+        "minimatch": "3.0.4",
         "mockery": "^1.7.0",
         "q": "^1.1.2",
         "semver": "^5.1.0",

--- a/Tasks/UniversalPackagesV0/package.json
+++ b/Tasks/UniversalPackagesV0/package.json
@@ -20,7 +20,7 @@
         "adm-zip": "^0.4.11",
         "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
         "vso-node-api": "6.5.0",
-        "vsts-task-lib": "2.0.6",
+        "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
     }
 }

--- a/Tasks/UniversalPackagesV0/package.json
+++ b/Tasks/UniversalPackagesV0/package.json
@@ -1,6 +1,6 @@
 {
     "name": "universalpackages",
-    "version": "0.0.1",
+    "version": "0.0.3",
     "description": "Download or publish universal packages.",
     "main": "universalmain.js",
     "scripts": {

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 2
+    "Patch": 3
   },
   "runsOn": [
     "Agent",

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 2
+    "Patch": 3
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
There was a dependency change in utility-common recently which broke universal packages. Fixing it to have same version of vsts-task-lib dependency throughout. Also applying the hack other protocols do to make sure this never happens. Basically, deleting the dependency for utility commons. 