### PR TITLE
Try increasing timeouts on App Center tests

### DIFF
--- a/Tasks/AppCenterTestV1/Tests/L0.ts
+++ b/Tasks/AppCenterTestV1/Tests/L0.ts
@@ -7,21 +7,21 @@ import * as assert from 'assert';
 import * as ttm from 'vsts-task-lib/mock-test';
 
 describe('AppCenterTest L0 Suite', function () {
-    before(() => {
+    before(function () {
         //Enable this for output
-        //process.env['TASK_TEST_TRACE'] = 1; 
+        //process.env['TASK_TEST_TRACE'] = 1;
 
         //setup endpoint
         process.env["ENDPOINT_AUTH_MyTestEndpoint"] = "{\"parameters\":{\"apitoken\":\"mytoken123\"},\"scheme\":\"apitoken\"}";
         process.env["ENDPOINT_AUTH_PARAMETER_MyTestEndpoint_APITOKEN"] = "mytoken123";
     });
 
-    after(() => {
+    after(function () {
 
     });
 
-    it('Positive path: upload Appium test with service endpoint', (done: MochaDone) => {
-        this.timeout(3000);
+    it('Positive path: upload Appium test with service endpoint', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0AppiumPass.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -29,21 +29,19 @@ describe('AppCenterTest L0 Suite', function () {
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.invokedToolCount === 2, 'Should have run test prepare and test run');
-        assert(tr.ran("/path/to/appcenter test prepare appium --artifacts-dir " + 
-            "/path/to/artifactsDir --build-dir /path/to/appium_build_dir --debug --quiet"), 
+        assert(tr.ran("/path/to/appcenter test prepare appium --artifacts-dir " +
+            "/path/to/artifactsDir --build-dir /path/to/appium_build_dir --debug --quiet"),
             "Should have run prepare");
 
-        assert(tr.ran("/path/to/appcenter test run manifest " + 
-            "--manifest-path /path/to/artifactsDir/manifest.json --app-path " + 
+        assert(tr.ran("/path/to/appcenter test run manifest " +
+            "--manifest-path /path/to/artifactsDir/manifest.json --app-path " +
             "/test/path/to/my.ipa --app testuser/testapp --devices 1234abcd " +
-            "--test-series master --dsym-dir /path/to/dsym --locale nl_NL --debug --quiet --token mytoken123"), 
+            "--test-series master --dsym-dir /path/to/dsym --locale nl_NL --debug --quiet --token mytoken123"),
             "Should have run test run");
-
-        done();
     });
 
-    it('Positive path: upload Espresso test with service endpoint', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: upload Espresso test with service endpoint', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0EspressoPass.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -51,21 +49,19 @@ describe('AppCenterTest L0 Suite', function () {
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.invokedToolCount === 2, 'Should have run test prepare and test run');
-        assert(tr.ran("/path/to/appcenter test prepare espresso --artifacts-dir " + 
-            "/path/to/artifactsDir --build-dir /path/to/espresso_build_dir --test-apk-path /path/to/espresso_test_apk --debug --quiet"), 
+        assert(tr.ran("/path/to/appcenter test prepare espresso --artifacts-dir " +
+            "/path/to/artifactsDir --build-dir /path/to/espresso_build_dir --test-apk-path /path/to/espresso_test_apk --debug --quiet"),
             "Should have run prepare");
 
-        assert(tr.ran("/path/to/appcenter test run manifest " + 
-            "--manifest-path /path/to/artifactsDir/manifest.json --app-path " + 
+        assert(tr.ran("/path/to/appcenter test run manifest " +
+            "--manifest-path /path/to/artifactsDir/manifest.json --app-path " +
             "/test/path/to/my.ipa --app testuser/testapp --devices 1234abcd " +
-            "--test-series master --dsym-dir /path/to/dsym --locale nl_NL --debug --quiet --token mytoken123"), 
+            "--test-series master --dsym-dir /path/to/dsym --locale nl_NL --debug --quiet --token mytoken123"),
             "Should have run test run");
-
-        done();
     });
 
-    it('Positive path: upload Calabash test with service endpoint', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: upload Calabash test with service endpoint', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0CalabashPass.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -80,16 +76,14 @@ describe('AppCenterTest L0 Suite', function () {
             "Should have run prepare");
 
         assert(tr.ran("/path/to/appcenter test run manifest " +
-            "--manifest-path /path/to/artifactsDir/manifest.json --app-path /test/path/to/my.ipa " + 
-            "--app testuser/testapp --devices 1234abcd --test-series master --dsym-dir /path/to/dsym " + 
-            "--async --locale nl_NL --myRunOpts abc --quiet --token mytoken123"), 
+            "--manifest-path /path/to/artifactsDir/manifest.json --app-path /test/path/to/my.ipa " +
+            "--app testuser/testapp --devices 1234abcd --test-series master --dsym-dir /path/to/dsym " +
+            "--async --locale nl_NL --myRunOpts abc --quiet --token mytoken123"),
             "Should have run test run");
-
-        done();
     });
 
-    it('Positive path: upload XCUITest test with service endpoint', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: upload XCUITest test with service endpoint', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0CXCUITestPass.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -102,16 +96,14 @@ describe('AppCenterTest L0 Suite', function () {
             "Should have run prepare");
 
         assert(tr.ran("/path/to/appcenter test run manifest " +
-            "--manifest-path /path/to/artifactsDir/manifest.json --app-path /test/path/to/my.ipa " + 
-            "--app testuser/testapp --devices 1234abcd --test-series master --dsym-dir /path/to/dsym " + 
-            "--async --locale nl_NL --myRunOpts abc --quiet --token mytoken123"), 
+            "--manifest-path /path/to/artifactsDir/manifest.json --app-path /test/path/to/my.ipa " +
+            "--app testuser/testapp --devices 1234abcd --test-series master --dsym-dir /path/to/dsym " +
+            "--async --locale nl_NL --myRunOpts abc --quiet --token mytoken123"),
             "Should have run test run");
-
-        done();
     });
 
-    it('Positive path: upload UITest with username and password', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: upload UITest with username and password', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0UITestPass.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -125,21 +117,19 @@ describe('AppCenterTest L0 Suite', function () {
         assert(tr.ran("/path/to/appcenter logout --quiet"),
             "Should have run logout");
 
-        assert(tr.ran("/path/to/appcenter test prepare uitest --artifacts-dir " + 
-            "/path/to/artifactsDir --app-path /test/path/to/my.ipa --build-dir /path/to/uitest_build_dir --myopts --quiet"), 
+        assert(tr.ran("/path/to/appcenter test prepare uitest --artifacts-dir " +
+            "/path/to/artifactsDir --app-path /test/path/to/my.ipa --build-dir /path/to/uitest_build_dir --myopts --quiet"),
             "Should have run prepare");
 
-        assert(tr.ran("/path/to/appcenter test run manifest " + 
-            "--manifest-path /path/to/artifactsDir/manifest.json --app-path " + 
+        assert(tr.ran("/path/to/appcenter test run manifest " +
+            "--manifest-path /path/to/artifactsDir/manifest.json --app-path " +
             "/test/path/to/my.ipa --app testuser/testapp --devices 1234abcd " +
-            "--test-series master --dsym-dir /path/to/dsym --locale nc_US --quiet"), 
+            "--test-series master --dsym-dir /path/to/dsym --locale nc_US --quiet"),
             "Should have run test run");
-
-        done();
     });
 
-    it('Negative path: with username and password, should always logout even when test run failed', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Negative path: with username and password, should always logout even when test run failed', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0UITestFailRun.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -153,27 +143,22 @@ describe('AppCenterTest L0 Suite', function () {
         assert(tr.ran("/path/to/appcenter logout --quiet"),
             "Should have run logout");
 
-        assert(tr.ran("/path/to/appcenter test run manifest --manifest-path " + 
-            "/path/to/artifactsDir/manifest.json --app-path /test/path/to/my.ipa --app testuser/testapp --devices 1234abcd --test-series master --dsym-dir /path/to/dsym --locale nc_US --quiet"), 
+        assert(tr.ran("/path/to/appcenter test run manifest --manifest-path " +
+            "/path/to/artifactsDir/manifest.json --app-path /test/path/to/my.ipa --app testuser/testapp --devices 1234abcd --test-series master --dsym-dir /path/to/dsym --locale nc_US --quiet"),
             "Should have run 'run'");
-
-        done();
     });
 
-    it('Favor system appcenter cli over bundled cli', (done: MochaDone) => {
+    it('Favor system appcenter cli over bundled cli', function () {
         this.timeout(5000);
 
         let tp = path.join(__dirname, 'L0FavorSystemToolPath.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-        
+
         tr.run();
         assert(tr.failed, 'task should have failed');
 
         assert(tr.invokedToolCount === 1, 'Should have run login only');
         assert(tr.ran("/system/path/to/appcenter login -u MyUsername -p MyPassword --quiet"),
             "Should have run login");
-
-        done();
     });
-
- });
+});


### PR DESCRIPTION
We’ve been seeing a variety of failed tests with Node 5 on Hosted Ubuntu since 9/13.  It doesn’t seem to be any single test case, but the entire App Center suite seems to be affected.

I tested on a Linux VM and none of the tests got near the timeout, but this is to see if it fixes it for hosted builds.