### PR TITLE
Removal of js-base64 package

### DIFF
--- a/Tasks/AzureMysqlDeploymentV1/package-lock.json
+++ b/Tasks/AzureMysqlDeploymentV1/package-lock.json
@@ -285,11 +285,6 @@
         "topo": "1.1.0"
       }
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "jsonwebtoken": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.3.0.tgz",
@@ -532,7 +527,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/AzureMysqlDeploymentV1/task.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 10
+        "Patch": 11
     },
     "demands": [],
     "minimumAgentVersion": "1.100.0",

--- a/Tasks/AzureMysqlDeploymentV1/task.loc.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 10
+    "Patch": 11
   },
   "demands": [],
   "minimumAgentVersion": "1.100.0",

--- a/Tasks/AzureVmssDeploymentV0/package-lock.json
+++ b/Tasks/AzureVmssDeploymentV0/package-lock.json
@@ -513,11 +513,6 @@
         "topo": "1.1.0"
       }
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "jsbn": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
@@ -957,7 +952,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/AzureVmssDeploymentV0/task.json
+++ b/Tasks/AzureVmssDeploymentV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 20
+        "Patch": 21
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/AzureVmssDeploymentV0/task.loc.json
+++ b/Tasks/AzureVmssDeploymentV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 20
+    "Patch": 21
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/Common/utility-common/kubectlutility.ts
+++ b/Tasks/Common/utility-common/kubectlutility.ts
@@ -7,8 +7,6 @@ import * as util from "util";
 const uuidV4 = require('uuid/v4');
 const kubectlToolName = "kubectl"
 export const stableKubectlVersion = "v1.8.9"
-var Base64 = require('js-base64').Base64;
-
 
 var fs = require('fs');
 
@@ -58,7 +56,8 @@ export function createKubeconfig(kubernetesServiceEndpoint: string): string
     //populate server url, ca cert and token fields
     kubeconfigTemplate.clusters[0].cluster.server = tl.getEndpointUrl(kubernetesServiceEndpoint, false);
     kubeconfigTemplate.clusters[0].cluster["certificate-authority-data"] = tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'serviceAccountCertificate', false);
-    kubeconfigTemplate.users[0].user.token = Base64.decode(tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'apiToken', false));
+    var base64ApiToken = Buffer.from(tl.getEndpointAuthorizationParameter(kubernetesServiceEndpoint, 'apiToken', false), 'base64');
+    kubeconfigTemplate.users[0].user.token = base64ApiToken.toString();
 
     return JSON.stringify(kubeconfigTemplate);
 }

--- a/Tasks/Common/utility-common/package-lock.json
+++ b/Tasks/Common/utility-common/package-lock.json
@@ -23,11 +23,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",

--- a/Tasks/Common/utility-common/package.json
+++ b/Tasks/Common/utility-common/package.json
@@ -16,7 +16,6 @@
     "semver": "^5.4.1",
     "vso-node-api": "6.5.0",
     "vsts-task-lib": "2.6.0",
-    "vsts-task-tool-lib": "0.4.0",
-    "js-base64": "2.4.3"
+    "vsts-task-tool-lib": "0.4.0"
   }
 }

--- a/Tasks/DotNetCoreCLIV2/npm-shrinkwrap.json
+++ b/Tasks/DotNetCoreCLIV2/npm-shrinkwrap.json
@@ -181,11 +181,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "lazystream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
@@ -377,7 +372,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 141,
-        "Patch": 3
+        "Patch": 4
     },
     "minimumAgentVersion": "2.0.0",
     "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 141,
-    "Patch": 3
+    "Patch": 4
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/DownloadPackageV0/npm-shrinkwrap.json
+++ b/Tasks/DownloadPackageV0/npm-shrinkwrap.json
@@ -84,11 +84,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -196,7 +191,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 13
+        "Patch": 14
     },
     "demands": [],
     "minimumAgentVersion": "1.99.0",

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 13
+    "Patch": 14
   },
   "demands": [],
   "minimumAgentVersion": "1.99.0",

--- a/Tasks/GradleV2/package-lock.json
+++ b/Tasks/GradleV2/package-lock.json
@@ -503,11 +503,6 @@
         }
       }
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -861,7 +856,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "5.5.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/GradleV2/task.json
+++ b/Tasks/GradleV2/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 2,
         "Minor": 141,
-        "Patch": 1
+        "Patch": 2
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/GradleV2/task.loc.json
+++ b/Tasks/GradleV2/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 2,
     "Minor": 141,
-    "Patch": 0
+    "Patch": 2
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/HelmDeployV0/package-lock.json
+++ b/Tasks/HelmDeployV0/package-lock.json
@@ -195,11 +195,6 @@
         "topo": "1.1.0"
       }
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "jsonwebtoken": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.3.0.tgz",
@@ -400,7 +395,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/HelmDeployV0/package.json
+++ b/Tasks/HelmDeployV0/package.json
@@ -4,7 +4,6 @@
     "@types/q": "^1.5.0",
     "azure-arm-rest": "file:../../_build/Tasks/Common/azure-arm-rest-1.0.2.tgz",
     "del": "2.2.0",
