### PR TITLE
Separated out packing the node file in makefile

### DIFF
--- a/make.js
+++ b/make.js
@@ -230,15 +230,13 @@ target.build = function() {
                         console.log('> getting module externals');
                         getExternals(modMake.externals, modOutDir);
                     }
+                }
 
-                    if (mod.type === 'node' && mod.compile == true) {
-                        var commonPack = util.getCommonPackInfo(modOutDir);
+                if (mod.type === 'node' && mod.compile == true) {
+                    var commonPack = util.getCommonPackInfo(modOutDir);
 
-                        // assert the pack file does not already exist (name should be unique)
-                        if (test('-f', commonPack.packFilePath)) {
-                            fail(`Pack file already exists: ${commonPack.packFilePath}`);
-                        }
-
+                    // check that the pack file does not already exist
+                    if (!test('-f', commonPack.packFilePath)) {
                         // pack the Node module. a pack file is required for dedupe.
                         // installing from a folder creates a symlink, and does not dedupe.
                         cd(path.dirname(modOutDir));


### PR DESCRIPTION
When building a dependency, the build would only check if a the directory for that module was there, rather than if the module itself was inside. This would lead to issues where a build would fail because a package relied on the packed node module but a prior task only built a powershell module (which the directory check would not catch).

To repro the issue on master: `node make.js build --task "@(VSBuildV1|XamariniOSV2)"`