### PR TITLE
added trailing / for compatibility with uri function

### DIFF
--- a/Tasks/AzureFileCopyV2/AzureFileCopy.ps1
+++ b/Tasks/AzureFileCopyV2/AzureFileCopy.ps1
@@ -183,7 +183,7 @@ if ($destination -eq "AzureBlob")
     # Get URI and SaSToken for output if needed
     if(-not [string]::IsNullOrEmpty($outputStorageURI))
     {
-        $storageAccountContainerURI = $storageContext.BlobEndPoint + $containerName
+        $storageAccountContainerURI = $storageContext.BlobEndPoint + $containerName + "/"
         Write-Host "##vso[task.setvariable variable=$outputStorageURI;]$storageAccountContainerURI"
     }
     if(-not [string]::IsNullOrEmpty($outputStorageContainerSASToken))


### PR DESCRIPTION
when working with uri's, System.Uri changes behavior when a trailing slash on a non-root path is omitted - it will remove the path leaving only the root.  This means it is not possible to build a uri with the path that is currently returned by the task without manually inserting the trailing slash... essentially the task returns the root when consumed by system.uri.  Adding the trailing slash preserves the path when building the uri.