### PR TITLE
Fix Conda Environment on Hosted Linux Preview

### DIFF
--- a/Tasks/CondaEnvironmentV1/Tests/L0.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0.ts
@@ -23,7 +23,7 @@ describe('CondaEnvironment L0 Suite', function () {
         if (getPlatform() === Platform.Windows) {
             assert(testRunner.ran('conda create --quiet --prefix \\miniconda\\envs\\test --mkdir --yes'));
         } else {
-            assert(testRunner.ran('sudo conda create --quiet --prefix /miniconda/envs/test --mkdir --yes'));
+            assert(testRunner.ran('sudo /miniconda/bin/conda create --quiet --prefix /miniconda/envs/test --mkdir --yes'));
         }
 
         assert.strictEqual(testRunner.stderr.length, 0, 'should not have written to stderr');
@@ -39,7 +39,7 @@ describe('CondaEnvironment L0 Suite', function () {
         if (getPlatform() === Platform.Windows) {
             assert(testRunner.ran('conda install python=3 --quiet --yes --json'));
         } else {
-            assert(testRunner.ran('sudo conda install python=3 --quiet --yes --json'));
+            assert(testRunner.ran('sudo /miniconda/bin/conda install python=3 --quiet --yes --json'));
         }
 
         assert.strictEqual(testRunner.stderr.length, 0, 'should not have written to stderr');

--- a/Tasks/CondaEnvironmentV1/Tests/L0BaseEnvironment.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0BaseEnvironment.ts
@@ -14,7 +14,7 @@ taskRunner.setAnswers({
         'conda': '/miniconda/bin/conda'
     },
     exec: {
-        'sudo conda install python=3 --quiet --yes --json': {
+        'sudo /miniconda/bin/conda install python=3 --quiet --yes --json': {
             code: 0
         },
         'conda install python=3 --quiet --yes --json': {
@@ -29,6 +29,9 @@ taskRunner.setAnswers({
         '/miniconda/bin/conda': true
     }
 });
+
+// `getVariable` is not supported by `TaskLibAnswers`
+process.env['AGENT_TEMPDIRECTORY'] = path.join('/', 'tmp');
 
 // Mock vsts-task-tool-lib
 taskRunner.registerMock('vsts-task-tool-lib/tool', {

--- a/Tasks/CondaEnvironmentV1/Tests/L0BaseEnvironment.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0BaseEnvironment.ts
@@ -30,9 +30,6 @@ taskRunner.setAnswers({
     }
 });
 
-// `getVariable` is not supported by `TaskLibAnswers`
-process.env['AGENT_TEMPDIRECTORY'] = path.join('/', 'tmp');
-
 // Mock vsts-task-tool-lib
 taskRunner.registerMock('vsts-task-tool-lib/tool', {
     prependPath: () => undefined,

--- a/Tasks/CondaEnvironmentV1/Tests/L0CreateEnvironment.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0CreateEnvironment.ts
@@ -25,9 +25,6 @@ taskRunner.setAnswers({
     }
 });
 
-// `getVariable` is not supported by `TaskLibAnswers`
-process.env['AGENT_TEMPDIRECTORY'] = path.join('/', 'tmp');
-
 // Mock vsts-task-tool-lib
 taskRunner.registerMock('vsts-task-tool-lib/tool', {
     prependPath: () => undefined,

--- a/Tasks/CondaEnvironmentV1/Tests/L0CreateEnvironment.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0CreateEnvironment.ts
@@ -16,7 +16,7 @@ taskRunner.setAnswers({
         'conda': '/miniconda/bin/conda'
     },
     exec: {
-        'sudo conda create --quiet --prefix /miniconda/envs/test --mkdir --yes': {
+        'sudo /miniconda/bin/conda create --quiet --prefix /miniconda/envs/test --mkdir --yes': {
             code: 0
         },
         'conda create --quiet --prefix \\miniconda\\envs\\test --mkdir --yes': {
@@ -24,6 +24,9 @@ taskRunner.setAnswers({
         },
     }
 });
+
+// `getVariable` is not supported by `TaskLibAnswers`
+process.env['AGENT_TEMPDIRECTORY'] = path.join('/', 'tmp');
 
 // Mock vsts-task-tool-lib
 taskRunner.registerMock('vsts-task-tool-lib/tool', {

--- a/Tasks/CondaEnvironmentV1/Tests/L0_conda_internal.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0_conda_internal.ts
@@ -120,6 +120,12 @@ it('finds the Conda installation with PATH', function () {
 });
 
 it('creates Conda environment', async function () {
+    mockTask.setAnswers({
+        which: {
+            'conda': '/miniconda/bin/conda'
+        }
+    });
+
     mockery.registerMock('vsts-task-lib/task', mockTask);
     mockery.registerMock('vsts-task-lib/toolrunner', mockToolRunner);
     const uut = reload('../conda_internal');
@@ -138,7 +144,7 @@ it('creates Conda environment', async function () {
             } else {
                 mockToolRunner.setAnswers({
                     exec: {
-                        [`sudo conda create --quiet --prefix ${path.join('envsDir', 'env')} --mkdir --yes`]: {
+                        [`sudo /miniconda/bin/conda create --quiet --prefix ${path.join('envsDir', 'env')} --mkdir --yes`]: {
                             code: 0
                         }
                     }
@@ -159,7 +165,7 @@ it('creates Conda environment', async function () {
             } else {
                 mockToolRunner.setAnswers({
                     exec: {
-                        [`sudo conda create --quiet --prefix ${path.join('envsDir', 'env')} --mkdir --yes`]: {
+                        [`sudo /miniconda/bin/conda create --quiet --prefix ${path.join('envsDir', 'env')} --mkdir --yes`]: {
                             code: 1
                         }
                     }

--- a/Tasks/CondaEnvironmentV1/conda_internal.ts
+++ b/Tasks/CondaEnvironmentV1/conda_internal.ts
@@ -40,10 +40,10 @@ function binaryDir(environmentRoot: string, platform: Platform): string {
  * Precondition: `toolName` executable is in PATH
  */
 function sudo(toolName: string, platform: Platform): ToolRunner {
-    const toolPath = task.which(toolName);
     if (platform === Platform.Windows) {
-        return task.tool(toolPath);
+        return task.tool(toolName);
     } else {
+        const toolPath = task.which(toolName);
         return task.tool('sudo').line(toolPath);
     }
 }

--- a/Tasks/CondaEnvironmentV1/conda_internal.ts
+++ b/Tasks/CondaEnvironmentV1/conda_internal.ts
@@ -35,11 +35,16 @@ function binaryDir(environmentRoot: string, platform: Platform): string {
     }
 }
 
-function sudo(toolPath: string, platform: Platform): ToolRunner {
+/**
+ * Run a tool with `sudo` on Linux and macOS
+ * Precondition: `toolName` executable is in PATH
+ */
+function sudo(toolName: string, platform: Platform): ToolRunner {
+    const toolPath = task.which(toolName);
     if (platform === Platform.Windows) {
-        return task.tool('conda');
+        return task.tool(toolPath);
     } else {
-        return task.tool('sudo').line('conda');
+        return task.tool('sudo').line(toolPath);
     }
 }
 

--- a/Tasks/CondaEnvironmentV1/task.json
+++ b/Tasks/CondaEnvironmentV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 140,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "instanceNameFormat": "Conda environment $(environmentName)",

--- a/Tasks/CondaEnvironmentV1/task.loc.json
+++ b/Tasks/CondaEnvironmentV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 140,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
On Hosted Linux Preview, `conda` is not in PATH for user or root, so the full PATH must be given when calling `sudo`.  This is because Hosted Linux Preview uses the CONDA environment variable that the task supports.

**Testing**
* L0
* Canary builds on
  - Hosted VS2017
  - Hosted macOS
  - Hosted Ubuntu 16.04
  - Hosted Linux Preview