### PR TITLE
increase timeout for App Center Distribute tests

### DIFF
--- a/Tasks/AppCenterDistributeV1/Tests/L0.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0.ts
@@ -25,172 +25,144 @@ describe('AppCenterDistribute L0 Suite', function () {
         delete process.env['LASTCOMMITMESSAGE'];
     });
 
-    it('Positive path: upload one ipa file', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: upload one ipa file', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0OneIpaPass.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 
-    it('Negative path: can not upload multiple files', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Negative path: can not upload multiple files', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0MultipleIpaFail.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.failed, 'task should have failed');
-
-        done();
     });
 
-    it('Negative path: cannot continue upload without symbols', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Negative path: cannot continue upload without symbols', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0NoSymbolsFails.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.failed, 'task should have failed');
-
-        done();
     });
 
-    it('Postiive path: can continue upload without symbols if variable VSMobileCenterUpload.ContinueIfSymbolsNotFound is true', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Postiive path: can continue upload without symbols if variable VSMobileCenterUpload.ContinueIfSymbolsNotFound is true', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0NoSymbolsConditionallyPass.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 
-    it('Negative path: mobile center api rejects fail the task', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Negative path: mobile center api rejects fail the task', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0ApiRejectsFail.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.failed, 'task should have failed');
-
-        done();
     });
 
-    it('Positive path: single file with Include Parent', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: single file with Include Parent', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymIncludeParent.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 
-    it('Positive path: multiple dSYMs in the same foder', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: multiple dSYMs in the same foder', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymMultipleDSYMs_flat_1.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 
-    it('Positive path: multiple dSYMs in parallel foders', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: multiple dSYMs in parallel foders', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymMultipleDSYMs_flat_2.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 
-    it('Positive path: multiple dSYMs in a tree', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: multiple dSYMs in a tree', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymMultipleDSYMs_tree.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 
-    it('Positive path: a single dSYM', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: a single dSYM', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymMultipleDSYMs_single.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 
-    it('Positive path: a single PDB', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: a single PDB', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymPDBs_single.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 
 
-    it('Positive path: multiple PDBs', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: multiple PDBs', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymPDBs_multiple.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 
-    it('Positive path: publish commit info (including commit message)', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: publish commit info (including commit message)', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0PublishCommitInfo_1.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
    
-    it('Positive path: publish commit info (excluding commit message)', (done: MochaDone) => {
-        this.timeout(2000);
+    it('Positive path: publish commit info (excluding commit message)', function () {
+        this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0PublishCommitInfo_2.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 });


### PR DESCRIPTION
Like App Center Test, these tests starting flaking on Hosted Ubuntu.  increasing the timeout to see if that fixes the issue.