### PR TITLE
Fix packer task test dependency issue between versions V0 and V1

### DIFF
--- a/Tasks/PackerBuildV0/Tests/L0.ts
+++ b/Tasks/PackerBuildV0/Tests/L0.ts
@@ -20,7 +20,7 @@ describe('PackerBuild Suite', function() {
     before((done) => {
 
         delete process.env["__build_output__"] ;
-        delete  process.env["__copy_fails__"] ;
+        delete process.env["__copy_fails__"] ;
         delete process.env["__deploy_package_found__"] ;
         delete process.env["__dest_path_exists__"] ;
         delete process.env["__download_fails__"] ;

--- a/Tasks/PackerBuildV0/Tests/L0.ts
+++ b/Tasks/PackerBuildV0/Tests/L0.ts
@@ -18,6 +18,23 @@ function runValidations(validator: () => void, tr, done) {
 describe('PackerBuild Suite', function() {
     this.timeout(30000);
     before((done) => {
+
+        delete process.env["__build_output__"] ;
+        delete  process.env["__copy_fails__"] ;
+        delete process.env["__deploy_package_found__"] ;
+        delete process.env["__dest_path_exists__"] ;
+        delete process.env["__download_fails__"] ;
+        delete process.env["__extract_fails__"] ;
+        delete process.env["__lower_version__"] ;
+        delete process.env["__no_output_vars__"] ;
+        delete process.env["__ostype__"] ;
+        delete process.env["__packer_build_fails__"] ;
+        delete process.env["__packer_build_no_output__"] ;
+        delete process.env["__packer_exists__"] ;
+        delete process.env["__packer_fix_fails__"] ;
+        delete process.env["__packer_validate_fails__"] ;
+        delete process.env["__spnObjectId_not_exists__"] ;
+
         done();
     });
     after(function () {

--- a/Tasks/PackerBuildV1/Tests/L0.ts
+++ b/Tasks/PackerBuildV1/Tests/L0.ts
@@ -15,9 +15,26 @@ function runValidations(validator: () => void, tr, done) {
     }
 }
 
-describe('PackerBuild Suite', function() {
+describe('PackerBuild Suite V1', function() {
     this.timeout(30000);
     before((done) => {
+
+        delete process.env["__build_output__"] ;
+        delete  process.env["__copy_fails__"] ;
+        delete process.env["__deploy_package_found__"] ;
+        delete process.env["__dest_path_exists__"] ;
+        delete process.env["__download_fails__"] ;
+        delete process.env["__extract_fails__"] ;
+        delete process.env["__lower_version__"] ;
+        delete process.env["__no_output_vars__"] ;
+        delete process.env["__ostype__"] ;
+        delete process.env["__packer_build_fails__"] ;
+        delete process.env["__packer_build_no_output__"] ;
+        delete process.env["__packer_exists__"] ;
+        delete process.env["__packer_fix_fails__"] ;
+        delete process.env["__packer_validate_fails__"] ;
+        delete process.env["__spnObjectId_not_exists__"] ;
+
         done();
     });
     after(function () {

--- a/Tasks/PackerBuildV1/Tests/L0.ts
+++ b/Tasks/PackerBuildV1/Tests/L0.ts
@@ -20,7 +20,7 @@ describe('PackerBuild Suite V1', function() {
     before((done) => {
 
         delete process.env["__build_output__"] ;
-        delete  process.env["__copy_fails__"] ;
+        delete process.env["__copy_fails__"] ;
         delete process.env["__deploy_package_found__"] ;
         delete process.env["__dest_path_exists__"] ;
         delete process.env["__download_fails__"] ;


### PR DESCRIPTION
Currently if you execute PackerBuildV0 task and PackerBuildV1 task tests individually they pass, however if you run them together, which ever gets executed first is successful and the second one fails. This is due to new environment variables set after the execution of the first test.  

The following additional environment variables are set by the test (V0 or V1) which ever executes first :

```
__build_output__: 'Executed Successfully\nOSDiskUri:   https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\rStorageAccountLocation: SouthIndia\r some random string\n',
  __copy_fails__: 'false',
  __deploy_package_found__: 'null',
  __dest_path_exists__: 'true',
  __download_fails__: 'false',
  __extract_fails__: 'false',
  __lower_version__: 'false',
  __no_output_vars__: 'false',
  __ostype__: 'windows',
  __packer_build_fails__: 'false',
  __packer_build_no_output__: 'false',
  __packer_exists__: 'false',
  __packer_fix_fails__: 'false',
  __packer_validate_fails__: 'false',
  __spnObjectId_not_exists__: 'false'
```

Changes in this PR unset these environment variables at the beginning of tests for Packer tasks V0 and V1. @bishal-pdMSFT / @sachinma  request you to please review