### PR TITLE
Temporarily remove nuget V2 credential provider based on quirks

### DIFF
--- a/Tasks/Common/nuget-task-common/NuGetToolRunner2.ts
+++ b/Tasks/Common/nuget-task-common/NuGetToolRunner2.ts
@@ -208,10 +208,11 @@ export function isCredentialProviderEnabled(quirks: NuGetQuirks): boolean {
         return false;
     }
 
-    if (quirks.hasQuirk(NuGetQuirkName.V2CredentialProvider) === true) {
+    // Disabling quirk check during investigation
+    /*if (quirks.hasQuirk(NuGetQuirkName.V2CredentialProvider) === true) {
         tl.debug("Credential provider V1 is disabled in favor of V2 plugin.");
         return false;
-    }
+    }*/
     
     if (isAnyCredentialProviderEnabled(quirks)) {
         tl.debug("V1 credential provider is enabled");
@@ -238,10 +239,11 @@ export function isCredentialProviderV2Enabled(quirks: NuGetQuirks): boolean {
         return false;
     }
 
-    if (quirks.hasQuirk(NuGetQuirkName.V2CredentialProvider) === true) {
+    // Disabling quirk check during investigation
+    /*if (quirks.hasQuirk(NuGetQuirkName.V2CredentialProvider) === true) {
         tl.debug("V2 credential provider is enabled.");
         return true;
-    }
+    }*/
 
     tl.debug("V2 credential provider is disabled due to quirks. To use V2 credential provider use NuGet version 4.8 or higher.");
     return false;

--- a/Tasks/NuGetCommandV2/package.json
+++ b/Tasks/NuGetCommandV2/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nugetcommand",
-    "version": "2.0.36",
+    "version": "2.0.41",
     "description": "Restore, pack, or push NuGet packages, or run a NuGet command.",
     "main": "nugetcommandmain.js",
     "scripts": {

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 40
+        "Patch": 41
     },
     "runsOn": [
         "Agent",


### PR DESCRIPTION
This change disables automatic use of the cred provider V2 if using NuGet greater than 4.8