-    "js-base64": "2.4.3",
     "moment": "2.21.0",
     "securefiles-common": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
     "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",

--- a/Tasks/HelmDeployV0/src/clusters/armkubernetescluster.ts
+++ b/Tasks/HelmDeployV0/src/clusters/armkubernetescluster.ts
@@ -13,8 +13,8 @@ async function getKubeConfigFromAKS(azureSubscriptionEndpoint: string, resourceG
     tl.debug(tl.loc("KubernetesClusterResourceGroup", clusterName, resourceGroup));
 
     var clusterInfo : AKSClusterAccessProfile = await aks.getAccessProfile(resourceGroup, clusterName);
-    var Base64 = require('js-base64').Base64;
-    return Base64.decode(clusterInfo.properties.kubeConfig);
+    var base64Kubeconfig = Buffer.from(clusterInfo.properties.kubeConfig, 'base64');
+    return base64Kubeconfig.toString();
 }
 
 export async function getKubeConfig(): Promise<string> {

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 138,
-        "Patch": 8
+        "Patch": 9
     },
     "demands": [],
     "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 138,
-    "Patch": 8
+    "Patch": 9
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmInstallerV0/package-lock.json
+++ b/Tasks/HelmInstallerV0/package-lock.json
@@ -128,11 +128,6 @@
         "path-is-inside": "1.0.2"
       }
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -252,7 +247,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/HelmInstallerV0/task.json
+++ b/Tasks/HelmInstallerV0/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 12
+        "Patch": 13
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/HelmInstallerV0/task.loc.json
+++ b/Tasks/HelmInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 12
+    "Patch": 13
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubernetesV0/npm-shrinkwrap.json
+++ b/Tasks/KubernetesV0/npm-shrinkwrap.json
@@ -170,11 +170,6 @@
         "path-is-inside": "1.0.2"
       }
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -299,7 +294,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 34
+        "Patch": 35
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 34
+    "Patch": 35
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/npm-shrinkwrap.json
+++ b/Tasks/KubernetesV1/npm-shrinkwrap.json
@@ -239,11 +239,6 @@
         "topo": "1.1.0"
       }
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "jsonwebtoken": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.3.0.tgz",
@@ -427,7 +422,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/KubernetesV1/package.json
+++ b/Tasks/KubernetesV1/package.json
@@ -8,7 +8,6 @@
     "azure-arm-rest": "file:../../_build/Tasks/Common/azure-arm-rest-1.0.2.tgz",
     "del": "2.2.0",
     "docker-common": "file:../../_build/Tasks/Common/docker-common-1.0.0.tgz",
-    "js-base64": "2.4.3",
     "moment": "2.21.0",
     "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
     "vsts-task-lib": "2.0.5",

--- a/Tasks/KubernetesV1/src/clusters/armkubernetescluster.ts
+++ b/Tasks/KubernetesV1/src/clusters/armkubernetescluster.ts
@@ -13,8 +13,8 @@ async function getKubeConfigFromAKS(azureSubscriptionEndpoint: string, resourceG
     tl.debug(tl.loc("KubernetesClusterResourceGroup", clusterName, resourceGroup));
 
     var clusterInfo : AKSClusterAccessProfile = await aks.getAccessProfile(resourceGroup, clusterName);
-    var Base64 = require('js-base64').Base64;
-    return Base64.decode(clusterInfo.properties.kubeConfig);
+    var base64Kubeconfig = Buffer.from(clusterInfo.properties.kubeConfig, 'base64');
+    return base64Kubeconfig.toString();
 }
 
 export async function getKubeConfig(): Promise<string> {

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 11
+        "Patch": 12
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 11
+    "Patch": 12
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/MavenV2/package-lock.json
+++ b/Tasks/MavenV2/package-lock.json
@@ -560,11 +560,6 @@
         }
       }
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -985,7 +980,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "5.5.0",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/MavenV2/task.json
+++ b/Tasks/MavenV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 141,
-        "Patch": 2
+        "Patch": 3
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV2/task.loc.json
+++ b/Tasks/MavenV2/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 141,
-    "Patch": 0
+    "Patch": 3
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/MavenV3/package-lock.json
+++ b/Tasks/MavenV3/package-lock.json
@@ -522,11 +522,6 @@
         }
       }
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -943,7 +938,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "5.5.0",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 3,
         "Minor": 141,
-        "Patch": 3
+        "Patch": 4
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV3/task.loc.json
+++ b/Tasks/MavenV3/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 3,
     "Minor": 141,
