### PR TITLE
Stop staging aggregate.

### DIFF
--- a/ci/publish-steps.yml
+++ b/ci/publish-steps.yml
@@ -64,23 +64,6 @@ steps:
 - powershell: 'Get-PSDrive C,D' 
   displayName: 'Disk Info'
 
-# Stage aggregate
-# - script: node .\ci\stage-aggregate.js
-#   displayName: Stage aggregate
-
-# - powershell: 'Get-PSDrive C,D' 
-#   displayName: 'Disk Info'
-
-# Publish aggregate artifact
-# - task: PublishBuildArtifacts@1
-#   inputs:
-#     pathToPublish: _package/publish-layout
-#     artifactName: TaskPackage
-#     publishLocation: container
-
-- powershell: 'Get-PSDrive C,D' 
-  displayName: 'Disk Info'
-
 # Stage per task NuGet package
 - script: npm run package
   displayName: npm run package

--- a/ci/publish-steps.yml
+++ b/ci/publish-steps.yml
@@ -65,18 +65,18 @@ steps:
   displayName: 'Disk Info'
 
 # Stage aggregate
-- script: node .\ci\stage-aggregate.js
-  displayName: Stage aggregate
+# - script: node .\ci\stage-aggregate.js
+#   displayName: Stage aggregate
 
-- powershell: 'Get-PSDrive C,D' 
-  displayName: 'Disk Info'
+# - powershell: 'Get-PSDrive C,D' 
+#   displayName: 'Disk Info'
 
 # Publish aggregate artifact
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: _package/publish-layout
-    artifactName: TaskPackage
-    publishLocation: container
+# - task: PublishBuildArtifacts@1
+#   inputs:
+#     pathToPublish: _package/publish-layout
+#     artifactName: TaskPackage
+#     publishLocation: container
 
 - powershell: 'Get-PSDrive C,D' 
   displayName: 'Disk Info'


### PR DESCRIPTION
We are running out of disk space so I am removing staging the aggregate to try and give us enough space.

I will be moving to build only changed but that is a bigger change I don't want to rush in.

Today, the individual NuGet packages somewhat rely on the old packaging system since we have the slicing.