### PR TITLE
Deprecate Conda Environment V0

### DIFF
--- a/Tasks/CondaEnvironmentV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CondaEnvironmentV0/Strings/resources.resjson/en-US/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Conda Environment",
   "loc.helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?linkid=873466)",
-  "loc.description": "Create and activate a Conda environment.",
+  "loc.description": "Major version 0 of this task has been deprecated and is no longer supported on Microsoft-hosted agents. Please update to a newer version.",
   "loc.instanceNameFormat": "Conda Environment $(environmentName)",
   "loc.group.displayName.advanced": "Advanced",
   "loc.input.label.environmentName": "Environment name",

--- a/Tasks/CondaEnvironmentV0/task.json
+++ b/Tasks/CondaEnvironmentV0/task.json
@@ -2,7 +2,7 @@
     "id": "03DD16C3-43E0-4667-BA84-40515D27A410",
     "name": "CondaEnvironment",
     "friendlyName": "Conda Environment",
-    "description": "Create and activate a Conda environment.",
+    "description": "Major version 0 of this task has been deprecated and is no longer supported on Microsoft-hosted agents. Please update to a newer version.",
     "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?linkid=873466)",
     "category": "Package",
     "runsOn": [
@@ -12,9 +12,10 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 139,
-        "Patch": 1
+        "Minor": 142,
+        "Patch": 0
     },
+    "deprecated": true,
     "demands": [],
     "instanceNameFormat": "Conda Environment $(environmentName)",
     "groups": [

--- a/Tasks/CondaEnvironmentV0/task.loc.json
+++ b/Tasks/CondaEnvironmentV0/task.loc.json
@@ -12,9 +12,10 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 139,
+    "Minor": 142,
     "Patch": 0
   },
+  "deprecated": true,
   "demands": [],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [


### PR DESCRIPTION
We had to react to some changes with the hosted agents with this task.  We're not going to service V0 with the fixes, so I'm marking it as deprecated.

We bumped to v1 when we stopped requiring a conda environment to be created so you can just install packages globally on hosted agents.  It wasn't a breaking change.