### PR TITLE
Update XcodeV5 description

### DIFF
--- a/Tasks/XcodeV5/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/XcodeV5/Strings/resources.resjson/en-US/resources.resjson
@@ -9,7 +9,7 @@
   "loc.group.displayName.devices": "Devices & simulators",
   "loc.group.displayName.advanced": "Advanced",
   "loc.input.label.actions": "Actions",
-  "loc.input.help.actions": "Enter a space-delimited list of actions. Valid options are `build`, `clean`, `test`, `analyze`, and `archive`. For example,`clean build` will run a clean build. See the [xcodebuild man page](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/xcodebuild.1.html).",
+  "loc.input.help.actions": "Enter a space-delimited list of actions. Valid options are `build`, `clean`, `test`, `analyze`, and `archive`. For example,`clean build` will run a clean build.",
   "loc.input.label.configuration": "Configuration",
   "loc.input.help.configuration": "Enter the Xcode project or workspace configuration to be built. The default value of this field is the variable `$(Configuration)`. When using a variable, make sure to specify a value (for example, `Release`) on the **Variables** tab.",
   "loc.input.label.sdk": "SDK",

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -11,8 +11,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 5,
-        "Minor": 141,
-        "Patch": 2
+        "Minor": 142,
+        "Patch": 0
     },
     "releaseNotes": "This version of the task is compatible with Xcode 8, Xcode 9 and Xcode 10. Features that were there solely to maintain compat with Xcode 7 have been removed. The task has better options to work with the Hosted macOS pool.",
     "demands": [
@@ -48,7 +48,7 @@
             "label": "Actions",
             "defaultValue": "build",
             "required": true,
-            "helpMarkDown": "Enter a space-delimited list of actions. Valid options are `build`, `clean`, `test`, `analyze`, and `archive`. For example,`clean build` will run a clean build. See the [xcodebuild man page](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/xcodebuild.1.html)."
+            "helpMarkDown": "Enter a space-delimited list of actions. Valid options are `build`, `clean`, `test`, `analyze`, and `archive`. For example,`clean build` will run a clean build."
         },
         {
             "name": "configuration",

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 141,
+    "Minor": 142,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
Removed link to man pages as the URL was invalid and we can't rely on always updating when the URL moves.

