### PR TITLE
Conda task missing `await` when packages installed globally

### DIFF
--- a/Tasks/CondaEnvironmentV1/Tests/L0_conda.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0_conda.ts
@@ -165,7 +165,10 @@ it('fails if installing packages to the base environment fails', async function 
 
     const findConda = sinon.stub().returns('path-to-conda');
     const prependCondaToPath = sinon.spy();
-    const installPackagesGlobally = sinon.stub().throws();
+    // const installPackagesGlobally = sinon.stub().throws(new Error('installPackagesGlobally'));
+    const installPackagesGlobally = sinon.stub().rejects(new Error('installPackagesGlobally'));
+    sinon.expectation
+
     mockery.registerMock('./conda_internal', {
         findConda: findConda,
         prependCondaToPath: prependCondaToPath,
@@ -179,9 +182,16 @@ it('fails if installing packages to the base environment fails', async function 
         updateConda: false
     };
 
-    assert.throws(async () => {
+    // Can't use `assert.throws` with an async function
+    let error: any | undefined;
+    try {
         await uut.condaEnvironment(parameters, Platform.Linux);
-    });
+    } catch (err) {
+        error = err;
+    }
+
+    assert(error instanceof Error);
+    assert.strictEqual(error.message, 'installPackagesGlobally');
 
     assert(findConda.calledOnceWithExactly(Platform.Linux));
     assert(prependCondaToPath.calledOnceWithExactly('path-to-conda', Platform.Linux));

--- a/Tasks/CondaEnvironmentV1/Tests/L0_conda.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0_conda.ts
@@ -159,3 +159,31 @@ it('fails if `conda` is not found', async function (done: MochaDone) {
         done();
     }
 });
+
+it('fails if installing packages to the base environment fails', async function () {
+    mockery.registerMock('vsts-task-lib/task', mockTask);
+
+    const findConda = sinon.stub().returns('path-to-conda');
+    const prependCondaToPath = sinon.spy();
+    const installPackagesGlobally = sinon.stub().throws();
+    mockery.registerMock('./conda_internal', {
+        findConda: findConda,
+        prependCondaToPath: prependCondaToPath,
+        installPackagesGlobally: installPackagesGlobally
+    });
+
+    const uut = reload('../conda');
+    const parameters = {
+        createCustomEnvironment: false,
+        packageSpecs: 'pytest',
+        updateConda: false
+    };
+
+    assert.throws(async () => {
+        await uut.condaEnvironment(parameters, Platform.Linux);
+    });
+
+    assert(findConda.calledOnceWithExactly(Platform.Linux));
+    assert(prependCondaToPath.calledOnceWithExactly('path-to-conda', Platform.Linux));
+    assert(installPackagesGlobally.calledOnceWithExactly('pytest', undefined));
+});

--- a/Tasks/CondaEnvironmentV1/Tests/L0_conda.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0_conda.ts
@@ -165,9 +165,7 @@ it('fails if installing packages to the base environment fails', async function 
 
     const findConda = sinon.stub().returns('path-to-conda');
     const prependCondaToPath = sinon.spy();
-    // const installPackagesGlobally = sinon.stub().throws(new Error('installPackagesGlobally'));
     const installPackagesGlobally = sinon.stub().rejects(new Error('installPackagesGlobally'));
-    sinon.expectation
 
     mockery.registerMock('./conda_internal', {
         findConda: findConda,

--- a/Tasks/CondaEnvironmentV1/conda.ts
+++ b/Tasks/CondaEnvironmentV1/conda.ts
@@ -63,6 +63,6 @@ export async function condaEnvironment(parameters: Readonly<TaskParameters>, pla
 
         internal.activateEnvironment(environmentsDir, environmentName, platform);
     } else if (parameters.packageSpecs) {
-        internal.installPackagesGlobally(parameters.packageSpecs, parameters.installOptions);
+        await internal.installPackagesGlobally(parameters.packageSpecs, parameters.installOptions);
     }
 }

--- a/Tasks/CondaEnvironmentV1/conda_internal.ts
+++ b/Tasks/CondaEnvironmentV1/conda_internal.ts
@@ -115,8 +115,8 @@ export function activateEnvironment(environmentsDir: string, environmentName: st
     // For now we will assume these names are stable.
     // If we ever get broken, we should write code to run the activation script, diff the environment before and after,
     // and surface up the new environment variables as build variables.
-    task.setVariable('CONDA_DEFAULT_ENV', environmentName)
-    task.setVariable('CONDA_PREFIX', environmentPath)
+    task.setVariable('CONDA_DEFAULT_ENV', environmentName);
+    task.setVariable('CONDA_PREFIX', environmentPath);
 }
 
 /**

--- a/Tasks/CondaEnvironmentV1/task.json
+++ b/Tasks/CondaEnvironmentV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 138,
+        "Minor": 140,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/CondaEnvironmentV1/task.loc.json
+++ b/Tasks/CondaEnvironmentV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 138,
+    "Minor": 140,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
Async function wasn't getting awaited so errors were getting swallowed instead of being thrown.

This was working fine on Hosted Linux Preview but was exposed by auth issues on Hosted Ubuntu 16.04.