### PR TITLE
Make CondaEnvironment more YAML-friendly

### DIFF
--- a/Tasks/CondaEnvironmentV1/Tests/L0.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0.ts
@@ -31,7 +31,7 @@ describe('CondaEnvironment L0 Suite', function () {
     });
 
     it('succeeds when creating and activating an environment with a YAML definition', function () {
-        const testFile = path.join(__dirname, 'L0CreateEnvironmentYAML.js');
+        const testFile = path.join(__dirname, 'L0CreateEnvironmentYaml.js');
         const testRunner = new MockTestRunner(testFile);
 
         testRunner.run();

--- a/Tasks/CondaEnvironmentV1/Tests/L0.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0.ts
@@ -14,8 +14,24 @@ describe('CondaEnvironment L0 Suite', function () {
         require('./L0_conda_internal');
     });
 
-    it('succeeds when creating and activating an environment', function () {
-        const testFile = path.join(__dirname, 'L0CreateEnvironment.js');
+    it('succeeds when creating and activating an environment with a designer definition', function () {
+        const testFile = path.join(__dirname, 'L0CreateEnvironmentDesigner.js');
+        const testRunner = new MockTestRunner(testFile);
+
+        testRunner.run();
+
+        if (getPlatform() === Platform.Windows) {
+            assert(testRunner.ran('conda create --quiet --prefix \\miniconda\\envs\\test --mkdir --yes'));
+        } else {
+            assert(testRunner.ran('sudo /miniconda/bin/conda create --quiet --prefix /miniconda/envs/test --mkdir --yes'));
+        }
+
+        assert.strictEqual(testRunner.stderr.length, 0, 'should not have written to stderr');
+        assert(testRunner.succeeded, 'task should have succeeded');
+    });
+
+    it('succeeds when creating and activating an environment with a YAML definition', function () {
+        const testFile = path.join(__dirname, 'L0CreateEnvironmentYAML.js');
         const testRunner = new MockTestRunner(testFile);
 
         testRunner.run();

--- a/Tasks/CondaEnvironmentV1/Tests/L0CreateEnvironmentDesigner.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0CreateEnvironmentDesigner.ts
@@ -7,6 +7,7 @@ import { TaskMockRunner } from 'vsts-task-lib/mock-run';
 const taskPath = path.join(__dirname, '..', 'main.js');
 const taskRunner = new TaskMockRunner(taskPath);
 
+// Designer uses the `createCustomEnvironment` checkbox to show/hide `environmentName`
 taskRunner.setInput('createCustomEnvironment', 'true');
 taskRunner.setInput('environmentName', 'test');
 

--- a/Tasks/CondaEnvironmentV1/Tests/L0CreateEnvironmentYaml.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0CreateEnvironmentYaml.ts
@@ -1,0 +1,37 @@
+import * as path from 'path';
+
+import * as mockery from 'mockery';
+
+import { TaskMockRunner } from 'vsts-task-lib/mock-run';
+
+const taskPath = path.join(__dirname, '..', 'main.js');
+const taskRunner = new TaskMockRunner(taskPath);
+
+taskRunner.setInput('environmentName', 'test');
+
+// Mock vsts-task-lib
+taskRunner.setAnswers({
+    which: {
+        'conda': '/miniconda/bin/conda'
+    },
+    exec: {
+        'sudo /miniconda/bin/conda create --quiet --prefix /miniconda/envs/test --mkdir --yes': {
+            code: 0
+        },
+        'conda create --quiet --prefix \\miniconda\\envs\\test --mkdir --yes': {
+            code: 0
+        },
+    }
+});
+
+// Mock vsts-task-tool-lib
+taskRunner.registerMock('vsts-task-tool-lib/tool', {
+    prependPath: () => undefined,
+});
+
+// Mock other dependencies
+mockery.registerMock('fs', {
+    existsSync: () => false
+});
+
+taskRunner.run();

--- a/Tasks/CondaEnvironmentV1/Tests/L0_conda.ts
+++ b/Tasks/CondaEnvironmentV1/Tests/L0_conda.ts
@@ -51,7 +51,6 @@ it('creates and activates environment', async function () {
 
     const uut = reload('../conda');
     const parameters = {
-        createCustomEnvironment: true,
         environmentName: 'env',
         updateConda: false
     };
@@ -62,36 +61,6 @@ it('creates and activates environment', async function () {
     assert(createEnvironment.calledOnceWithExactly(path.join('path-to-conda', 'envs', 'env'), Platform.Linux, undefined, undefined));
     assert(activateEnvironment.calledOnceWithExactly(path.join('path-to-conda', 'envs'), 'env', Platform.Linux));
 });
-
-it('requires `createCustomEnvironment` to be set to create a custom environment', async function () {
-    mockery.registerMock('fs', {
-        existsSync: () => false
-    });
-
-    mockery.registerMock('vsts-task-lib/task', mockTask);
-
-    const findConda = sinon.stub().returns('path-to-conda');
-    const prependCondaToPath = sinon.spy();
-    const createEnvironment = sinon.spy();
-    const activateEnvironment = sinon.spy();
-    mockery.registerMock('./conda_internal', {
-        findConda,
-        prependCondaToPath,
-        createEnvironment,
-        activateEnvironment
-    });
-
-    const uut = reload('../conda');
-    const parameters = {
-        environmentName: 'env',
-        updateConda: false
-    };
-
-    await uut.condaEnvironment(parameters, Platform.Linux);
-    assert(createEnvironment.notCalled);
-    assert(activateEnvironment.notCalled);
-});
-
 
 it('updates Conda if the user requests it', async function () {
     mockery.registerMock('fs', {

--- a/Tasks/CondaEnvironmentV1/conda.ts
+++ b/Tasks/CondaEnvironmentV1/conda.ts
@@ -41,7 +41,9 @@ export async function condaEnvironment(parameters: Readonly<TaskParameters>, pla
         await internal.updateConda(condaRoot, platform);
     }
 
-    if (parameters.createCustomEnvironment) { // activate the environment, creating it if it does not exist
+    // In Designer `environmentName` is conditionally visible based on `createCustomEnvironment`
+    // In YAML there is no need for `createCustomEnvironment`
+    if (parameters.createCustomEnvironment || parameters.environmentName) { // activate the environment, creating it if it does not exist
         const environmentName = assertParameter(parameters.environmentName, 'environmentName');
 
         const environmentsDir = path.join(condaRoot, 'envs');

--- a/Tasks/CondaEnvironmentV1/task.json
+++ b/Tasks/CondaEnvironmentV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 140,
-        "Patch": 3
+        "Minor": 142,
+        "Patch": 0
     },
     "demands": [],
     "instanceNameFormat": "Conda environment $(environmentName)",

--- a/Tasks/CondaEnvironmentV1/task.loc.json
+++ b/Tasks/CondaEnvironmentV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 140,
-    "Patch": 2
+    "Minor": 142,
+    "Patch": 0
   },
   "demands": [],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
Ref: https://github.com/Microsoft/vsts-tasks/issues/8299#issuecomment-422534904

In Designer, the "Environment name" parameter gets conditionally hidden based on a checkbox:

![image](https://user-images.githubusercontent.com/33549821/46625851-77336f00-cb03-11e8-822a-f4435cfb62ed.png)

![image](https://user-images.githubusercontent.com/33549821/46625868-81ee0400-cb03-11e8-889d-ee9238a27a53.png)

The checkbox parameter should not be required in YAML because it is just redundant.  Originally I had required it for the upgrade scenario: going from V0, where environment name is required, to V1, an environment would start getting created and it would not be clear why since it is hidden in designer.

That still applies for this change: someone who upgraded from V0 to V1 and then takes this update will start getting the environment created again.  But this is easily fixed, and all tasks need to be YAML-friendly now.

**Testing**
* L0
* Manually tested Designer
* Tested the following matrix on all 3 OSes + Hosted Linux Preview:
    * YAML that specifies only environmentName creates the environment
    * YAML that specifes createCustomEnvironment and environmentName creates the environment
    * YAML that specifies neither createCustomEnvironment nor environmentName installs to the base environment
    * YAML that specifies createCustomEnvironment but not environmentName fails
