### PR TITLE
Clean up test code for Python tasks

### DIFF
--- a/Tasks/CondaEnvironmentV0/Tests/L0.ts
+++ b/Tasks/CondaEnvironmentV0/Tests/L0.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import { EOL } from 'os';
 import * as path from 'path';
 
 import { MockTestRunner } from 'vsts-task-lib/mock-test';

--- a/Tasks/CondaEnvironmentV0/Tests/L0CondaNotFound.ts
+++ b/Tasks/CondaEnvironmentV0/Tests/L0CondaNotFound.ts
@@ -1,7 +1,5 @@
 import * as path from 'path';
 
-import * as sinon from 'sinon';
-
 import { TaskMockRunner } from 'vsts-task-lib/mock-run';
 
 const taskPath = path.join(__dirname, '..', 'main.js');

--- a/Tasks/CondaEnvironmentV0/Tests/L0_conda.ts
+++ b/Tasks/CondaEnvironmentV0/Tests/L0_conda.ts
@@ -43,10 +43,10 @@ it('creates and activates environment', async function () {
     const createEnvironment = sinon.spy();
     const activateEnvironment = sinon.spy();
     mockery.registerMock('./conda_internal', {
-        findConda: findConda,
-        prependCondaToPath: prependCondaToPath,
-        createEnvironment: createEnvironment,
-        activateEnvironment: activateEnvironment
+        findConda,
+        prependCondaToPath,
+        createEnvironment,
+        activateEnvironment
     });
 
     const uut = reload('../conda');
@@ -76,11 +76,11 @@ it('updates Conda if the user requests it', async function () {
     const createEnvironment = sinon.spy();
     const activateEnvironment = sinon.spy();
     mockery.registerMock('./conda_internal', {
-        findConda: findConda,
-        prependCondaToPath: prependCondaToPath,
-        updateConda: updateConda,
-        createEnvironment: createEnvironment,
-        activateEnvironment: activateEnvironment
+        findConda,
+        prependCondaToPath,
+        updateConda,
+        createEnvironment,
+        activateEnvironment
     });
 
     const uut = reload('../conda');
@@ -109,9 +109,9 @@ it('fails if `conda` is not found', async function (done: MochaDone) {
     const createEnvironment = sinon.spy();
     const activateEnvironment = sinon.spy();
     mockery.registerMock('./conda_internal', {
-        findConda: findConda,
-        createEnvironment: createEnvironment,
-        activateEnvironment: activateEnvironment
+        findConda,
+        createEnvironment,
+        activateEnvironment
     });
 
     const uut = reload('../conda');

--- a/Tasks/CondaEnvironmentV0/Tests/L0_conda_internal.ts
+++ b/Tasks/CondaEnvironmentV0/Tests/L0_conda_internal.ts
@@ -31,13 +31,13 @@ afterEach(function () {
     mockery.resetCache();
 });
 
-it('finds the Conda installation with the CONDA variable', async function () {
+it('finds the Conda installation with the CONDA variable', function () {
     const existsSync = sinon.stub();
     const statSync = sinon.stub();
 
     mockery.registerMock('fs', {
-        existsSync: existsSync,
-        statSync: statSync
+        existsSync,
+        statSync
     });
 
     mockTask.setAnswers({
@@ -50,7 +50,7 @@ it('finds the Conda installation with the CONDA variable', async function () {
     getVariable.withArgs('Agent.ToolsDirectory').returns('path-to-tools');
 
     mockery.registerMock('vsts-task-lib/task', Object.assign({}, mockTask, {
-        getVariable: getVariable
+        getVariable
     }));
 
     mockery.registerMock('vsts-task-tool-lib/tool', {});
@@ -89,15 +89,15 @@ it('finds the Conda installation with the CONDA variable', async function () {
     }
 });
 
-it('finds the Conda installation with PATH', async function () {
+it('finds the Conda installation with PATH', function () {
     const existsSync = sinon.stub().returns(true);
     const statSync = sinon.stub().returns({
         isFile: () => true
     });
 
     mockery.registerMock('fs', {
-        existsSync: existsSync,
-        statSync: statSync
+        existsSync,
+        statSync
     });
 
     mockTask.setAnswers({
@@ -111,7 +111,7 @@ it('finds the Conda installation with PATH', async function () {
     getVariable.withArgs('Agent.ToolsDirectory').returns('path-to-tools');
 
     mockery.registerMock('vsts-task-lib/task', Object.assign({}, mockTask, {
-        getVariable: getVariable
+        getVariable
     }));
 
     mockery.registerMock('vsts-task-tool-lib/tool', {});
@@ -167,15 +167,15 @@ it('creates Conda environment', async function (done: MochaDone) {
     }
 });
 
-it('activates Conda environment', async function () {
+it('activates Conda environment', function () {
     const setVariable = sinon.spy();
     mockery.registerMock('vsts-task-lib/task', Object.assign({}, mockTask, {
-        setVariable: setVariable
+        setVariable
     }));
 
     const prependPath = sinon.spy();
     mockery.registerMock('vsts-task-tool-lib/tool', {
-        prependPath: prependPath
+        prependPath
     });
 
     const uut = reload('../conda_internal');

--- a/Tasks/CondaEnvironmentV1/Tests/L0.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import { EOL } from 'os';
 import * as path from 'path';
 
 import { MockTestRunner } from 'vsts-task-lib/mock-test';

--- a/Tasks/CondaEnvironmentV1/Tests/L0BaseEnvironment.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0BaseEnvironment.ts
@@ -1,7 +1,5 @@
 import * as path from 'path';
 
-import * as mockery from 'mockery';
-
 import { TaskMockRunner } from 'vsts-task-lib/mock-run';
 
 const taskPath = path.join(__dirname, '..', 'main.js');

--- a/Tasks/CondaEnvironmentV1/Tests/L0CondaNotFound.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0CondaNotFound.ts
@@ -1,7 +1,5 @@
 import * as path from 'path';
 
-import * as sinon from 'sinon';
-
 import { TaskMockRunner } from 'vsts-task-lib/mock-run';
 
 const taskPath = path.join(__dirname, '..', 'main.js');

--- a/Tasks/CondaEnvironmentV1/Tests/L0_conda.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0_conda.ts
@@ -43,10 +43,10 @@ it('creates and activates environment', async function () {
     const createEnvironment = sinon.spy();
     const activateEnvironment = sinon.spy();
     mockery.registerMock('./conda_internal', {
-        findConda: findConda,
-        prependCondaToPath: prependCondaToPath,
-        createEnvironment: createEnvironment,
-        activateEnvironment: activateEnvironment
+        findConda,
+        prependCondaToPath,
+        createEnvironment,
+        activateEnvironment
     });
 
     const uut = reload('../conda');
@@ -75,10 +75,10 @@ it('requires `createCustomEnvironment` to be set to create a custom environment'
     const createEnvironment = sinon.spy();
     const activateEnvironment = sinon.spy();
     mockery.registerMock('./conda_internal', {
-        findConda: findConda,
-        prependCondaToPath: prependCondaToPath,
-        createEnvironment: createEnvironment,
-        activateEnvironment: activateEnvironment
+        findConda,
+        prependCondaToPath,
+        createEnvironment,
+        activateEnvironment
     });
 
     const uut = reload('../conda');
@@ -106,11 +106,11 @@ it('updates Conda if the user requests it', async function () {
     const createEnvironment = sinon.spy();
     const activateEnvironment = sinon.spy();
     mockery.registerMock('./conda_internal', {
-        findConda: findConda,
-        prependCondaToPath: prependCondaToPath,
-        updateConda: updateConda,
-        createEnvironment: createEnvironment,
-        activateEnvironment: activateEnvironment
+        findConda,
+        prependCondaToPath,
+        updateConda,
+        createEnvironment,
+        activateEnvironment
     });
 
     const uut = reload('../conda');
@@ -136,9 +136,9 @@ it('fails if `conda` is not found', async function () {
     const createEnvironment = sinon.spy();
     const activateEnvironment = sinon.spy();
     mockery.registerMock('./conda_internal', {
-        findConda: findConda,
-        createEnvironment: createEnvironment,
-        activateEnvironment: activateEnvironment
+        findConda,
+        createEnvironment,
+        activateEnvironment
     });
 
     const uut = reload('../conda');
@@ -173,9 +173,9 @@ it('fails if installing packages to the base environment fails', async function 
     const installPackagesGlobally = sinon.stub().rejects(new Error('installPackagesGlobally'));
 
     mockery.registerMock('./conda_internal', {
-        findConda: findConda,
-        prependCondaToPath: prependCondaToPath,
-        installPackagesGlobally: installPackagesGlobally
+        findConda,
+        prependCondaToPath,
+        installPackagesGlobally
     });
 
     const uut = reload('../conda');

--- a/Tasks/CondaEnvironmentV1/Tests/L0_conda_internal.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0_conda_internal.ts
@@ -36,8 +36,8 @@ it('finds the Conda installation with the CONDA variable', function () {
     const statSync = sinon.stub();
 
     mockery.registerMock('fs', {
-        existsSync: existsSync,
-        statSync: statSync
+        existsSync,
+        statSync
     });
 
     mockTask.setAnswers({
@@ -50,7 +50,7 @@ it('finds the Conda installation with the CONDA variable', function () {
     getVariable.withArgs('Agent.ToolsDirectory').returns('path-to-tools');
 
     mockery.registerMock('vsts-task-lib/task', Object.assign({}, mockTask, {
-        getVariable: getVariable
+        getVariable
     }));
 
     { // executable exists and is a file
@@ -94,8 +94,8 @@ it('finds the Conda installation with PATH', function () {
     });
 
     mockery.registerMock('fs', {
-        existsSync: existsSync,
-        statSync: statSync
+        existsSync,
+        statSync
     });
 
     mockTask.setAnswers({
@@ -109,7 +109,7 @@ it('finds the Conda installation with PATH', function () {
     getVariable.withArgs('Agent.ToolsDirectory').returns('path-to-tools');
 
     mockery.registerMock('vsts-task-lib/task', Object.assign({}, mockTask, {
-        getVariable: getVariable
+        getVariable
     }));
 
     const uut = reload('../conda_internal');
@@ -184,12 +184,12 @@ it('creates Conda environment', async function () {
 it('activates Conda environment', function () {
     const setVariable = sinon.spy();
     mockery.registerMock('vsts-task-lib/task', Object.assign({}, mockTask, {
-        setVariable: setVariable
+        setVariable
     }));
 
     const prependPathSafe = sinon.spy();
     mockery.registerMock('./toolutil', {
-        prependPathSafe: prependPathSafe
+        prependPathSafe
     });
 
     const uut = reload('../conda_internal');
@@ -242,7 +242,7 @@ it('adds base environment to path successfully', function () {
 
     const prependPathSafe = sinon.spy();
     mockery.registerMock('./toolutil', {
-        prependPathSafe: prependPathSafe
+        prependPathSafe
     });
 
     const uut = reload('../conda_internal');

--- a/Tasks/CondaEnvironmentV1/Tests/L0_conda_internal.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0_conda_internal.ts
@@ -31,7 +31,7 @@ afterEach(function () {
     mockery.resetCache();
 });
 
-it('finds the Conda installation with the CONDA variable', async function () {
+it('finds the Conda installation with the CONDA variable', function () {
     const existsSync = sinon.stub();
     const statSync = sinon.stub();
 
@@ -87,7 +87,7 @@ it('finds the Conda installation with the CONDA variable', async function () {
     }
 });
 
-it('finds the Conda installation with PATH', async function () {
+it('finds the Conda installation with PATH', function () {
     const existsSync = sinon.stub().returns(true);
     const statSync = sinon.stub().returns({
         isFile: () => true
@@ -181,7 +181,7 @@ it('creates Conda environment', async function () {
     }
 });
 
-it('activates Conda environment', async function () {
+it('activates Conda environment', function () {
     const setVariable = sinon.spy();
     mockery.registerMock('vsts-task-lib/task', Object.assign({}, mockTask, {
         setVariable: setVariable

--- a/Tasks/UsePythonVersionV0/Tests/L0_usepythonversion.ts
+++ b/Tasks/UsePythonVersionV0/Tests/L0_usepythonversion.ts
@@ -76,12 +76,12 @@ it('sets PATH correctly on Linux', async function () {
 
     const findLocalTool = sinon.stub().returns('findLocalTool');
     mockery.registerMock('vsts-task-tool-lib/tool', {
-        findLocalTool: findLocalTool
+        findLocalTool
     });
 
     const prependPathSafe = sinon.spy();
     mockery.registerMock('./toolutil', {
-        prependPathSafe: prependPathSafe
+        prependPathSafe
     });
 
     const uut = reload();
@@ -105,12 +105,12 @@ it('sets PATH correctly on Windows', async function () {
     const toolPath = path.join('/', 'Python', '3.6.4', 'x64');
     const findLocalTool = sinon.stub().returns(toolPath);
     mockery.registerMock('vsts-task-tool-lib/tool', {
-        findLocalTool: findLocalTool
+        findLocalTool
     });
 
     const prependPathSafe = sinon.spy();
     mockery.registerMock('./toolutil', {
-        prependPathSafe: prependPathSafe
+        prependPathSafe
     });
 
     process.env['APPDATA'] = '/mock-appdata'; // needed for running this test on Linux and macOS


### PR DESCRIPTION
Follow-up from #8402 
- Remove unnecessary `async`
- Use object initializer sugar for mocks
- Remove unused imports

**Testing**
* L0 (note that this is only test code being changed)