### PR TITLE
Make "tool not found" messages more descriptive

### DIFF
--- a/Tasks/UsePythonVersionV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UsePythonVersionV0/Strings/resources.resjson/en-US/resources.resjson
@@ -13,7 +13,7 @@
   "loc.messages.ListAvailableVersions": "Versions in %s:",
   "loc.messages.PlatformNotRecognized": "Platform not recognized",
   "loc.messages.PrependPath": "Prepending PATH environment variable with directory: %s",
-  "loc.messages.ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s.",
+  "loc.messages.ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s at %s.",
   "loc.messages.ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
-  "loc.messages.VersionNotFound": "Version spec %s for architecture %s did not match any version in $(Agent.ToolsDirectory)."
+  "loc.messages.VersionNotFound": "Version spec %s for architecture %s did not match any version in Agent.ToolsDirectory."
 }

--- a/Tasks/UsePythonVersionV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UsePythonVersionV0/Strings/resources.resjson/en-US/resources.resjson
@@ -10,8 +10,10 @@
   "loc.input.help.addToPath": "Whether to prepend the retrieved Python version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable.",
   "loc.input.label.architecture": "Architecture",
   "loc.input.help.architecture": "The target architecture (x86, x64) of the Python interpreter.",
-  "loc.messages.ListAvailableVersions": "Available versions:",
+  "loc.messages.ListAvailableVersions": "Versions in %s:",
   "loc.messages.PlatformNotRecognized": "Platform not recognized",
   "loc.messages.PrependPath": "Prepending PATH environment variable with directory: %s",
-  "loc.messages.VersionNotFound": "Version spec %s for architecture %s did not match any version in the tool cache."
+  "loc.messages.ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s.",
+  "loc.messages.ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
+  "loc.messages.VersionNotFound": "Version spec %s for architecture %s did not match any version in $(Agent.ToolsDirectory)."
 }

--- a/Tasks/UsePythonVersionV0/Tests/L0.ts
+++ b/Tasks/UsePythonVersionV0/Tests/L0.ts
@@ -32,11 +32,13 @@ describe('UsePythonVersion L0 Suite', function () {
 
         const errorMessage = [
             'loc_mock_VersionNotFound 3.x x64',
-            'loc_mock_ListAvailableVersions',
+            'loc_mock_ListAvailableVersions $(Agent.ToolsDirectory)',
             '2.6.0 (x86)',
             '2.7.13 (x86)',
             '2.6.0 (x64)',
-            '2.7.13 (x64)'
+            '2.7.13 (x64)',
+            'loc_mock_ToolNotFoundMicrosoftHosted Python',
+            'loc_mock_ToolNotFoundSelfHosted Python https://go.microsoft.com/fwlink/?linkid=871498',
         ].join(EOL);
 
         assert(testRunner.createdErrorIssue(errorMessage));

--- a/Tasks/UsePythonVersionV0/Tests/L0.ts
+++ b/Tasks/UsePythonVersionV0/Tests/L0.ts
@@ -37,7 +37,7 @@ describe('UsePythonVersion L0 Suite', function () {
             '2.7.13 (x86)',
             '2.6.0 (x64)',
             '2.7.13 (x64)',
-            'loc_mock_ToolNotFoundMicrosoftHosted Python',
+            'loc_mock_ToolNotFoundMicrosoftHosted Python https://aka.ms/hosted-agent-software',
             'loc_mock_ToolNotFoundSelfHosted Python https://go.microsoft.com/fwlink/?linkid=871498',
         ].join(EOL);
 

--- a/Tasks/UsePythonVersionV0/Tests/L0FailsWhenVersionIsMissing.ts
+++ b/Tasks/UsePythonVersionV0/Tests/L0FailsWhenVersionIsMissing.ts
@@ -9,6 +9,9 @@ taskRunner.setInput('versionSpec', '3.x');
 taskRunner.setInput('addToPath', 'false');
 taskRunner.setInput('architecture', 'x64');
 
+// `getVariable` is not supported by `TaskLibAnswers`
+process.env['AGENT_TOOLSDIRECTORY'] = '$(Agent.ToolsDirectory)';
+
 // Mock vsts-task-tool-lib
 taskRunner.registerMock('vsts-task-tool-lib/tool', {
     findLocalTool: () => null,

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -71,8 +71,8 @@
         "ListAvailableVersions": "Versions in %s:",
         "PlatformNotRecognized": "Platform not recognized",
         "PrependPath": "Prepending PATH environment variable with directory: %s",
-        "ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s.",
+        "ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s at %s.",
         "ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
-        "VersionNotFound": "Version spec %s for architecture %s did not match any version in $(Agent.ToolsDirectory)."
+        "VersionNotFound": "Version spec %s for architecture %s did not match any version in Agent.ToolsDirectory."
     }
 }

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 138,
-        "Patch": 2
+        "Minor": 142,
+        "Patch": 0
     },
     "demands": [],
     "instanceNameFormat": "Use Python $(versionSpec)",
@@ -68,9 +68,11 @@
         }
     },
     "messages": {
-        "ListAvailableVersions": "Available versions:",
+        "ListAvailableVersions": "Versions in %s:",
         "PlatformNotRecognized": "Platform not recognized",
         "PrependPath": "Prepending PATH environment variable with directory: %s",
-        "VersionNotFound": "Version spec %s for architecture %s did not match any version in the tool cache."
+        "ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s.",
+        "ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
+        "VersionNotFound": "Version spec %s for architecture %s did not match any version in $(Agent.ToolsDirectory)."
     }
 }

