### PR TITLE
Updated CUrlUploader Task description

### DIFF
--- a/Tasks/CUrlUploaderV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CUrlUploaderV2/Strings/resources.resjson/en-US/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "cURL Upload Files",
   "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=627418)",
-  "loc.description": "Use cURL to upload files with FTP, FTPS, SFTP, HTTP, and more.",
+  "loc.description": "Use cURL to upload files.",
   "loc.instanceNameFormat": "Upload $(files) with cURL",
   "loc.group.displayName.advanced": "Advanced",
   "loc.input.label.files": "Files",

--- a/Tasks/CUrlUploaderV2/task.json
+++ b/Tasks/CUrlUploaderV2/task.json
@@ -2,14 +2,14 @@
     "id": "AD8974D8-DE11-11E4-B2FE-7FB898A745F3",
     "name": "cURLUploader",
     "friendlyName": "cURL Upload Files",
-    "description": "Use cURL to upload files with FTP, FTPS, SFTP, HTTP, and more.",
+    "description": "Use cURL to upload files.",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=627418)",
     "category": "Utility",
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
         "Minor": 142,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent",

--- a/Tasks/CUrlUploaderV2/task.loc.json
+++ b/Tasks/CUrlUploaderV2/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 2,
     "Minor": 142,
-    "Patch": 0
+    "Patch": 2
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
The cURL uploader task does not package itself with its own version of cURL, so the description should not specify support of any specific protocols.

See related issue: #8443 