-    "Patch": 1
+    "Patch": 4
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/NpmAuthenticateV0/package-lock.json
+++ b/Tasks/NpmAuthenticateV0/package-lock.json
@@ -42,11 +42,6 @@
         "sprintf-js": "1.1.0"
       }
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
@@ -163,7 +158,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "^5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/NpmAuthenticateV0/task.json
+++ b/Tasks/NpmAuthenticateV0/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 10
+        "Patch": 11
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NpmAuthenticateV0/task.loc.json
+++ b/Tasks/NpmAuthenticateV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 10
+    "Patch": 11
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NpmV0/package-lock.json
+++ b/Tasks/NpmV0/package-lock.json
@@ -23,11 +23,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -83,7 +78,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "^5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/NpmV0/task.json
+++ b/Tasks/NpmV0/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 23
+        "Patch": 24
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NpmV0/task.loc.json
+++ b/Tasks/NpmV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 23
+    "Patch": 24
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NpmV1/package-lock.json
+++ b/Tasks/NpmV1/package-lock.json
@@ -42,11 +42,6 @@
         "sprintf-js": "1.1.0"
       }
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
@@ -148,7 +143,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "^5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 27
+        "Patch": 28
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NpmV1/task.loc.json
+++ b/Tasks/NpmV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 27
+    "Patch": 28
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetCommandV2/package-lock.json
+++ b/Tasks/NuGetCommandV2/package-lock.json
@@ -28,11 +28,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "ltx": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
@@ -137,7 +132,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "^5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 46
+        "Patch": 47
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 45
+    "Patch": 47
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetInstallerV0/package-lock.json
+++ b/Tasks/NuGetInstallerV0/package-lock.json
@@ -28,11 +28,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "ltx": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
@@ -134,7 +129,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "^5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/NuGetInstallerV0/task.json
+++ b/Tasks/NuGetInstallerV0/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 35
+        "Patch": 36
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetInstallerV0/task.loc.json
+++ b/Tasks/NuGetInstallerV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 34
+    "Patch": 36
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetPublisherV0/package-lock.json
+++ b/Tasks/NuGetPublisherV0/package-lock.json
@@ -28,11 +28,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "ltx": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
@@ -134,7 +129,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "^5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/NuGetPublisherV0/task.json
+++ b/Tasks/NuGetPublisherV0/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 42
+        "Patch": 43
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetPublisherV0/task.loc.json
+++ b/Tasks/NuGetPublisherV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 40
+    "Patch": 43
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetRestoreV1/package-lock.json
+++ b/Tasks/NuGetRestoreV1/package-lock.json
@@ -28,11 +28,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "ltx": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
@@ -144,7 +139,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "^5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/NuGetRestoreV1/task.json
+++ b/Tasks/NuGetRestoreV1/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 5
+        "Patch": 6
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetRestoreV1/task.loc.json
+++ b/Tasks/NuGetRestoreV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 4
+    "Patch": 6
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetV0/package-lock.json
+++ b/Tasks/NuGetV0/package-lock.json
@@ -28,11 +28,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "ltx": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
@@ -134,7 +129,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "^5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/NuGetV0/task.json
+++ b/Tasks/NuGetV0/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 6
+        "Patch": 7
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetV0/task.loc.json
+++ b/Tasks/NuGetV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 5
+    "Patch": 7
   },
   "runsOn": [
     "Agent",

--- a/Tasks/PipAuthenticateV0/package-lock.json
+++ b/Tasks/PipAuthenticateV0/package-lock.json
@@ -23,11 +23,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -83,7 +78,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "^5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/PipAuthenticateV0/task.json
+++ b/Tasks/PipAuthenticateV0/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   }, 
   "runsOn": [
     "Agent",

--- a/Tasks/PipAuthenticateV0/task.loc.json
+++ b/Tasks/PipAuthenticateV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/TwineAuthenticateV0/package-lock.json
+++ b/Tasks/TwineAuthenticateV0/package-lock.json
@@ -28,11 +28,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -88,7 +83,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "^5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/TwineAuthenticateV0/task.json
+++ b/Tasks/TwineAuthenticateV0/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   }, 
   "runsOn": [
     "Agent",

--- a/Tasks/TwineAuthenticateV0/task.loc.json
+++ b/Tasks/TwineAuthenticateV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/UniversalPackagesV0/package-lock.json
+++ b/Tasks/UniversalPackagesV0/package-lock.json
@@ -28,11 +28,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -74,7 +69,6 @@
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
-        "js-base64": "2.4.3",
         "semver": "^5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 6
+        "Patch": 7
     },
     "runsOn": [
         "Agent",

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 6
+    "Patch": 7
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
For issue https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1359968

Commit 1: Changes where js-base64 package is actually used
-- utility-common
-- HelmDeployV0
-- KubernetesV1
https://github.com/Microsoft/vsts-tasks/commit/5a67ef29b1bd38920b82b829aa7b98d7ad82711f

Commit 2 - 6 : Removal of js-base64 in tasts dependent on utility-common
AzureMysqlDeploymentV1
AzureVmssDeploymentV0
DotNetCoreCLIV2
DownloadPackageV0
GradleV2
HelmInstallerV0
KubernetesV0
MavenV2
MavenV3
NpmAuthenticateV0
NpmV0
NpmV1
NuGetCommandV2
NuGetInstallerV0
NuGetPublisherV0
NuGetRestoreV1
NuGetV0
PipAuthenticateV0
TwineAuthenticateV0
UniversalPackagesV0