--- a/Tasks/UsePythonVersionV0/task.loc.json
+++ b/Tasks/UsePythonVersionV0/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 138,
-    "Patch": 1
+    "Minor": 142,
+    "Patch": 0
   },
   "demands": [],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -71,6 +71,8 @@
     "ListAvailableVersions": "ms-resource:loc.messages.ListAvailableVersions",
     "PlatformNotRecognized": "ms-resource:loc.messages.PlatformNotRecognized",
     "PrependPath": "ms-resource:loc.messages.PrependPath",
+    "ToolNotFoundMicrosoftHosted": "ms-resource:loc.messages.ToolNotFoundMicrosoftHosted",
+    "ToolNotFoundSelfHosted": "ms-resource:loc.messages.ToolNotFoundSelfHosted",
     "VersionNotFound": "ms-resource:loc.messages.VersionNotFound"
   }
 }

--- a/Tasks/UsePythonVersionV0/usepythonversion.ts
+++ b/Tasks/UsePythonVersionV0/usepythonversion.ts
@@ -43,7 +43,7 @@ export async function usePythonVersion(parameters: Readonly<TaskParameters>, pla
             task.loc('ListAvailableVersions', task.getVariable('Agent.ToolsDirectory')),
             x86Versions,
             x64Versions,
-            task.loc('ToolNotFoundMicrosoftHosted', 'Python'),
+            task.loc('ToolNotFoundMicrosoftHosted', 'Python', 'https://aka.ms/hosted-agent-software'),
             task.loc('ToolNotFoundSelfHosted', 'Python', 'https://go.microsoft.com/fwlink/?linkid=871498')
         ].join(os.EOL));
     }

--- a/Tasks/UsePythonVersionV0/usepythonversion.ts
+++ b/Tasks/UsePythonVersionV0/usepythonversion.ts
@@ -40,9 +40,11 @@ export async function usePythonVersion(parameters: Readonly<TaskParameters>, pla
 
         throw new Error([
             task.loc('VersionNotFound', parameters.versionSpec, parameters.architecture),
-            task.loc('ListAvailableVersions'),
+            task.loc('ListAvailableVersions', task.getVariable('Agent.ToolsDirectory')),
             x86Versions,
-            x64Versions
+            x64Versions,
+            task.loc('ToolNotFoundMicrosoftHosted', 'Python'),
+            task.loc('ToolNotFoundSelfHosted', 'Python', 'https://go.microsoft.com/fwlink/?linkid=871498')
         ].join(os.EOL));
     }
 

--- a/Tasks/UseRubyVersionV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UseRubyVersionV0/Strings/resources.resjson/en-US/resources.resjson
@@ -9,5 +9,7 @@
   "loc.input.help.addToPath": "Prepend the retrieved Ruby version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable.",
   "loc.messages.ListAvailableVersions": "Available versions:",
   "loc.messages.PlatformNotRecognized": "Platform not recognized",
-  "loc.messages.VersionNotFound": "Version spec %s did not match any version in the tool cache."
+  "loc.messages.ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s at %s.",
+  "loc.messages.ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
+  "loc.messages.VersionNotFound": "Version spec %s for architecture %s did not match any version in Agent.ToolsDirectory."
 }

--- a/Tasks/UseRubyVersionV0/Tests/L0.ts
+++ b/Tasks/UseRubyVersionV0/Tests/L0.ts
@@ -5,13 +5,13 @@ import * as ttm from 'vsts-task-lib/mock-test';
 describe('UseRubyVersion L0 Suite', function () {
 
     this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
-    before(() => {
+    before(function () {
     });
 
-    after(() => {
+    after(function () {
     });
 
-    it('finds version in cache in Linux', function (done: MochaDone) {
+    it('finds version in cache in Linux', function () {
         this.timeout(1000);
 
         let tp: string = path.join(__dirname, 'L0FindVersionInLinuxCache.js');
@@ -22,12 +22,10 @@ describe('UseRubyVersion L0 Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.includes("task.setvariable variable=rubyLocation"), 'variable was not set as expected');
         assert(tr.stdout.includes(path.join('/', 'Ruby', '2.5.4', 'bin')), 'ruby location is not set as expected');
-
-        done();
     });
 
 
-    it('rejects version not in cache', function (done: MochaDone) {
+    it('rejects version not in cache', function () {
         this.timeout(1000);
 
         let tp: string = path.join(__dirname, 'L0RejectVersionNotInCache.js');
@@ -37,13 +35,13 @@ describe('UseRubyVersion L0 Suite', function () {
 
         assert(tr.failed, 'task should have failed');
         assert(tr.stdout.includes('loc_mock_VersionNotFound 3.x'), 'error message not as expected');
-        assert(tr.stdout.includes('loc_mock_ListAvailableVersions'), 'list of available versions is not printed as expected');
+        assert(tr.stdout.includes('loc_mock_ListAvailableVersions $(Agent.ToolsDirectory)'), 'list of available versions is not printed as expected');
         assert(tr.stdout.includes('2.7.13'), 'list of available versions is not printed as expected');
-
-        done();
+        assert(tr.stdout.includes('loc_mock_ToolNotFoundMicrosoftHosted Ruby https://aka.ms/hosted-agent-software'));
+        assert(tr.stdout.includes('loc_mock_ToolNotFoundSelfHosted Ruby https://go.microsoft.com/fwlink/?linkid=2005989'));
     });
 
-    it('sets PATH correctly on Linux', function (done: MochaDone) {
+    it('sets PATH correctly on Linux', function () {
         this.timeout(1000);
 
         let tp: string = path.join(__dirname, 'L0SetPathOnLinux.js');
@@ -54,11 +52,11 @@ describe('UseRubyVersion L0 Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.includes("task.setvariable variable=rubyLocation"), 'variable was not set as expected');
         assert(tr.stdout.includes(path.join('/', 'Ruby', '2.4.4', 'bin')), 'ruby location is not set as expected');
+        assert(tr.stdout.includes(path.join('/', 'Ruby', '2.4.4', 'bin')), 'ruby location is not set as expected');
         assert(tr.stdout.includes('##vso[task.prependpath]' + path.join('/', 'Ruby', '2.4.4', 'bin')), 'ruby tool location was not added to PATH as expected');
-        done();
     });
 
-    it('sets PATH correctly on Windows', function (done: MochaDone) {
+    it('sets PATH correctly on Windows', function () {
         this.timeout(1000);
 
         let tp: string = path.join(__dirname, 'L0SetPathOnWindows.js');
@@ -70,6 +68,5 @@ describe('UseRubyVersion L0 Suite', function () {
         assert(tr.stdout.includes("task.setvariable variable=rubyLocation"), 'variable was not set as expected');
         assert(tr.stdout.includes(path.join('/', 'Ruby', '2.4.4', 'bin')), 'ruby location is not set as expected');
         assert(tr.stdout.includes('##vso[task.prependpath]' + path.join('/', 'Ruby', '2.4.4', 'bin')), 'ruby tool location was not added to PATH as expected');
-        done();
     });
 });

--- a/Tasks/UseRubyVersionV0/Tests/L0RejectVersionNotInCache.ts
+++ b/Tasks/UseRubyVersionV0/Tests/L0RejectVersionNotInCache.ts
@@ -9,6 +9,9 @@ let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 tr.setInput('versionSpec', '3.x');
 tr.setInput('addToPath', 'false');
 
+// `getVariable` is not supported by `TaskLibAnswers`
+process.env['AGENT_TOOLSDIRECTORY'] = '$(Agent.ToolsDirectory)';
+
 tr.registerMock('vsts-task-tool-lib/tool', {
     findLocalTool: () => null,
     findLocalToolVersions: () => ['2.7.13']

--- a/Tasks/UseRubyVersionV0/task.json
+++ b/Tasks/UseRubyVersionV0/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 140,
-        "Patch": 1
+        "Minor": 142,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.115.0",
@@ -51,6 +51,8 @@
     "messages": {
         "ListAvailableVersions": "Available versions:",
         "PlatformNotRecognized": "Platform not recognized",
-        "VersionNotFound": "Version spec %s did not match any version in the tool cache."
+        "ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s at %s.",
+        "ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
+        "VersionNotFound": "Version spec %s for architecture %s did not match any version in Agent.ToolsDirectory."
     }
 }

--- a/Tasks/UseRubyVersionV0/task.loc.json
+++ b/Tasks/UseRubyVersionV0/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 140,
+    "Minor": 142,
     "Patch": 0
   },
   "demands": [],
@@ -51,6 +51,8 @@
   "messages": {
     "ListAvailableVersions": "ms-resource:loc.messages.ListAvailableVersions",
     "PlatformNotRecognized": "ms-resource:loc.messages.PlatformNotRecognized",
+    "ToolNotFoundMicrosoftHosted": "ms-resource:loc.messages.ToolNotFoundMicrosoftHosted",
+    "ToolNotFoundSelfHosted": "ms-resource:loc.messages.ToolNotFoundSelfHosted",
     "VersionNotFound": "ms-resource:loc.messages.VersionNotFound"
   }
 }

--- a/Tasks/UseRubyVersionV0/userubyversion.ts
+++ b/Tasks/UseRubyVersionV0/userubyversion.ts
@@ -32,8 +32,10 @@ export async function useRubyVersion(parameters: TaskParameters, platform: Platf
         // Fail and list available versions
         throw new Error([
             task.loc('VersionNotFound', parameters.versionSpec),
-            task.loc('ListAvailableVersions'),
-            tool.findLocalToolVersions('Ruby')
+            task.loc('ListAvailableVersions', task.getVariable('Agent.ToolsDirectory')),
+            tool.findLocalToolVersions('Ruby'),
+            task.loc('ToolNotFoundMicrosoftHosted', 'Ruby', 'https://aka.ms/hosted-agent-software'),
+            task.loc('ToolNotFoundSelfHosted', 'Ruby', 'https://go.microsoft.com/fwlink/?linkid=2005989')
         ].join(os.EOL));
     }
 


### PR DESCRIPTION
We've gotten feedback that it's confusing when an image like Hosted VS2015 doesn't work with Use Python Version.

I'm improving the error message we show to:
* Say `Agent.ToolsDirectory` instead of "tools cache"
* Show the path we search for tools (value of `Agent.ToolsDirectory`)
* Point to documentation for Microsoft-hosted and self-hosted agents

**Testing**
* Ran tasks on Hosted VS2015 and checked the error message